### PR TITLE
Add browserslist config file

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -1,4 +1,4 @@
-# This is currently set for only new browser support.
+# TODO: This is currently set for only new browser support.
 # Update as needed once we determine what should be supported.
 # See: https://github.com/ai/browserslist#config-file
 


### PR DESCRIPTION
This adds a `browserslist` config file for Autoprefixer to use.

Closes #77
