### PR TITLE
WIP SVG icon component, task, examples

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,6 +13,7 @@ var imagemin = require('gulp-imagemin');
 var modernizr = require('gulp-modernizr');
 var postcss = require('gulp-postcss');
 var rename = require('gulp-rename');
+var svgSprite = require('gulp-svg-sprite');
 var reload = browserSync.reload;
 var reporter = require('postcss-reporter');
 var requireDir = require('require-dir');
@@ -33,6 +34,7 @@ var config = {
       toolkit: 'src/assets/toolkit/styles/toolkit.css'
     },
     images: 'src/assets/toolkit/images/**/*',
+    icons: 'src/assets/toolkit/icons/*.svg',
     views: 'src/toolkit/views/*.html'
   },
   dest: 'dist'
@@ -131,7 +133,7 @@ gulp.task('modernizr', function () {
 
 
 // images
-gulp.task('images', ['favicon'], function () {
+gulp.task('images', ['favicon', 'icons'], function () {
   return gulp.src(config.src.images)
     .pipe(imagemin())
     .pipe(gulp.dest(config.dest + '/assets/toolkit/images'));
@@ -140,6 +142,20 @@ gulp.task('images', ['favicon'], function () {
 gulp.task('favicon', function () {
   return gulp.src('./src/favicon.ico')
     .pipe(gulp.dest(config.dest));
+});
+
+gulp.task('icons', function () {
+  return gulp.src(config.src.icons)
+    .pipe(imagemin())
+    .pipe(svgSprite({
+      mode: {
+        symbol: {
+          dest: '',
+          sprite: 'icons.svg'
+        },
+      }
+    }))
+    .pipe(gulp.dest(config.dest + '/assets/toolkit/images'));
 });
 
 // assemble
@@ -205,7 +221,7 @@ gulp.task('serve', function () {
   gulp.watch('src/assets/{fabricator,toolkit}/scripts/**/*.js', ['scripts:watch']).on('change', webpackCache);
 
   gulp.task('images:watch', ['images'], reload);
-  gulp.watch(config.src.images, ['images:watch']);
+  gulp.watch([config.src.images, config.src.icons], ['images:watch']);
 
 });
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-modernizr": "^1.0.0-alpha",
     "gulp-postcss": "^5.1.9",
     "gulp-rename": "^1.2.2",
+    "gulp-svg-sprite": "^1.2.5",
     "gulp-util": "^3.0.4",
     "imports-loader": "^0.6.3",
     "keyboard-shortcut": "^1.2.0",

--- a/src/assets/toolkit/icons/arrow.svg
+++ b/src/assets/toolkit/icons/arrow.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="26px" height="20px" viewBox="0 0 26 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g stroke-linecap="round" stroke="currentColor" stroke-width="4">
+            <g transform="translate(2.000000, 2.000000)">
+                <path d="M9,3 L19,3 L19,13" stroke-linejoin="round" transform="translate(14.000000, 8.000000) rotate(-315.000000) translate(-14.000000, -8.000000) "></path>
+                <path d="M20.5,8 L0.5,8"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/assets/toolkit/icons/envelope.svg
+++ b/src/assets/toolkit/icons/envelope.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="26px" height="26px" viewBox="0 0 26 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+  <path fill="currentColor" d="M0,6 C0,4.8954305 0.894978851,4 1.99700466,4 L24.0029953,4 C25.1059106,4 26,4.88772964 26,6 L26,8 C26,8 17.2751465,14 13,14 C8.60847982,14 0,8 0,8 L0,6 L0,6 Z M0,19.9914698 C0,21.1007504 0.894978851,22 1.99700466,22 L24.0029953,22 C25.1059106,22 26,21.0980496 26,19.9914698 L26,10 C26,10 17.2751465,16 13,16 C8.60847982,16 0,10 0,10 L0,19.9914698 L0,19.9914698 Z"></path>
+</svg>

--- a/src/assets/toolkit/styles/components/icon.css
+++ b/src/assets/toolkit/styles/components/icon.css
@@ -1,0 +1,62 @@
+/**
+ * Icon
+ *
+ * Inline SVG icon component. Use currentColor in SVGs themselves to control
+ * which elements inherit color.
+ */
+
+:root {
+  --Icon-size-sm: 1em;
+  --Icon-size-md: calc(var(--Icon-size-sm) * var(--ratio));
+  --Icon-size-lg: calc(var(--Icon-size-md) * var(--ratio));
+  --Icon-size-xl: calc(var(--Icon-size-lg) * var(--ratio));
+
+  /**
+   * Attempts thus far to figure out some sort of proportional ratio for this
+   * have failed. So here's a bunch of mysterious math that looks right!
+   */
+  --Icon-vertical-align-sm: -0.125em;
+  --Icon-vertical-align-lg: calc(var(--Icon-vertical-align-md) * 2);
+  --Icon-vertical-align-md: calc(var(--Icon-vertical-align-sm) * 3);
+  --Icon-vertical-align-xl: calc(var(--Icon-vertical-align-lg) * 1.75);
+}
+
+/**
+ * 1. Reset any inherited margin.
+ * 2. Flow with inline content.
+ * 3. Assume square proportions for container.
+ * 4. Reset `line-height` to avoid throwing off `vertical-align` (5).
+ * 5. Adjust `vertical-align` for best visual appearance with text. Using this
+ *    instead of the more common negative `top` value because it does not
+ *    impact the dimensions of its parent as quickly.
+ */
+.Icon {
+  margin: 0; /* 1 */
+  display: inline-block; /* 2 */
+  width: var(--Icon-size-sm); /* 3 */
+  height: var(--Icon-size-sm); /* 3 */
+  line-height: 1; /* 4 */
+  vertical-align: var(--Icon-vertical-align-sm); /* 5 */
+}
+
+/**
+ * Modifiers: size
+ */
+
+.Icon--md {
+  width: var(--Icon-size-md);
+  height: var(--Icon-size-md);
+  vertical-align: var(--Icon-vertical-align-md);
+}
+
+.Icon--lg {
+  width: var(--Icon-size-lg);
+  height: var(--Icon-size-lg);
+  vertical-align: var(--Icon-vertical-align-lg);
+}
+
+.Icon--xl {
+  width: var(--Icon-size-xl);
+  height: var(--Icon-size-xl);
+  vertical-align: var(--Icon-vertical-align-xl);
+}

--- a/src/assets/toolkit/styles/components/index.css
+++ b/src/assets/toolkit/styles/components/index.css
@@ -1,5 +1,6 @@
 @import "./button.css";
 @import "./grid.css";
+@import "./icon.css";
 @import "./input.css";
 @import "./input-group.css";
 @import "./thumbnail.css";

--- a/src/materials/components/icon.html
+++ b/src/materials/components/icon.html
@@ -1,0 +1,24 @@
+---
+notes: |
+  Consistently styles inline SVG icons. Icons that use `currentColor` will
+  inherit the parent element's text color.
+
+  Size can be adjusted by including a modifier class in the format of
+  `Icon--{size}`. Current sizes include `md`, `lg` or `xl`.
+labels:
+  - inprogress
+---
+<div>
+  <button class="Button Button--primary">
+    <svg class="Icon Icon--md">
+      <use xlink:href="{{baseurl}}/assets/toolkit/images/icons.svg#envelope" />
+    </svg>
+    Drop us a line!
+  </button>
+</div>
+<div>
+  Look over there!!
+  <svg class="Icon Icon--lg">
+    <use xlink:href="{{baseurl}}/assets/toolkit/images/icons.svg#arrow" />
+  </svg>
+</div>


### PR DESCRIPTION
This is the first step to getting a robust and performant icon system in place.

![screen shot 2015-07-16 at 4 48 00 pm](https://cloud.githubusercontent.com/assets/69633/8737747/8dda9ccc-2bda-11e5-9e6c-bf81b48e1e00.png)

I've chosen to use SVG for icons. They're a more semantic choice than icon fonts, offer more design flexibility, render more predictably, and are easier to implement fallbacks for (IMO).

Contrary to the last couple of times I've implemented an SVG icon system, I decided not to set `fill: currentColor` this time. On past projects, I've encountered exceptions to this that have required some CSS overrides to accomodate. I think the icon designer should know which parts of the icon should or shouldn't inherit `currentColor`, so I've moved that into the icon assets themselves.

The icons are assembled into an SVG sprite using [`gulp-svg-sprite`](https://github.com/jkphl/gulp-svg-sprite), my personal favorite tool for this sort of thing.

Right now there are only two icons, and those should probably be revised (they are currently 26px wide each, which is an odd measurement). We should also explore having a standalone "Icons" page that can be a larger reference of everything that's available.

To keep things simple for now, I'm referencing the SVG path directly, but that will fail in IE. We should follow up later to decide if we want to include [a polyfill](https://github.com/jonathantneal/svg4everybody), or the SVG sprite in the `<body>`.
