### PR TITLE
Revise and simplify Icon component

### DIFF
--- a/src/assets/toolkit/styles/components/icon.css
+++ b/src/assets/toolkit/styles/components/icon.css
@@ -7,10 +7,8 @@
 
 :root {
   --Icon-line-height-offset: calc((var(--line-height) - 1) / -2em);
-  --Icon-size-sm: 1em;
-  --Icon-size-md: calc(var(--Icon-size-sm) * var(--ratio));
-  --Icon-size-lg: calc(var(--Icon-size-md) * var(--ratio));
-  --Icon-size-xl: calc(var(--Icon-size-lg) * var(--ratio));
+  --Icon-size: 1em;
+  --Icon-size-lg: calc(var(--Icon-size) * var(--ratio));
 }
 
 /**
@@ -26,47 +24,18 @@
   display: inline-block;
   width: 1em;
   height: 1em;
-  font-size: var(--Icon-size-sm); /* 2 */
+  font-size: var(--Icon-size); /* 2 */
   vertical-align: middle;
 }
 
 /**
- * Modifiers should avoid disrupting their container where possible. Setting
- * negative values for both vertical margins makes sure this won't happen unless
- * the icon is actually too tall for the container rather than the container's
- * `line-height`.
+ * 1. Negative vertical margins prevent the icon from disrupting the surrounding
+ *    content's `line-height`.
+ * 2. Actual size adjustment occurs via `font-size`.
  */
 
-.Icon--md,
-.Icon--lg,
-.Icon--xl {
-  margin-top: var(--Icon-line-height-offset);
-  margin-bottom: var(--Icon-line-height-offset);
-}
-
-/**
- * Above a certain size, modifiers no longer need the top offset because the
- * dominant visual relationship at this point will be with the container rather
- * than the baseline.
- */
-
-.Icon--lg,
-.Icon--xl {
-  top: 0;
-}
-
-/**
- * At this point, modifiers are defined with simple `font-size` adjustments.
- */
-
-.Icon--md {
-  font-size: var(--Icon-size-md);
-}
-
-.Icon--lg {
-  font-size: var(--Icon-size-lg);
-}
-
-.Icon--xl {
-  font-size: var(--Icon-size-xl);
+.Icon--large {
+  margin-top: var(--Icon-line-height-offset); /* 1 */
+  margin-bottom: var(--Icon-line-height-offset); /* 1 */
+  font-size: var(--Icon-size-lg); /* 2 */
 }

--- a/src/materials/components/icon.html
+++ b/src/materials/components/icon.html
@@ -2,15 +2,10 @@
 notes: |
   Consistently styles inline SVG icons. Icons that use `currentColor` will
   inherit the parent element's text color.
-
-  Size can be adjusted by including a modifier class in the format of
-  `Icon--{size}`. Current sizes include `md`, `lg` or `xl`.
-labels:
-  - inprogress
 ---
 <div>
   <button class="Button Button--primary">
-    <svg class="Icon Icon--md">
+    <svg class="Icon Icon--large">
       <use xlink:href="{{baseurl}}/assets/toolkit/images/icons.svg#envelope" />
     </svg>
     Drop us a line!
@@ -19,7 +14,7 @@ labels:
 <div>
   <a href="#">
     View live demo
-    <svg class="Icon Icon--md">
+    <svg class="Icon Icon--large">
       <use xlink:href="{{baseurl}}/assets/toolkit/images/icons.svg#arrow" />
     </svg>
   </a>

--- a/src/views/icons.html
+++ b/src/views/icons.html
@@ -5,7 +5,11 @@ fabricator: true
 
 <h1>Icons</h1>
 
-<p>This toolkit includes a custom library of icons to accompany content where appropriate. These icons will inherit the parent element's text color where specified by the icon designer.</p>
+<p>
+  This toolkit includes a custom library of icons to accompany content where
+  appropriate. These icons will inherit the parent element's text color where
+  specified by the icon designer.
+</p>
 
 <ul class="f-Icons">
   {{#each toolkit.icons}}
@@ -20,13 +24,21 @@ fabricator: true
 
 <h2 id="usage">How to use</h2>
 
-<p>Reference the <code>icons.svg</code> file with the hash of the icon you wish to use (e.g. <code>#arrow</code>) in a standard SVG element:</p>
+<p>
+  Reference the <code>icons.svg</code> file with the hash of the icon you wish
+  to use (e.g. <code>#arrow</code>) in a standard SVG element:
+</p>
 
 <pre class="language-markup"><code class="language-markup">&lt;svg class=&quot;Icon&quot;&gt;
   &lt;use xlink:href=&quot;assets/toolkit/images/icons.svg#foobar&quot; /&gt;
 &lt;/svg&gt;</code></pre>
 
-<p>The <code>.Icon</code> component class is included for consistent styles. This can be combined with modifiers to adjust the icon's size relative to the current <code>font-size</code>:</p>
+<p>
+  The <code>.Icon</code> component class is included for consistent styles.
+  Include the <code>.Icon--large</code> modifier to increase the icon's size
+  relative to the containing element's <code>font-size</code>:
+</p>
+
 
 <div>
   <svg class="Icon">
@@ -35,25 +47,15 @@ fabricator: true
   <code>.Icon</code>
 </div>
 <div>
-  <svg class="Icon Icon--md">
+  <svg class="Icon Icon--large">
     <use xlink:href="{{baseurl}}/assets/toolkit/images/icons.svg#envelope" />
   </svg>
-  <code>.Icon.Icon--md</code>
-</div>
-<div>
-  <svg class="Icon Icon--lg">
-    <use xlink:href="{{baseurl}}/assets/toolkit/images/icons.svg#envelope" />
-  </svg>
-  <code>.Icon.Icon--lg</code>
-</div>
-<div>
-  <svg class="Icon Icon--xl">
-    <use xlink:href="{{baseurl}}/assets/toolkit/images/icons.svg#envelope" />
-  </svg>
-  <code>.Icon.Icon--xl</code>
+  <code>.Icon.Icon--large</code>
 </div>
 
-<p>Use <code>.u-turnXofY</code> utility classes to change an icon's direction:</p>
+<p>
+  Use <code>.u-turnXofY</code> utility classes to change an icon's direction:
+</p>
 
 <div>
   <svg class="Icon">


### PR DESCRIPTION
This PR addresses #38, plus some related housekeeping:
- Size modifier format for `.Icon` changed from `lg` to `large`
- Modifiers we don't need yet have been removed, styles simplified
- Documentation updated to reflect these changes (plus a few whitespace tweaks)
