### PR TITLE
WIP refactored nav prototype

### DIFF
--- a/src/assets/toolkit/styles/sandbox/tcs-nav-d.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-nav-d.css
@@ -1,0 +1,215 @@
+@import "../base/theme.css";
+@import "../base/theme-map.css";
+
+/* variables and such */
+
+@custom-media --nav-visible-viewport (--sm-viewport);
+
+/* existing component modifiers */
+
+.Button {
+  transition-property: background-color, border-color, color;
+}
+
+.Button--inverse {
+  background-color: var(--color-white);
+  border-color: var(--color-gray);
+}
+
+.Button--inverse,
+.Button--inverse:matches(:focus, :hover) {
+  color: var(--link-color);
+}
+
+.Button--inverse:matches(:focus, :hover) {
+  border-color: var(--color-white);
+}
+
+.Button--inverse:active {
+  background-color: var(--color-gray);
+  border-color: var(--color-gray);
+}
+
+.Button--sheer {
+  background-color: color(var(--color-navy) a(0));
+  border-color: color(var(--color-white) a(20%));
+}
+
+.Button--sheer,
+.Button--sheer:matches(:focus, :hover) {
+  color: var(--color-white);
+}
+
+.Button--sheer:matches(:focus, :hover) {
+  border-color: color(var(--color-white) a(50%));
+}
+
+.Button--sheer:active {
+  background-color: color(var(--color-navy) a(25%));
+}
+
+/* new sky component */
+
+.Sky {
+  background-color: var(--color-blue);
+  color: var(--color-white);
+}
+
+.Sky-nav {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+}
+
+@media (--nav-visible-viewport) {
+  .Sky-nav {
+    flex-wrap: nowrap;
+  }
+}
+
+.Sky-nav-controls {
+  list-style: none;
+  margin-left: auto;
+  order: 1;
+  padding: var(--space-xs) var(--space-md);
+  position: relative;
+}
+
+@media (--nav-visible-viewport) {
+  .Sky-nav-controls {
+    padding: 0;
+    position: static;
+  }
+}
+
+.Sky-nav-controls-skipToMain {
+  position: absolute;
+  right: var(--space-md);
+}
+
+@media (--nav-visible-viewport) {
+  .Sky-nav-controls-skipToMain {
+    right: 50%;
+    top: var(--space-xs);
+    transform: translateX(50%);
+  }
+}
+
+@media (--nav-visible-viewport) {
+  .Sky-nav-controls-skipToMenu {
+    display: none;
+  }
+}
+
+.Sky-nav-logo {
+  color: var(--color-white) !important;
+  padding: var(--space-xs) var(--space-md);
+}
+
+.Sky-nav-logo-img {
+  display: block;
+  height: auto;
+  width: 5em;
+}
+
+.Sky-nav-menu {
+  display: none;
+  flex: 100%;
+  order: -1;
+  padding-bottom: var(--space-md);
+}
+
+.Sky-nav-menu:target,
+.Sky-nav-menu.is-open {
+  display: block;
+}
+
+@media (--nav-visible-viewport) {
+  .Sky-nav-menu {
+    display: block;
+    order: 0;
+    padding-bottom: 0;
+  }
+}
+
+.Sky-nav-menu-items {
+  list-style: none;
+  padding: 0;
+}
+
+@media (--nav-visible-viewport) {
+  .Sky-nav-menu-items {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    padding: var(--space-sm);
+  }
+}
+
+.Sky-nav-menu-item {
+  background-color: var(--color-navy);
+  color: var(--color-white) !important;
+  display: block;
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-xs);
+  padding: var(--space-sm);
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.Sky-nav-menu-items > *:nth-last-child(7) > .Sky-nav-menu-item {
+  background-color: color(var(--color-navy) a(84%));
+}
+
+.Sky-nav-menu-items > *:nth-last-child(6) > .Sky-nav-menu-item {
+  background-color: color(var(--color-navy) a(72%));
+}
+
+.Sky-nav-menu-items > *:nth-last-child(5) > .Sky-nav-menu-item {
+  background-color: color(var(--color-navy) a(60%));
+}
+
+.Sky-nav-menu-items > *:nth-last-child(4) > .Sky-nav-menu-item {
+  background-color: color(var(--color-navy) a(48%));
+}
+
+.Sky-nav-menu-items > *:nth-last-child(3) > .Sky-nav-menu-item {
+  background-color: color(var(--color-navy) a(36%));
+}
+
+.Sky-nav-menu-items > *:nth-last-child(2) > .Sky-nav-menu-item {
+  background-color: color(var(--color-navy) a(24%));
+}
+
+.Sky-nav-menu-items > *:last-child > .Sky-nav-menu-item {
+  background-color: color(var(--color-navy) a(12%));
+}
+
+@media (--nav-visible-viewport) {
+  .Sky-nav-menu-item {
+    background-color: transparent !important;
+  }
+}
+
+/* new utilities */
+
+.u-textNoWrap {
+  white-space: nowrap !important;
+}
+
+.u-hiddenTillFocus:not(:focus) {
+  border: 0 !important;
+  clip: rect(1px, 1px, 1px, 1px) !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  position: absolute !important;
+  width: 1px !important;
+}
+
+.u-testBlock {
+  display: block;
+  position: fixed;
+  transform: translate(-100%, -100%);
+}

