### PR TITLE
Remove default top margin on all siblings

### DIFF
--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -1,10 +1,1 @@
 @import "suitcss-base";
-
-/**
- * Apply vertical margin to all siblings by default
- * http://alistapart.com/article/axiomatic-css-and-lobotomized-owls
- */
-
-* + * {
-  margin-top: var(--margin-base);
-}


### PR DESCRIPTION
This needs to be accounted for in the Fabricator UI first.
