### PR TITLE
Add modernizr gulp task

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,4 @@ labels:
 * We've added a new Gulp task: `styles:test`
   - This analyzes CSS files using [postcss-bem-linter](https://github.com/postcss/postcss-bem-linter)
   - Any issues found are output as console warnings with [postcss-reporter](https://github.com/postcss/postcss-reporter)
+* There's also a new `modernizr` task. Any [Modernizr v3](http://v3.modernizr.com/) tests referenced via CSS or JS files will be automatically included thanks to [gulp-modernizr](https://github.com/doctyper/gulp-modernizr).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ var gulp = require('gulp');
 var gutil = require('gulp-util');
 var gulpif = require('gulp-if');
 var imagemin = require('gulp-imagemin');
+var modernizr = require('gulp-modernizr');
 var postcss = require('gulp-postcss');
 var rename = require('gulp-rename');
 var reload = browserSync.reload;
@@ -116,6 +117,19 @@ gulp.task('scripts', function (done) {
 });
 
 
+// modernizr
+gulp.task('modernizr', function () {
+  return gulp.src('./src/assets/toolkit/**/*.{js,css}')
+    .pipe(modernizr({
+      options: [
+        'setClasses',
+        'html5shiv'
+      ]
+    }))
+    .pipe(gulp.dest(config.dest + '/assets/toolkit/scripts'));
+});
+
+
 // images
 gulp.task('images', ['favicon'], function () {
   return gulp.src(config.src.images)
@@ -203,6 +217,7 @@ gulp.task('default', ['clean'], function () {
   var tasks = [
     'styles',
     'scripts',
+    'modernizr',
     'images',
     'assemble'
   ];

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp": "^3.8.11",
     "gulp-if": "^1.2.5",
     "gulp-imagemin": "^2.2.1",
+    "gulp-modernizr": "^1.0.0-alpha",
     "gulp-postcss": "^5.1.9",
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.4",

--- a/src/views/layouts/default.html
+++ b/src/views/layouts/default.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html {{#if fabricator}}class="f-Layout"{{/if}}>
+<html class="no-js {{#if fabricator}}f-Layout{{/if}}">
 <head>
 
 	<meta charset="utf-8">
@@ -13,6 +13,8 @@
 	<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700|Source+Code+Pro">
 	<link rel="stylesheet" href="{{baseurl}}/assets/toolkit/styles/toolkit.css">
 	<!-- /toolkit styles -->
+
+	<script src="{{baseurl}}/assets/toolkit/scripts/modernizr.js"></script>
 
 </head>
 <body {{#if fabricator}}class="f-Layout-body"{{/if}}>


### PR DESCRIPTION
Uses [gulp-modernizr](https://github.com/doctyper/gulp-modernizr) to automatically build a custom Modernizr v3 based on test usage in CSS and JS files. For now, it only runs at the start of a build (seemed excessive to have it run on watch).

Given CSS or JS like this:

``` css
.flexbox { }
.no-rgba {  }
```

``` js
if (Modernizr.touch) { }
```

Modernizr will build with those tests:

``` html
<html class="js flexbox rgba touch"></html>
```

Refs: #25
