### PR TITLE
Add pseudo classes to Button modifiers

### DIFF
--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -102,7 +102,8 @@
   --Button-default-color: var(--color-white);
 }
 
-.Button--default {
+.Button--default,
+.Button--default:matches(:focus, :hover, :active) {
   color: var(--Button-default-color);
   border-color: color(var(--Button-default-background-color) shade(10%));
   background-color: var(--Button-default-background-color);
@@ -126,7 +127,8 @@
   --Button-primary-color: var(--color-white);
 }
 
-.Button--primary {
+.Button--primary,
+.Button--primary:matches(:focus, :hover, :active) {
   color: var(--Button-primary-color);
   border-color: color(var(--Button-primary-background-color) shade(10%));
   background-color: var(--Button-primary-background-color);
@@ -150,7 +152,8 @@
   --Button-secondary-color: inherit;
 }
 
-.Button--secondary {
+.Button--secondary,
+.Button--secondary:matches(:focus, :hover, :active) {
   color: var(--Button-secondary-color);
   background-color: var(--Button-secondary-background-color);
 }


### PR DESCRIPTION
With the addition of default anchor pseudo classes, `.Button` modifiers were inheriting more styles than they should.

Initially I created separate rules overriding only the `color` property, but decided in this case the cascade was my friend and I could simplify things by appending the pseudo-classes to the initial modifier group.

Refs: #61 #52 #19