--- a/src/views/sandbox/tyler-nav-d.html
+++ b/src/views/sandbox/tyler-nav-d.html
@@ -1,0 +1,96 @@
+---
+title: "Accessible Nav Prototype"
+labels:
+  - inprogress
+stylesheets:
+  - sandbox/tcs-nav-d
+---
+
+<div class="Sky">
+  <header class="Sky-nav" role="banner">
+    <ul class="Sky-nav-controls">
+      <li><a class="Sky-nav-controls-skipToMain Button Button--inverse u-textNoWrap u-hiddenTillFocus" href="#main">Skip to main content</a></li>
+      <li><a class="Sky-nav-controls-skipToMenu Button Button--sheer" href="#menu" aria-label="Skip to navigation">Menu</a></li>
+    </ul>
+    <a class="Sky-nav-logo" href="/">
+      <svg class="Sky-nav-logo-img" width="80" height="80" role="img" aria-labelledby="logo-title">
+        <title id="logo-title">Cloud Four</title>
+        <use xlink:href="/assets/toolkit/images/icons.svg#cloud-four" fill="currentColor"/>
+      </svg>
+    </a>
+    <nav class="Sky-nav-menu" role="navigation" id="menu">
+      <ul class="Sky-nav-menu-items">
+        <li><a class="Sky-nav-menu-item" href="/#main" aria-current>Section Title</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">Section</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">Section</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">Section</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">Section</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">Section</a></li>
+      </ul>
+    </nav>
+  </header>
+</div>
+
+<main role="main" id="main">
+  <h1>Page title</h1>
+  <p>Some sort of descriptive text.</p>
+  <p>More content.</p>
+</main>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.2.3/velocity.min.js"></script>
+<script>
+
+var effectOptions = {
+  duration: 500,
+  easing: [0.455, 0.03, 0.515, 0.955] // easeInOutQuad
+};
+
+var snapOptions = {
+  duration: 0
+};
+
+var body = document.body;
+var menuId = 'menu';
+var toggle = document.querySelector('a[href="#' + menuId + '"]');
+var menu = document.getElementById(menuId);
+var testClass = 'u-testBlock';
+var openClass = 'is-open';
+
+function getHeight (element) {
+  var height = element.offsetHeight;
+
+  if (!height) {
+    element.classList.add(testClass);
+    height = element.offsetHeight;
+    element.classList.remove(testClass);
+  }
+
+  return height;
+}
+
+toggle.addEventListener('click', function (event) {
+  event.preventDefault();
+
+  var isOpen = menu.classList.contains(openClass);
+  var menuHeight = getHeight(menu);
+  var startOptions = isOpen ? effectOptions : snapOptions;
+  var endOptions = isOpen ? snapOptions : effectOptions;
+
+  if (isOpen) {
+    endOptions.complete = function () {
+      menu.classList.remove(openClass);
+    };
+  } else {
+    endOptions.begin = function () {
+      menu.classList.add(openClass);
+    }
+  }
+
+  startOptions.complete = function () {
+    Velocity(body, { translateY: 0 }, endOptions);
+  };
+
+  Velocity(body, { translateY: menuHeight * -1 }, startOptions);
+});
+
+</script>


### PR DESCRIPTION
I decided to leave my "nav c" prototype as-is because I think the various toggles and stuff are kinda neat and I'd like to still refer to them. :smile: 

![nav-wip-responsive-2](https://cloud.githubusercontent.com/assets/69633/13894723/766ffcac-ed28-11e5-9096-76d1d666e6f9.gif)

This introduces a fourth nav prototype where I'm trying to keep an eye toward production-readiness.

It isn't there quite yet, but it's closer. Markup's better, lots more accessibility thought has gone into it so far, and the CSS is far less chaotic.

I'm mainly doing a PR now because I've been futzing with it for a few days and I'm getting antsy. :ant: 

---

@erikjung @nicolemors @saralohr 
