### PR TITLE
Add dependencies introduced in #97

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "suitcss-components-flex-embed": "^2.0.4",
     "suitcss-components-grid": "^3.0.2",
     "suitcss-utils-display": "^1.0.2",
+    "suitcss-utils-flex": "^1.1.1",
+    "suitcss-utils-position": "^1.0.1",
     "suitcss-utils-size": "^1.0.2",
     "svgxuse": "^1.1.10",
     "webpack": "^1.12.1"


### PR DESCRIPTION
PR #97 introduced a few additional SUIT CSS dependencies that were eroneously omitted from our `package.json` file, resulting in errors on a fresh pull when `npm start` was attempted. This corrects the oversight.

---

@nicolemors @erikjung @saralohr 
