### PR TITLE
Fix: Simplify responsive heading size adjustments (Issue #43)

### DIFF
--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -65,6 +65,11 @@ body {
  */
 
 h1 {
+  font-size: var(--font-size-lg);
+  line-height: 1;
+}
+
+h2 {
   font-size: var(--font-size-md);
   line-height: 1;
 }
@@ -79,17 +84,6 @@ h6 {
  */
 
 @media (--md-viewport) {
-  h1 {
-    font-size: var(--font-size-lg);
-  }
-
-  h2 {
-    font-size: var(--font-size-md);
-    line-height: 1;
-  }
-}
-
-@media (--lg-viewport) {
   h1 {
     font-size: var(--font-size-xl);
   }


### PR DESCRIPTION
For #43 

This change removes a media query for heading size adjustments, resulting in larger sizes for `<h1>` and `<h2>` by default. Doing this nullifies the need to address anything on the `.TextBlock` component, because the font sizes within it now correspond to `<h1>` and `<h2>` at default screen sizes.

New heading size adjustments (now only using default plus one breakpoint):

![Headings Default](https://cloud.githubusercontent.com/assets/61204/8887283/39c4ccaa-3230-11e5-8dd0-90918696f7b0.png)

---

![Headings @ Medium Viewport](https://cloud.githubusercontent.com/assets/61204/8887284/48cf706a-3230-11e5-889f-167888e8cb49.png)

---

Closes #43

CC @lyzadanger 
