### PR TITLE
Fix for logo size in Safari

### DIFF
--- a/src/assets/toolkit/styles/sandbox/tcs-nav-d.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-nav-d.css
@@ -130,7 +130,7 @@ hr {
 
 .Sky-nav-logo-img {
   display: block;
-  height: auto;
+  height: 5em;
   width: 5em;
 }
 


### PR DESCRIPTION
`height: auto` would only work initially, it would not increase as base `font-size` did (for some strange reason).

---

@nicolemors @saralohr @erikjung @mrgerardorodriguez 
