### PR TITLE
Add CTA with revised Portland illustration

### DIFF
--- a/src/assets/toolkit/images/sandbox/portland-alt.svg
+++ b/src/assets/toolkit/images/sandbox/portland-alt.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+  viewBox="0 0 140 70"
+  width="140"
+  height="70">
+  <defs>
+    <polygon id="tree" points="0,70 30,0 60,70"/>
+    <use id="tree-bg" xlink:href="#tree" fill="#249579"/>
+    <use id="tree-fg" xlink:href="#tree" fill="#35C98D"/>
+    <g id="limbs" stroke="#DBE5EA">
+      <line x1="30" y1="30" x2="30" y2="70"/>
+      <line x1="30" y1="45" x2="40" y2="37"/>
+      <line x1="21" y1="44" x2="30" y2="50"/>
+      <line x1="30" y1="55" x2="40" y2="47"/>
+    </g>
+    <g id="building">
+      <rect x="0" y="0" width="38" height="48" fill="#D8E5EA"/>
+      <rect id="building-detail" x="0" y="3" width="38" height="3" fill="#9FB3BE"/>
+      <use xlink:href="#building-detail" y="6"/>
+    </g>
+  </defs>
+  <use xlink:href="#building" x="20" y="22"/>
+  <use xlink:href="#tree-bg" x="70"/>
+  <use xlink:href="#building" x="102" y="42"/>
+  <g transform="translate(0 14) scale(0.8)">
+    <use xlink:href="#tree-fg"/>
+    <use xlink:href="#limbs" stroke-width="3"/>
+  </g>
+  <g transform="translate(50 28) scale(0.6)">
+    <use xlink:href="#tree-fg"/>
+    <use xlink:href="#limbs" stroke-width="4" y="5"/>
+  </g>
+</svg>

--- a/src/assets/toolkit/styles/sandbox/tcs-nav-d.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-nav-d.css
@@ -220,6 +220,38 @@ hr {
   background-color: var(--color-white);
 }
 
+/* possibly throwaway Portland component */
+
+.Portland {
+  padding-right: calc(140 / 16rem);
+  position: relative;
+}
+
+.Portland::before {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  background-image: url("/assets/toolkit/images/sandbox/portland-alt.svg");
+  background-repeat: no-repeat;
+  background-size: cover;
+  height: calc(70 / 16rem);
+  width: calc(140 / 16rem);
+}
+
+@media (--sm-viewport) {
+  .Portland::before {
+    right: var(--space-md);
+  }
+}
+
+@media (--md-viewport) {
+  .Portland::before {
+    height: calc(70 / 16rem * 1.6667);
+    width: calc(140 / 16rem * 1.6667);
+  }
+}
+
 /* new utilities */
 
 .u-textNoWrap {
@@ -266,6 +298,27 @@ hr {
 
 .u-paddingMd {
   padding: var(--space-md);
+}
+
+.u-paddingTopXs {
+  padding-top: var(--space-xs);
+}
+
+.u-marginMd {
+  margin: var(--space-md);
+}
+
+.u-marginEndsXs {
+  margin-top: var(--space-xs);
+  margin-bottom: var(--space-xs);
+}
+
+.u-marginRightXs {
+  margin-right: var(--space-xs);
+}
+
+.u-marginRightSm {
+  margin-right: var(--space-sm);
 }
 
 .u-marginEndsMd,

--- a/src/views/sandbox/tyler-nav-d.html
+++ b/src/views/sandbox/tyler-nav-d.html
@@ -36,14 +36,30 @@ stylesheets:
       <p>Perhaps with a helpful yet succinct description.</p>
     </div>
   </div>
-  <div class="Page u-paddingMd u-spaceChildren">
-    <h1>In-Page Heading</h1>
-    <p>Bulk of content would likely start here.</p>
-    <p>But, maybe not, y'know? The world's a crazy place.</p>
-    <p>Some <a href="http://www.buseyipsum.com/">Busey Ipsum</a>:</p>
-    <blockquote>
-      <p>It depends on your ability to take a risk on eating something when you dont know what it is. Thats why I enjoy eating in the dark. When you get lost in your imaginatory vagueness, your foresight will become a nimble vagrant.</p>
-    </blockquote>
+  <div class="Page">
+    <div class="u-paddingMd u-spaceChildren">
+      <h1>In-Page Heading</h1>
+      <p>Bulk of content would likely start here.</p>
+      <p>But, maybe not, y'know? The world's a crazy place.</p>
+      <p>Some <a href="http://www.buseyipsum.com/">Busey Ipsum</a>:</p>
+      <blockquote>
+        <p>It depends on your ability to take a risk on eating something when you dont know what it is. Thats why I enjoy eating in the dark. When you get lost in your imaginatory vagueness, your foresight will become a nimble vagrant.</p>
+      </blockquote>
+    </div>
+    <hr class="u-marginMd u-marginBottom0">
+    <div class="Portland">
+      <p class="u-paddingMd u-posRelative">
+        <span class="u-inlineBlock u-textNoWrap u-textLarger u-marginRightSm">
+          Need help clouding your fours?
+        </span>
+        <a class="Button Button--primary u-marginEndsXs u-textNoWrap" href="mailto:info@cloudfour.com">
+          <svg class="Icon Icon--large" role="img">
+            <use xlink:href="/assets/toolkit/images/icons.svg#envelope"/>
+          </svg>
+          Squiddly-doo
+        </a>
+      </p>
+    </div>
   </div>
 </main>
 


### PR DESCRIPTION
This PR restores the "hey, hire Cloud Four and here's a button" section between the main site content and the footer area.

As with #105, I took this as an opportunity to create a new Portland SVG that will be easier to tweak in-browser. Here are the size benefits:

| File | Original Size (bytes) | GZIP'd Size (bytes) |
| --- | --- | --- |
| `portland.svg` | 3,064 | 923 |
| `portland-alt.svg` | 1,188 | 463 |

Here's what it looks like:

![footer-progress-2](https://cloud.githubusercontent.com/assets/69633/14049011/7c5fdad2-f26f-11e5-9c8b-efe9a9903d8a.gif)

---

@mrgerardorodriguez @erikjung @nicolemors @saralohr 
