### PR TITLE
Customize gutter size

### DIFF
--- a/src/assets/toolkit/styles/components/grid.css
+++ b/src/assets/toolkit/styles/components/grid.css
@@ -1,1 +1,5 @@
 @import "suitcss-components-grid";
+
+:root {
+  --Grid-gutter-size: var(--space-md);
+}


### PR DESCRIPTION
We were using SUIT's default `20px` value for gutters. This updates it to use one of our spacing variables instead. Yay for proportional units! Yay for responsive!

---

@nicolemors @erikjung @saralohr @mrgerardorodriguez 
