### PR TITLE
Custom font-family

### DIFF
--- a/src/assets/toolkit/styles/base/theme.css
+++ b/src/assets/toolkit/styles/base/theme.css
@@ -48,7 +48,7 @@
 
 :root {
   --font-size: 16px;
-  --font-family: sans-serif;
+  --font-family: "Source Sans Pro", sans-serif;
   --line-height: var(--ratio);
 }
 

--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -5,3 +5,7 @@
 :--headings {
   font-weight: bold;
 }
+
+body {
+  font: var(--font-base);
+}

--- a/src/views/layouts/default.html
+++ b/src/views/layouts/default.html
@@ -10,6 +10,7 @@
 	{{#if fabricator}}<link rel="stylesheet" href="{{baseurl}}/assets/fabricator/styles/f.css">{{/if}}
 
 	<!-- toolkit styles -->
+	<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700|Source+Code+Pro">
 	<link rel="stylesheet" href="{{baseurl}}/assets/toolkit/styles/toolkit.css">
 	<!-- /toolkit styles -->
 


### PR DESCRIPTION
Including Source Sans Pro (weights 400, 600 and 700) and Source Code Pro (400) from Google Fonts, and adding the former to the `--font-family` variable.

`--font-base` wasn't being used anywhere yet, so I added a rule to our typography stylesheet. Obviously we can revise later.
