### PR TITLE
Add button modifiers for dark backgrounds

### DIFF
--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -96,18 +96,31 @@
 }
 
 .Button--default,
-.Button--default:matches(:focus, :hover, :active) {
+.Button--default:matches(:focus, :hover, :active),
+.Button--defaultLight,
+.Button--defaultLight:matches(:focus, :hover, :active) {
   color: var(--Button-default-color);
   border-color: color(var(--Button-default-background-color) shade(10%));
   background-color: var(--Button-default-background-color);
 }
 
-.Button--default:matches(:focus, :hover) {
+.Button--defaultLight,
+.Button--defaultLight:matches(:focus, :hover, :active) {
+  border-color: color(var(--Button-default-background-color) l(+10%));
+}
+
+.Button--default:matches(:focus, :hover),
+.Button--defaultLight:matches(:focus, :hover) {
   border-color: color(var(--Button-default-background-color) shade(5%));
   background-color: color(var(--Button-default-background-color) l(+5%));
 }
 
-.Button--default:active {
+.Button--defaultLight:matches(:focus, :hover) {
+  border-color: color(var(--Button-default-background-color) l(+20%));
+}
+
+.Button--default:active,
+.Button--defaultLight:active {
   background-color: color(var(--Button-default-background-color) shade(10%));
 }
 
@@ -157,4 +170,30 @@
 
 .Button--secondary:active {
   background-color: color(var(--Button-secondary-background-color) shade(10%));
+}
+
+/**
+ * Modifier: inverse buttons
+ */
+
+:root {
+  --Button-inverse-background-color: var(--color-white);
+  --Button-inverse-border-color: var(--color-gray);
+  --Button-inverse-color: var(--color-blue);
+}
+
+.Button--inverse,
+.Button--inverse:matches(:focus, :hover, :active) {
+  color: var(--Button-inverse-color);
+  background-color: var(--Button-inverse-background-color);
+  border-color: var(--Button-inverse-border-color);
+}
+
+.Button--inverse:matches(:focus, :hover) {
+  border-color: var(--color-white);
+}
+
+.Button--inverse:active {
+  background-color: var(--Button-inverse-border-color);
+  border-color: var(--Button-inverse-border-color);
 }

--- a/src/assets/toolkit/styles/sandbox/tcs-nav-e.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-nav-e.css
@@ -6,45 +6,6 @@
 @custom-media --nav-visible-viewport (--sm-viewport);
 @custom-media --nav-single-row-viewport (--lg-viewport);
 
-/* existing component modifiers */
-
-.Button--inverse {
-  background-color: var(--color-white);
-  border-color: var(--color-gray);
-}
-
-.Button--inverse,
-.Button--inverse:matches(:focus, :hover) {
-  color: var(--link-color);
-}
-
-.Button--inverse:matches(:focus, :hover) {
-  border-color: var(--color-white);
-}
-
-.Button--inverse:active {
-  background-color: var(--color-gray);
-  border-color: var(--color-gray);
-}
-
-.Button--sheer {
-  background-color: color(var(--color-navy) a(0));
-  border-color: color(var(--color-white) a(20%));
-}
-
-.Button--sheer,
-.Button--sheer:matches(:focus, :hover) {
-  color: var(--color-white);
-}
-
-.Button--sheer:matches(:focus, :hover) {
-  border-color: color(var(--color-white) a(50%));
-}
-
-.Button--sheer:active {
-  background-color: color(var(--color-navy) a(25%));
-}
-
 /* new sky component */
 
 .Sky {

--- a/src/materials/components/button.html
+++ b/src/materials/components/button.html
@@ -28,6 +28,23 @@ notes: |
   <input type="submit" class="Button Button--secondary" value="Input">
   <button type="button" class="Button Button--secondary" disabled>Disabled</button>
 </div>
+{{!--
+TODO: When we have better pattern ordering and the latest UI integrated, we
+should have these "dark background" modifiers in a separate pattern... perhaps
+one with a dark background!
+--}}
+<div>
+  <a href="#" class="Button Button--defaultLight">Link</a>
+  <button type="button" class="Button Button--defaultLight">Button</button>
+  <input type="submit" class="Button Button--defaultLight" value="Input">
+  <button type="button" class="Button Button--defaultLight" disabled>Disabled</button>
+</div>
+<div>
+  <a href="#" class="Button Button--inverse">Link</a>
+  <button type="button" class="Button Button--inverse">Button</button>
+  <input type="submit" class="Button Button--inverse" value="Input">
+  <button type="button" class="Button Button--inverse" disabled>Disabled</button>
+</div>
 <div>
   <button type="button" class="Button Button--default u-sizeFull u-block">Full-width, block button</button>
 </div>

--- a/src/views/sandbox/nicole-core-blog.html
+++ b/src/views/sandbox/nicole-core-blog.html
@@ -11,7 +11,7 @@ stylesheets:
   <header class="Sky-nav" role="banner">
     <ul class="Sky-nav-controls">
       <li><a class="Sky-nav-controls-skipToMain Button Button--inverse u-textNoWrap u-hiddenTillFocus" href="#main">Skip to main content</a></li>
-      <li><a class="Sky-nav-controls-skipToMenu Button Button--sheer" href="#menu" aria-label="Skip to navigation">Menu</a></li>
+      <li><a class="Sky-nav-controls-skipToMenu Button Button--defaultLight" href="#menu" aria-label="Skip to navigation">Menu</a></li>
     </ul>
     <a class="Sky-nav-logo" href="/">
       <svg class="Sky-nav-logo-img" width="80" height="80" role="img" aria-labelledby="logo-title">
@@ -56,14 +56,14 @@ stylesheets:
       </section>
 
       <div class="full-width">
-        <img class="blog-image" src="/assets/toolkit/images/sandbox/unicorn.png" alt="unicorn">    
+        <img class="blog-image" src="/assets/toolkit/images/sandbox/unicorn.png" alt="unicorn">
       </div>
 
       <section class="blog-section u-spaceChildren u-paddingMd">
         <p>But after a few months of having my code reviewed by my fellow unicorns, I felt less like a magnificent unicorn and more like this:</p>
 
         <div style="text-align: center">
-          <img class="blog-image" src="/assets/toolkit/images/sandbox/ugly-unicorn.png" alt="ugly unicorn"> 
+          <img class="blog-image" src="/assets/toolkit/images/sandbox/ugly-unicorn.png" alt="ugly unicorn">
         </div>
 
         <p>Working in code every day has given me a new perspective… <em>I am an Ugly Unicorn</em>.</p>
@@ -72,7 +72,7 @@ stylesheets:
 
         <p>Here is a little how that went:</p>
 
-        <img style="width:100%" src="/assets/toolkit/images/sandbox/no-good.png" alt="PR comment"> 
+        <img style="width:100%" src="/assets/toolkit/images/sandbox/no-good.png" alt="PR comment">
 
         <p>Yikes. I kept hearing the those words echo through my head: <code>.code dabbler</code> <code>&lt;code dabbler&gt;</code> <code>.code dabbler</code>. Over the last year I have been waiting for an “ah-ha” moment where things would click and I would feel super comfortable and confident in my skill set, that really hasn’t been the case.</p>
 

--- a/src/views/sandbox/tyler-nav-e.html
+++ b/src/views/sandbox/tyler-nav-e.html
@@ -10,7 +10,7 @@ stylesheets:
   <header class="Sky-nav" role="banner">
     <ul class="Sky-nav-controls">
       <li><a class="Sky-nav-controls-skipToMain Button Button--inverse u-textNoWrap u-hiddenTillFocus" href="#main">Skip to main content</a></li>
-      <li><a class="Sky-nav-controls-skipToMenu Button Button--sheer" href="#menu" aria-label="Skip to navigation">Menu</a></li>
+      <li><a class="Sky-nav-controls-skipToMenu Button Button--defaultLight" href="#menu" aria-label="Skip to navigation">Menu</a></li>
     </ul>
     <a class="Sky-nav-logo" href="/">
       <svg class="Sky-nav-logo-img" width="80" height="80" role="img" aria-labelledby="logo-title">


### PR DESCRIPTION
Based on those added in the recent nav prototype.

I ended up calling the one `.Button--defaultLight` when I realized it was almost identical to `.Button--default`, save for a lighter outline!

![screen shot 2016-03-30 at 2 57 28 pm](https://cloud.githubusercontent.com/assets/69633/14158924/cd0479e0-f687-11e5-9210-d3a68992e8f6.png)

---

@nicolemors @saralohr @erikjung @mrgerardorodriguez 
