### PR TITLE
Chore: Create separate flex-embed patterns

### DIFF
--- a/src/patterns/components/flex-embed/16-9-ratio.hbs
+++ b/src/patterns/components/flex-embed/16-9-ratio.hbs
@@ -1,0 +1,14 @@
+---
+name: 16:9 Ratio
+order: 2
+---
+{{#embed "patterns.components.flex-embed.base" ratio="16by9"}}
+  {{#content "content"}}
+    <iframe class="FlexEmbed-content"
+      width="420"
+      height="315"
+      src="https://www.youtube.com/embed/Nx64_N4AA04"
+      frameborder="0"
+      allowfullscreen></iframe>
+  {{/content}}
+{{/embed}}

--- a/src/patterns/components/flex-embed/4-3-ratio.hbs
+++ b/src/patterns/components/flex-embed/4-3-ratio.hbs
@@ -1,0 +1,14 @@
+---
+name: 4:3 Ratio
+order: 3
+---
+{{#embed "patterns.components.flex-embed.base" ratio="4by3"}}
+  {{#content "content"}}
+    <iframe class="FlexEmbed-content"
+      width="420"
+      height="315"
+      src="https://www.youtube.com/embed/Nx64_N4AA04"
+      frameborder="0"
+      allowfullscreen></iframe>
+  {{/content}}
+{{/embed}}

--- a/src/patterns/components/flex-embed/base.hbs
+++ b/src/patterns/components/flex-embed/base.hbs
@@ -2,7 +2,7 @@
 hidden: true
 ---
 <div class="FlexEmbed">
-  <div class="FlexEmbed-ratio FlexEmbed-ratio--{{ratio}}"></div>
+  <div class="FlexEmbed-ratio{{#if ratio}} FlexEmbed-ratio--{{ratio}}{{/if}}"></div>
   {{#block "content"}}
     <div class="FlexEmbed-content"></div>
   {{/block}}

--- a/src/patterns/components/flex-embed/overview.hbs
+++ b/src/patterns/components/flex-embed/overview.hbs
@@ -1,4 +1,5 @@
 ---
+order: 1
 notes: |
   For use with media embeds (videos, slideshows, etc.) that need to retain a
   specific aspect ratio while adapting to the width of their containing element.
@@ -11,23 +12,7 @@ links:
   SUITCSS FlexEmbed Component: https://github.com/suitcss/components-flex-embed
   Creating Intrinsic Ratios for Video: http://alistapart.com/article/creating-intrinsic-ratios-for-video
 ---
-
-<h3>4:3 Ratio</h3>
-
-{{#embed "patterns.components.flex-embed.base" ratio="4by3"}}
-  {{#content "content"}}
-    <iframe class="FlexEmbed-content"
-      width="420"
-      height="315"
-      src="https://www.youtube.com/embed/Nx64_N4AA04"
-      frameborder="0"
-      allowfullscreen></iframe>
-  {{/content}}
-{{/embed}}
-
-<h3>16:9 Ratio</h3>
-
-{{#embed "patterns.components.flex-embed.base" ratio="16by9"}}
+{{#embed "patterns.components.flex-embed.base"}}
   {{#content "content"}}
     <iframe class="FlexEmbed-content"
       width="420"


### PR DESCRIPTION
This PR creates separate flex-embed patterns for the `16:9` and `4:3` sizes.

![flex-embed](https://cloud.githubusercontent.com/assets/459757/14898961/8ef8c016-0d3e-11e6-89a4-dfcf26769694.png)

cc: @tylersticka @erikjung 
