### PR TITLE
Make browserslist slightly less aggressive

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -2,4 +2,5 @@
 # Update as needed once we determine what should be supported.
 # See: https://github.com/ai/browserslist#config-file
 
+> 4%
 Last 1 version


### PR DESCRIPTION
Adding `> 4%` fixes a few issues in later versions of the stock Android browser, most notably issues with Flexbox syntax.

:cinema: [Video of nav working in stock Android after this change](https://cloudfourredesign.slack.com/files/tylersticka/F0VFY7SKD/it_works_.mp4)

---

@mrgerardorodriguez @erikjung @nicolemors @saralohr 
