### PR TITLE
Fix for inline code wrapping

### DIFF
--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -95,9 +95,12 @@ code {
   white-space: pre;
 }
 
+code {
+  word-wrap: normal;
+}
+
 pre > code {
   white-space: pre-wrap;
-  word-wrap: normal;
 }
 
 /**


### PR DESCRIPTION
Because we set `word-wrap` to `break-word` on `body`, inline `<code>` elements (not nested in a `<pre>` element) were breaking awkwardly. This simply moves the `word-wrap: normal` declaration from `pre > code` to `code`.
## Before

![screen shot 2015-07-20 at 4 28 10 pm](https://cloud.githubusercontent.com/assets/69633/8789968/0c9601bc-2efd-11e5-9e83-8730d4f1bacb.png)
## After

![screen shot 2015-07-20 at 4 30 31 pm](https://cloud.githubusercontent.com/assets/69633/8789969/10ccfff6-2efd-11e5-8b9b-98adcc822c2d.png)
