### PR TITLE
Add times helper to build/helpers

### DIFF
--- a/build/helpers/times.js
+++ b/build/helpers/times.js
@@ -1,0 +1,22 @@
+/**
+ * Iterate over a block a given number of times.
+ *
+ * Usage:
+ *   <ul>
+ *     {{#times 5}}<li>Item {{@index}}</li>{{/times}}
+ *   </ul>
+ */
+
+var Handlebars  = require('handlebars');
+
+module.exports = function (n, options) {
+  var out = '', data;
+
+  for (var i = 0; i < n; ++i) {
+    data = Handlebars.createFrame(options.data || {});
+    data.index = i;
+    out += options.fn(i, { data: data });
+  }
+
+  return out;
+};

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-svg-sprite": "^1.2.5",
     "gulp-util": "^3.0.4",
+    "handlebars": "^3.0.3",
     "imports-loader": "^0.6.3",
     "moment": "^2.10.2",
     "postcss-bem-linter": "^0.4.0",


### PR DESCRIPTION
While working on nav prototypes, I found it useful to restore one of the Handlebars helpers I wrote for past projects, `times`. It allows for "dumb" iterations over a block of HTML an arbitrary number of times.

Example:

``` hbs
<ul>
  {{#times 5}}<li>Item {{@index}}</li>{{/times}}
</ul>
```

Result:

``` html
<ul>
  <li>Item 0</li>
  <li>Item 1</li>
  <li>Item 2</li>
  <li>Item 3</li>
  <li>Item 4</li>
</ul>
```

It depends on the `Handlebars.createFrame` method to support references to `@index` as other loops do.
