### PR TITLE
Add text-size-adjust to body

### DIFF
--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -44,12 +44,14 @@ html {
  * 1. Base font style for everything
  * 2. Allow long words (links) to brake at arbitrary points
  * 3. Auto-hyphens by default (assuming removal for specific elements)
+ * 4. Prevent automatic size adjustments on orientation change
  */
 
 body {
   font: var(--base-font); /* 1 */
   word-wrap: break-word; /* 2 */
   hyphens: auto; /* 3 */
+  text-size-adjust: none; /* 4 */
 }
 
 /**


### PR DESCRIPTION
Prior to this, mobile devices were enlarging the `font-size` of any elements inheriting that size from the `<body>` tag when a device's orientation changed.

Here's a screenshot in "portrait" orientation on my iPhone 6:

![img_0531](https://cloud.githubusercontent.com/assets/69633/8969404/0a9adc14-35f8-11e5-9460-3a86e259416a.PNG)

Here's that same page rotated _before_ this PR. Note in particular how the "Usage" heading is nearly dwarfed by the body content:

![img_0532](https://cloud.githubusercontent.com/assets/69633/8969407/10612144-35f8-11e5-88e3-71f830d5b92f.PNG)

Here's that same rotation, _after_ this PR, the `font-size` consistent with our design intention:

![img_0533](https://cloud.githubusercontent.com/assets/69633/8969410/14e046c8-35f8-11e5-9825-38daf5a0c9d3.PNG)
