### PR TITLE
Core events page prototype R1

### DIFF
--- a/src/assets/toolkit/styles/sandbox/tcs-events-a.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-events-a.css
@@ -1,0 +1,80 @@
+@import "../base/theme.css";
+@import "../base/theme-map.css";
+
+.BigOlMasthead {
+  font-size: calc(1em * var(--ms5));
+}
+
+@media (--sm-viewport) {
+  .BigOlMasthead {
+    font-size: calc(1em * var(--ms6));
+  }
+}
+
+@media (--md-viewport) {
+  .BigOlMasthead {
+    font-size: calc(1em * var(--ms7));
+  }
+}
+
+@media (--lg-viewport) {
+  .BigOlMasthead {
+    font-size: calc(1em * var(--ms8));
+    letter-spacing: -0.0375em;
+  }
+}
+
+.HotDate {
+  background: #fff;
+  border: 3px solid currentColor;
+  border-radius: 0.25em;
+  color: var(--color-blue);
+  display: inline-flex;
+  flex-direction: column;
+  font-weight: 600;
+  min-height: 4.5em;
+  min-width: 4.5em;
+  text-align: center;
+}
+
+.HotDate-header {
+  background: var(--color-blue);
+  border-bottom: 3px solid transparent;
+  color: var(--color-white);
+  line-height: var(--line-height-sm);
+}
+
+.HotDate-body {
+  font-size: calc(1em * var(--ms3));
+  line-height: var(--line-height-xs);
+  margin: auto 0;
+}
+
+.HotDate--range .HotDate-body {
+  font-size: calc(1em * var(--ms1));
+}
+
+.SecretLink,
+.SecretLink:matches(:hover, :focus, :active) {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+.SecretLink-beanSpiller {
+  color: var(--color-blue);
+}
+
+.u-decorationNone {
+  text-decoration: none;
+}
+
+.u-marginSidesMinusMd {
+  margin-left: calc(var(--space-md) * -1);
+  margin-right: calc(var(--space-md) * -1);
+}
+
+@media (--sm-viewport) {
+  .Thumbnail--rounded\@sm {
+    border-radius: var(--control-radius);
+  }
+}

--- a/src/views/sandbox/tyler-events.html
+++ b/src/views/sandbox/tyler-events.html
@@ -1,0 +1,134 @@
+---
+title: "Core Events Page"
+stylesheets:
+  - sandbox/tcs-events-a
+labels:
+  - inprogress
+---
+
+{{> sky }}
+
+<main role="main" id="main">
+  {{#embed "sky" class="Sky--clouds"}}
+    {{#content "top"}}
+      <div class="u-paddingMd u-md-flex u-flexAlignItemsBaseline">
+        <h1 class="BigOlMasthead u-marginRightMd">Speaking</h1>
+        <p class="u-textLarger">
+          Saying what we mean, meaning what we say
+        </p>
+      </div>
+    {{/content}}
+  {{/embed}}
+  <div class="u-bgWhite">
+
+    <div class="u-paddingMd">
+      <h1 class="u-marginEndsXs">Future Events</h1>
+      <div class="Grid Grid--withGutter">
+        {{#iterate 5}}
+          <article class="Grid-cell u-marginEndsXs u-sm-size1of2 u-md-size1of3">
+            <a href="#" class="SecretLink u-flex u-flexAlignItemsCenter">
+              <time class="HotDate" datetime="2016-04-12T18:30">
+                <span class="HotDate-header">Sup</span>
+                <span class="HotDate-body">13</span>
+              </time>
+              <div class="u-marginLeftSm">
+                <h3 class="u-textLarger SecretLink-beanSpiller">One Egret Adrift</h3>
+                <p><b>Gotham City, NJ</b></p>
+                <p>Speakers: Jason</p>
+              </div>
+            </a>
+          </article>
+        {{/iterate}}
+      </div>
+      <hr class="u-marginEndsMd">
+      <h1 class="u-marginEndsXs">Our Talks</h1>
+      <div class="Grid Grid--withGutter">
+        {{#iterate 8}}
+          <article class="Grid-cell u-marginEndsXs u-sm-size1of2 u-md-size1of3">
+            <div class="Thumbnail Thumbnail--rounded@sm u-block u-marginSidesMinusMd u-sm-marginSidesNone">
+              <img class="u-sizeFull" src="http://placeimg.com/320/180/tech" alt="">
+            </div>
+            <h2 class="u-marginTopXs">
+              <a class="u-decorationNone" href="#">
+                Responsive: What Even?
+              </a>
+            </h2>
+            <p><b>By Tyroy Stiltman</b></p>
+            <p>
+              Presented at
+              One Egret Adrift,
+              Tanned Flesh PDX,
+              Dashing Confluence
+              <a class="u-decorationNone u-textNoWrap" href="#">
+                + 7 more
+              </a>
+            </p>
+          </article>
+        {{/iterate}}
+      </div>
+    </div>
+
+    <hr class="u-marginSidesMd u-marginEndsNone">
+    <div class="u-posRelative">
+      <p class="u-paddingMd u-size2of3">
+        <span class="u-inlineBlock u-textLarger u-marginRightSm u-textNoWrap">
+          Need help clouding your fours?
+        </span>
+        <a class="Button Button--primary u-marginEndsXs u-textNoWrap" href="mailto:info@cloudfour.com">
+          <svg class="Icon Icon--large" role="img">
+            <use xlink:href="/assets/toolkit/images/icons.svg#envelope"/>
+          </svg>
+          Squiddly-doo
+        </a>
+      </p>
+      <img class="u-posAbsoluteBottomRight u-size2of5 u-sm-size1of3 u-sm-marginRightMd u-md-size1of4"
+        src="/assets/toolkit/images/portland.svg" alt="">
+    </div>
+  </div>
+</main>
+
+<footer class="u-paddingMd" role="contentinfo">
+  <p>
+    <a href="/"><strong>Cloud Four, Inc.</strong></a>
+  </p>
+  <div class="Grid u-posRelative">
+    <div class="Grid-cell u-sm-size1of2 u-md-size1of3">
+      <p>
+        208 SW 1st Ave, Suite 240<br>
+        Portland, Oregon 97204 USA
+      </p>
+      <ul class="u-listUnstyled">
+        <li><a href="mailto:info@cloudfour.com">info@cloudfour.com</a></li>
+        <li><a href="tel:15032901090">+1 503.290.1090</a></li>
+      </ul>
+      <ul class="u-listInline u-marginTopMd u-md-marginTopNone u-md-posAbsoluteTopRight">
+        {{#each toolkit.social}}
+          <li>
+            <a class="u-textLarger" href="{{url}}" title="{{text}}">
+              <svg class="Icon Icon--large" role="img">
+                <use xlink:href="/assets/toolkit/images/icons.svg#{{@key}}"/>
+              </svg>
+            </a>
+          </li>
+        {{/each}}
+      </ul>
+    </div>
+    <hr class="Grid-cell u-sm-hidden u-marginTopMd u-marginBottomNone"/>
+    <nav class="Grid-cell u-marginTopMd u-sm-marginTopNone u-sm-size1of2 u-md-size1of3">
+      <ul class="u-listUnstyled u-columns2">
+        <li><a href="/">Our Process</a></li>
+        <li><a href="/">Our Work</a></li>
+        <li><a href="/">Articles</a></li>
+        <li><a href="/">Speaking</a></li>
+        <li><a href="/">Code</a></li>
+        <li><a href="/">The Team</a></li>
+        <li><a href="/">Patterns</a></li>
+        <li><a href="/">Device Lab</a></li>
+      </ul>
+    </nav>
+    <hr class="Grid-cell u-md-hidden u-marginTopMd u-marginBottomNone"/>
+    <p class="Grid-cell u-marginTopMd u-md-sizeFit u-md-flexAlignSelfEnd u-md-flexExpandLeft">
+      <small>&copy; 2007 - 2016 Cloud Four, Inc.</small>
+    </p>
+  </div>
+</footer>


### PR DESCRIPTION
First iteration of an in-browser mockup of the core events page. Want to get it up on the preview URL so folks can take a look. 🐒 
## Teeny Tiny

![events-r1-narrow](https://cloud.githubusercontent.com/assets/69633/14503751/421687e4-0166-11e6-8069-a0b97c9e2c7a.png)
## Friggin' Monstrous

![events-r1-wide](https://cloud.githubusercontent.com/assets/69633/14503760/4abc884e-0166-11e6-8c79-489d9880b2ef.png)

---

@nicolemors @erikjung @saralohr @mrgerardorodriguez 
