### PR TITLE
Labs core page prototype (R1)

### DIFF
--- a/src/assets/toolkit/styles/sandbox/tcs-labs-a.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-labs-a.css
@@ -1,0 +1,55 @@
+@import "../base/theme.css";
+@import "../base/theme-map.css";
+
+@media (--xl-viewport) {
+  html {
+    font-size: calc(var(--ms1) * 1rem);
+  }
+}
+
+.u-bigOlContainer {
+  max-width: 60rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.u-bebehContainer {
+  max-width: 40rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.BigOlMasthead {
+  font-size: calc(1em * var(--ms5));
+}
+
+@media (--sm-viewport) {
+  .BigOlMasthead {
+    font-size: calc(1em * var(--ms6));
+  }
+}
+
+.u-marginSidesMinusMd {
+  margin-left: calc(var(--space-md) * -1);
+  margin-right: calc(var(--space-md) * -1);
+}
+
+@media (--sm-viewport) {
+  .Thumbnail--rounded\@sm {
+    border-radius: var(--control-radius);
+  }
+}
+
+.SecretLink,
+.SecretLink:matches(:hover, :focus, :active) {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+.SecretLink-beanSpiller {
+  color: var(--color-blue);
+}
+
+.SecretLink:matches(:active, :focus, :hover) .SecretLink-beanSpiller {
+  color: var(--link-hover-color);
+}

--- a/src/data/labs.yml
+++ b/src/data/labs.yml
@@ -1,0 +1,87 @@
+projects:
+  - name: Drizzle
+    color: '#004966'
+    url: "#"
+    notes: |
+      Our pattern library, style guide and prototyping environment.
+    links:
+      - label: Homepage
+        url: "#"
+      - label: Source
+        url: "#"
+  - name: Leveller
+    color: '#444'
+    url: "#"
+    notes: |
+      A jQuery plugin for equalizing element heights when Flexbox just isn't an
+      option.
+    links:
+      - label: Demo
+        url: "#"
+      - label: Article
+        url: "#"
+      - label: Source
+        url: "#"
+  - name: Image Resizing Services
+    color: '#1BB162'
+    url: "#"
+    notes: |
+      Comparison spreadsheet of available options, features and prices.
+    links:
+      - label: View
+        url: "#"
+      - label: Article
+        url: "#"
+  - name: hideShowPassword
+    url: "#"
+    notes: |
+      Customizable touch-friendly password visibility toggles with jQuery.
+    links:
+      - label: Demo
+        url: "#"
+      - label: Article
+        url: "#"
+      - label: Source
+        url: "#"
+  - name: Common Patterns
+    color: '#1BB162'
+    url: "#"
+    notes: |
+      Spreadsheet of recurring UI elements in frameworks, boilerplates and
+      pattern libraries.
+    links:
+      - label: View
+        url: "#"
+      - label: Article
+        url: "#"
+  - name: SimpleSlideView
+    url: "#"
+    notes: |
+      jQuery plugin for prototyping simple in-page content transitions.
+    links:
+      - label: Demo
+        url: "#"
+      - label: Article
+        url: "#"
+      - label: Source
+        url: "#"
+
+pens:
+  - title: Profile Header
+    creator: Tyler Sticka
+    url: http://codepen.io/tylersticka/pen/mewaqW
+  - title: A Pen by Erik Jung
+    creator: Erik Jung
+    url: http://codepen.io/erikjung/pen/XdWEKE
+  - title: Responsive Type Sizing
+    creator: Erik Jung
+    url: http://codepen.io/erikjung/pen/XmOdEo
+  - title: "Flexible image experiment (div + filter)"
+    creator: Tyler Sticka
+    url: http://codepen.io/erikjung/pen/yOqKQV
+  - title: Responsive tiles with column-spanning flyouts
+    creator: Tyler Sticka
+    url: http://codepen.io/erikjung/pen/eNLEVE
+  - title: Responsive SVG Logo Composition
+    creator: Tyler Sticka
+    url: http://codepen.io/erikjung/pen/yOjNpY

--- a/src/pages/sandbox/tyler-labs-a.hbs
+++ b/src/pages/sandbox/tyler-labs-a.hbs
@@ -1,0 +1,168 @@
+---
+title: Core Labs Page
+layout: toolkit.blank
+stylesheets:
+  - sandbox/tcs-labs-a
+labels:
+  - inprogress
+notes: |
+  Will include our open source projects and recent nuggets of code goodness.
+---
+
+{{#embed "patterns.components.sky.base"}}
+  {{#content "top"}}
+    <div class="u-bigOlContainer">
+      <header class="Sky-nav" role="banner">
+        <ul class="Sky-nav-controls">
+          {{! TODO: Allow these href destinations to be customized }}
+          <li><a class="Sky-nav-controls-skipToMain Button Button--inverse u-textNoWrap u-hiddenTillFocus" href="#main">Skip to main content</a></li>
+          <li><a class="Sky-nav-controls-skipToMenu Button Button--defaultLight" href="#menu" aria-label="Skip to navigation">Menu</a></li>
+        </ul>
+        <a class="Sky-nav-logo" href="/">
+          <svg class="Sky-nav-logo-object" width="80" height="80" role="img" aria-labelledby="logo-title">
+            <title id="logo-title">Cloud Four</title>
+            <use xlink:href="/assets/toolkit/images/icons.svg#cloud-four" fill="currentColor"/>
+          </svg>
+        </a>
+        {{! TODO: Allow this ID to be customized (see above href todo as well) }}
+        <nav class="Sky-nav-menu" role="navigation" id="menu">
+          <ul class="Sky-nav-menu-items">
+            <li><a class="Sky-nav-menu-item" href="/#main" aria-current>Our Process</a></li>
+            <li><a class="Sky-nav-menu-item" href="/">Our Work</a></li>
+            <li><a class="Sky-nav-menu-item" href="/">Articles</a></li>
+            <li><a class="Sky-nav-menu-item" href="/">Speaking</a></li>
+            <li><a class="Sky-nav-menu-item" href="/">Code</a></li>
+            <li><a class="Sky-nav-menu-item" href="/">The Team</a></li>
+          </ul>
+        </nav>
+      </header>
+    </div>
+  {{/content}}
+{{/embed}}
+
+<main role="main" id="main">
+  {{#embed "patterns.components.sky.base" class="Sky--clouds"}}
+    {{#content "top"}}
+      <div class="u-bigOlContainer u-paddingMd u-md-flex u-flexAlignItemsBaseline">
+        <h1 class="BigOlMasthead u-marginRightMd">Labs</h1>
+        <p class="u-textLarger" style="opacity: 0.8;">
+          Open source goodness for our fellow web craftspeople
+        </p>
+      </div>
+    {{/content}}
+  {{/embed}}
+  <div class="u-bgWhite">
+
+    <div class="u-bigOlContainer u-paddingMd">
+
+      <h1 class="u-marginEndsXs">Tools and Resources</h1>
+      <div class="Grid Grid--withGutter">
+        {{#each drizzle.data.labs.contents.projects}}
+          <article class="Grid-cell u-flex u-marginEndsLg u-md-size1of2 u-lg-size1of3">
+            <div>
+              <div class="Thumbnail Thumbnail--circle">
+                <img src="{{dummyImgSrc 128 128 text='ICON' bg=(defaultTo color '#dbe5ea')}}" alt="" style="width: 4em; height: auto;">
+              </div>
+            </div>
+            <div class="u-marginLeftSm u-flex u-flexCol">
+              <h3 class="u-textLarger">{{name}}</h3>
+              <p class="u-md-paddingRightSm">{{{notes}}}</p>
+              <ul class="u-listInline u-paddingTopXs u-flexExpandTop">
+                {{#each links}}
+                  <li><a href="{{url}}">{{label}}</a></li>
+                {{/each}}
+              </ul>
+            </div>
+          </article>
+        {{/each}}
+      </div>
+      <hr class="u-marginEndsMd u-marginBottomLg">
+      <h1 class="u-marginEndsXs">Experiments</h1>
+      <div class="Grid Grid--withGutter">
+        {{#each drizzle.data.labs.contents.pens}}
+          <article class="Grid-cell u-marginEndsXs u-marginBottomMd u-sm-size1of2 u-md-size1of3">
+            <a href="{{url}}" class="SecretLink u-block">
+              <div class="Thumbnail Thumbnail--rounded@sm u-block u-marginSidesMinusMd u-sm-marginSidesNone">
+                <img class="u-sizeFull" src="{{url}}/image/small.png" alt="">
+              </div>
+              <p class="SecretLink-beanSpiller u-marginTopXs u-sm-paddingRightSm">
+                {{title}}
+              </p>
+            </a>
+          </article>
+        {{/each}}
+      </div>
+    </div>
+
+    <div class="u-bigOlContainer">
+      <hr class="u-marginSidesMd u-marginEndsNone">
+    </div>
+    <div class="u-bigOlContainer u-posRelative">
+      <p class="u-paddingMd u-size2of3">
+        <span class="u-inlineBlock u-textLarger u-marginRightSm u-textNoWrap">
+          Need help clouding your fours?
+        </span>
+        <a class="Button Button--primary u-marginEndsXs u-textNoWrap" href="mailto:info@cloudfour.com">
+          <svg class="Icon Icon--large" role="img">
+            <use xlink:href="/assets/toolkit/images/icons.svg#envelope"/>
+          </svg>
+          Squiddly-doo
+        </a>
+      </p>
+      <img class="u-posAbsoluteBottomRight u-size2of5 u-sm-size1of3 u-sm-marginRightMd u-md-size1of4"
+        src="/assets/toolkit/images/portland.svg" alt="">
+    </div>
+  </div>
+</main>
+
+<footer class="u-bigOlContainer u-paddingMd u-marginBottomSm" role="contentinfo">
+  <p>
+    <a href="/"><strong>Cloud Four, Inc.</strong></a>
+  </p>
+  <div class="u-posRelative">
+    <div class="Grid Grid--withGutter">
+      <div class="Grid-cell u-sm-size1of2 u-md-size1of3">
+        <p>
+          208 SW 1st Ave, Suite 240<br>
+          Portland, Oregon 97204 USA
+        </p>
+        <ul class="u-listUnstyled">
+          <li><a href="mailto:info@cloudfour.com">info@cloudfour.com</a></li>
+          <li><a href="tel:15032901090">+1 503.290.1090</a></li>
+        </ul>
+        <ul class="u-listInline u-marginTopMd u-md-marginTopNone u-md-posAbsoluteTopRight">
+          {{#each drizzle.data.toolkit.contents.social}}
+            <li>
+              <a class="u-textLarger" href="{{url}}" title="{{text}}">
+                <svg class="Icon Icon--large" role="img">
+                  <use xlink:href="/assets/toolkit/images/icons.svg#{{@key}}"/>
+                </svg>
+              </a>
+            </li>
+          {{/each}}
+        </ul>
+      </div>
+      <div class="Grid-cell u-sm-hidden">
+        <hr class="u-marginTopMd u-marginBottomNone"/>
+      </div>
+      <nav class="Grid-cell u-marginTopMd u-sm-marginTopNone u-sm-size1of2 u-md-size1of3">
+        <ul class="u-listUnstyled u-columns2">
+          <li><a href="/">Our Process</a></li>
+          <li><a href="/">Our Work</a></li>
+          <li><a href="/">Articles</a></li>
+          <li><a href="/">Speaking</a></li>
+          <li><a href="/">Code</a></li>
+          <li><a href="/">The Team</a></li>
+          <li><a href="/">Patterns</a></li>
+          <li><a href="/">Device Lab</a></li>
+        </ul>
+      </nav>
+      <div class="Grid-cell u-md-hidden">
+        <hr class="u-marginTopMd u-marginBottomNone"/>
+      </div>
+      <p class="Grid-cell u-marginTopMd u-md-sizeFit u-md-flexAlignSelfEnd u-md-flexExpandLeft">
+        <small>&copy; 2007 - 2016 Cloud Four, Inc.</small>
+      </p>
+    </div>
+  </div>
+</footer>


### PR DESCRIPTION
First sandbox prototype for the Labs core page.

Note that this is not using any of the fancy new layout templates yet. I prototyped some different base `font-size` stuff and `max-width` containers that I wanted to leverage from my event/speaking prototypes. Since that stuff hasn't been componentized yet, I just copied and pasted for now.
## Screenshots
### Narrow

![screencapture-localhost-3000-sandbox-tyler-labs-a-html-1461951504654](https://cloud.githubusercontent.com/assets/69633/14924289/a19ea2ea-0df6-11e6-8d18-d7eccf2209e6.png)
### Wide

![screencapture-localhost-3000-sandbox-tyler-labs-a-html-1461951535774](https://cloud.githubusercontent.com/assets/69633/14924296/a5fa58ca-0df6-11e6-8791-f1525a0fffbc.png)
### Wider

![screencapture-localhost-3000-sandbox-tyler-labs-a-html-1461951476660](https://cloud.githubusercontent.com/assets/69633/14924298/a96d061a-0df6-11e6-91d3-f8205416758e.png)

---

@erikjung @mrgerardorodriguez @nicolemors @saralohr 
