### PR TITLE
Add more realistic placeholder nav link titles

### DIFF
--- a/src/views/sandbox/tyler-nav-d.html
+++ b/src/views/sandbox/tyler-nav-d.html
@@ -20,10 +20,12 @@ stylesheets:
     </a>
     <nav class="Sky-nav-menu" role="navigation" id="menu">
       <ul class="Sky-nav-menu-items">
-        <li><a class="Sky-nav-menu-item" href="/#main" aria-current>Section Title</a></li>
-        {{#iterate 5}}
-          <li><a class="Sky-nav-menu-item" href="/">Section</a></li>
-        {{/iterate}}
+        <li><a class="Sky-nav-menu-item" href="/#main" aria-current>Our Process</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">Our Work</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">Articles</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">Speaking</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">Code</a></li>
+        <li><a class="Sky-nav-menu-item" href="/">The Team</a></li>
       </ul>
     </nav>
   </header>
@@ -92,10 +94,12 @@ stylesheets:
     <hr class="Grid-cell u-sm-hidden u-marginTopMd u-marginBottom0"/>
     <nav class="Grid-cell u-marginTopMd u-sm-marginTop0 u-sm-size1of2 u-md-size1of3">
       <ul class="u-listUnstyled u-columns2">
-        <li><a href="/">Section Title</a></li>
-        {{#iterate 5}}
-          <li><a href="/">Section</a></li>
-        {{/iterate}}
+        <li><a href="/">Our Process</a></li>
+        <li><a href="/">Our Work</a></li>
+        <li><a href="/">Articles</a></li>
+        <li><a href="/">Speaking</a></li>
+        <li><a href="/">Code</a></li>
+        <li><a href="/">The Team</a></li>
         <li><a href="/">Patterns</a></li>
         <li><a href="/">Device Lab</a></li>
       </ul>


### PR DESCRIPTION
@nicolemors asked if I could restore the more realistic-sounding nav link labels instead of the generic ones. Here they are!
