### PR TITLE
Update `talk-preview` to use `u-linkBlock` and `u-linkBlockTarget`

### DIFF
--- a/src/patterns/combos/speaking/talk-preview.hbs
+++ b/src/patterns/combos/speaking/talk-preview.hbs
@@ -17,11 +17,11 @@ default:
     moreEvents: 3
 ---
 {{#with (defaultTo talk default.talk)}}
-  <a href="{{url}}" class="u-block u-linkClean u-textInheritColor">
+  <a href="{{url}}" class="u-linkBlock u-textInheritColor">
     <div class="Thumbnail u-block u-marginSidesMinusMd u-sm-marginSidesNone u-sm-borderRadius">
       <img class="u-sizeFull" src="{{thumbnail}}" alt="{{alt}}">
     </div>
-    <h2 class="u-marginTopXs u-linkCleanTarget">
+    <h2 class="u-marginTopXs u-linkBlockTarget">
       {{title}}
     </h2>
     <p class="u-textBold">By {{speaker}}</p>


### PR DESCRIPTION
This PR updates the `talk-preview` combo to use the `u-linkBlock` and custom `u-linkBlockTarget` class.

This update came about from the result of https://github.com/cloudfour/cloudfour.com-patterns/pull/168

cc: @tylersticka @erikjung 
