### PR TITLE
Add postcss-easings

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var bemLinter = require('postcss-bem-linter');
 var browserSync = require('browser-sync');
 var cssnext = require('cssnext');
 var del = require('del');
+var easings = require('postcss-easings');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
 var gulpif = require('gulp-if');
@@ -93,7 +94,8 @@ gulp.task('styles:test', function () {
 gulp.task('styles:toolkit', function () {
   return gulp.src(config.src.styles.toolkit)
     .pipe(postcss([
-      cssnext()
+      cssnext(),
+      easings()
     ]))
     .pipe(gulp.dest(config.dest + '/assets/toolkit/styles'))
     .pipe(gulpif(config.dev, reload({stream:true})));

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "imports-loader": "^0.6.3",
     "moment": "^2.10.2",
     "postcss-bem-linter": "^0.4.0",
+    "postcss-easings": "^0.2.0",
     "postcss-reporter": "^0.1.0",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.0.2",


### PR DESCRIPTION
Official PostCSS plugin for supporting Penner easing functions wherever CSS timing functions are used.

More info: https://github.com/postcss/postcss-easings
