### PR TITLE
Reset appearance of .Input for webkit

### DIFF
--- a/src/assets/toolkit/styles/components/input.css
+++ b/src/assets/toolkit/styles/components/input.css
@@ -21,6 +21,8 @@
  *    cross-browser edge cases where the rule would be ignored or would conflict
  *    with platform-specific input type controls (search decorations, etc.).
  * 3. Same `line-height` as `.Button` for easy alignment.
+ * 4. Unfortunately, Webkit won't play nice with our styles on some input types
+ *    unless we override its appearance.
  */
 .Input {
   margin: 0;
@@ -35,6 +37,7 @@
   border-radius: var(--Input-border-radius);
   background: var(--Input-background-color);
   transition: all var(--Input-transition-duration) var(--Input-transition-timing-function);
+  -webkit-appearance: none; /* 4 */
 }
 
 .Input:matches(:active, :hover) {


### PR DESCRIPTION
This PR attempts to address the most pressing aspects of #23 by setting `-webkit-appearance` to `none`.

The vendor prefix is purposely retained because the problem is specific to Webkit.

This only solves the most pressing layout issues. Other issues, such as bugs with the search cancel button ([see here](https://bugs.webkit.org/show_bug.cgi?id=111843)) may persist.
## Before

![](https://cloud.githubusercontent.com/assets/69633/8709227/c2b41daa-2af5-11e5-9891-e6dca8814fa0.png)
## After

![screen shot 2015-07-15 at 1 38 21 pm](https://cloud.githubusercontent.com/assets/69633/8709456/1e5416c8-2af7-11e5-9b4b-3d185fe46d48.png)
