### PR TITLE
Add list utilities

### DIFF
--- a/src/assets/toolkit/styles/sandbox/tcs-nav-e.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-nav-e.css
@@ -320,24 +320,6 @@ hr {
   transform: translate(-100%, -100%);
 }
 
-.u-listUnstyled,
-.u-listInline {
-  list-style: none;
-  padding-left: 0;
-}
-
-.u-listInline {
-  display: flex;
-  flex-wrap: wrap;
-  margin-left: calc(var(--space-md) / -2);
-  margin-right: calc(var(--space-md) / -2);
-}
-
-.u-listInline > li {
-  margin-left: calc(var(--space-md) / 2);
-  margin-right: calc(var(--space-md) / 2);
-}
-
 .u-textLarger {
   font-size: calc(var(--ms1) * 1em);
 }

--- a/src/assets/toolkit/styles/utils/index.css
+++ b/src/assets/toolkit/styles/utils/index.css
@@ -1,6 +1,7 @@
 @import "./display.css";
+@import "./list.css";
 @import "./size.css";
 @import "./space.css";
 @import "./position.css";
-@import "./flex.css";
 @import "./text.css";
+@import "./flex.css";

--- a/src/assets/toolkit/styles/utils/list.css
+++ b/src/assets/toolkit/styles/utils/list.css
@@ -1,0 +1,34 @@
+/**
+ * 1. Turn off list decorations (bullets, numbers)
+ * 2. Override default padding
+ */
+
+.u-listUnstyled,
+.u-listInline {
+  list-style: none; /* 1 */
+  padding-left: 0; /* 2 */
+}
+
+/**
+ * 1. Make elements align in a row.
+ * 2. Make elements wrap when they can't fit on a single line.
+ * 3. Compensate for left/right padding between list items. Without this, we'd
+ *    either have gaps on either side of the container, or gaps to the left
+ *    of list items that wrapped.
+ */
+
+.u-listInline {
+  display: flex; /* 1 */
+  flex-wrap: wrap; /* 2 */
+  margin-left: calc(var(--space-md) / -2); /* 3 */
+  margin-right: calc(var(--space-md) / -2); /* 3 */
+}
+
+/**
+ * Add a consistent gap between list items.
+ */
+
+.u-listInline > li {
+  margin-left: calc(var(--space-md) / 2);
+  margin-right: calc(var(--space-md) / 2);
+}


### PR DESCRIPTION
This PR continues the work started in #113 by bringing some list utilities into the fold.

`.u-listUnstyled` does it sounds like: Removes bullets and overrides `padding-left`. Throw it on a `<ul>` or `<ol>` to make it look like _not_ a `<ul>` or `<ol>`.

`.u-listInline` makes the list items flow in a row, with some space in-between. It uses flexbox instead of `inline-block` so that the gaps are consistent in length regardless of line breaks in the markup.

---

@nicolemors @saralohr @mrgerardorodriguez @erikjung 
