### PR TITLE
Restore inset shadow effect to Thumbnail

### DIFF
--- a/src/assets/toolkit/styles/components/thumbnail.css
+++ b/src/assets/toolkit/styles/components/thumbnail.css
@@ -15,25 +15,48 @@
  */
 
 /**
- * 1. Mimic default display of img elements.
- * 2. Removes extra space below img for certain vertical alignments. Preferable
+ * 1. Allow children to position themselves absolutely.
+ * 2. Mimic default display of img elements.
+ * 3. Make sure images are clipped by rounded corners (if any).
+ * 4. Removes extra space below img for certain vertical alignments. Preferable
  *    to setting display: block on img because it respects vertical-align rules
  *    on either this element or the img itself.
- * 3. Transition rules for border.
  */
+
 .Thumbnail {
-  display: inline-block; /* 1 */
-  line-height: 0; /* 2 */
-  border: solid var(--Thumbnail-border-width) color(var(--Thumbnail-border-color) a(10%));
-  transition: border 300ms ease; /* 3 */
+  position: relative; /* 1 */
+  display: inline-block; /* 2 */
+  overflow: hidden; /* 3 */
+  line-height: 0; /* 4 */
 }
 
-.Thumbnail:matches(:focus, :hover) {
-  border: solid var(--Thumbnail-border-width) color(var(--Thumbnail-border-color) a(25%));
+/**
+ * 1. Absolute position pseudo element.
+ * 2. Fix to all edges (also matches parent dimensions).
+ * 3. Makes pseudo element visible.
+ * 4. Subtle inset border.
+ * 5. Inherit rounded corners (if any) from parent.
+ * 6. Animate border property changes.
+ */
+
+.Thumbnail::after {
+  position: absolute; /* 1 */
+  top: 0; /* 2 */
+  right: 0; /* 2 */
+  bottom: 0; /* 2 */
+  left: 0; /* 2 */
+  content: ""; /* 3 */
+  border: var(--Thumbnail-border-width) solid color(var(--Thumbnail-border-color) a(10%)); /* 4 */
+  border-radius: inherit; /* 5 */
+  transition: border 300ms ease; /* 6 */
 }
 
-.Thumbnail:active {
-  border: solid var(--Thumbnail-border-width) color(var(--Thumbnail-border-color) a(50%));
+.Thumbnail:matches(:focus, :hover)::after {
+  border-color: color(var(--Thumbnail-border-color) a(25%));
+}
+
+.Thumbnail:active::after {
+  border-color: color(var(--Thumbnail-border-color) a(50%));
 }
 
 /**


### PR DESCRIPTION
My previous technique for this did not work if nested in any containers without a new positioning context. @nicolemors revised as part of #128 with a temporary solution. This restores the previous effect in a way that's a tad more verbose but also less fragile.
## Before

![screen shot 2016-04-12 at 9 44 31 am](https://cloud.githubusercontent.com/assets/69633/14468150/54138272-0093-11e6-8af6-e6c93ee6e1ec.png)
## After

![screen shot 2016-04-12 at 9 44 08 am](https://cloud.githubusercontent.com/assets/69633/14468161/5df0525c-0093-11e6-99bf-ba5e10d0d5a6.png)

---

@nicolemors @erikjung @saralohr @mrgerardorodriguez 
