### PR TITLE
Chore: Rid CSS output of empty :root blocks and comments

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ var browserSync = require('browser-sync');
 var cssnext = require('cssnext');
 var del = require('del');
 var discardComments = require('postcss-discard-comments');
+var discardEmpty = require('postcss-discard-empty');
 var easings = require('postcss-easings');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
@@ -97,7 +98,8 @@ gulp.task('styles:toolkit', function () {
     .pipe(postcss([
       cssnext(),
       easings(),
-      discardComments()
+      discardComments(),
+      discardEmpty()
     ]))
     .pipe(gulp.dest(config.dest + '/assets/toolkit/styles'))
     .pipe(gulpif(config.dev, reload({stream:true})));

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "moment": "^2.10.2",
     "postcss-bem-linter": "^0.4.0",
     "postcss-discard-comments": "^1.2.0",
+    "postcss-discard-empty": "^1.1.1",
     "postcss-easings": "^0.2.0",
     "postcss-reporter": "^0.1.0",
     "require-dir": "^0.3.0",


### PR DESCRIPTION
This addresses #80 by:
- Adding a new PostCSS [plugin](https://github.com/ben-eb/postcss-discard-comments) that strips comments out of the transpiled CSS
- Adding a new PostCSS  [plugin](https://github.com/ben-eb/postcss-discard-empty) that strips empty `:root {}` blocks out of the transpiled CSS
