### PR TITLE
Initial color palette

### DIFF
--- a/src/assets/toolkit/styles/base/theme.css
+++ b/src/assets/toolkit/styles/base/theme.css
@@ -28,6 +28,18 @@
 :root {
   --color-black: #000;
   --color-white: #fff;
+
+  /* Primary blues */
+  --color-dark-blue: #0f1c3f;
+  --color-deep-blue: #456bd9;
+
+  /* Primary grays */
+  --color-gray: #dbe5ea;
+
+  /* Secondary colors */
+  --color-orange: #f26941;
+  --color-green: #35c98d;
+  --color-pink: #f14ca3;
 }
 
 /**

--- a/src/data/toolkit.yml
+++ b/src/data/toolkit.yml
@@ -1,8 +1,9 @@
 colors:
   primary:
-    Dark: "rgb(30, 30, 30)"
-    Light: "rgb(242, 242, 242)"
+    Dark Blue: "rgb(15, 28, 63)"
+    Deep Blue: "rgb(69, 107, 217)"
+    Gray: "rgb(219, 229, 234)"
   secondary:
-    Red: "rgb(201, 55, 6)"
-    Yellow: "rgb(252, 207, 80)"
-    Blue: "rgb(39, 102, 143)"
+    Orange: "rgb(242, 105, 65)"
+    Green: "rgb(53, 201, 141)"
+    Pink: "rgb(241, 76, 163)"


### PR DESCRIPTION
Adding the color palette values from @nicolemors' branch, but also to the theme file. These are not applied anywhere yet, I'll save that for when we're actually plugging in the various patterns.

The variable names are loosely based on those in the SUITCSS example: https://github.com/suitcss/theme/blob/master/lib/theme.css
