### PR TITLE
Generalize link target class, update files

### DIFF
--- a/src/assets/toolkit/styles/utils/link.css
+++ b/src/assets/toolkit/styles/utils/link.css
@@ -1,9 +1,10 @@
 @import "suitcss-utils-link";
 
-.u-linkBlockTarget {
+.u-linkTarget {
   color: var(--color-blue);
 }
 
-.u-linkBlock:matches(:active, :focus, :hover) .u-linkBlockTarget {
+.u-linkBlock:matches(:active, :focus, :hover) .u-linkTarget,
+.u-linkClean:matches(:active, :focus, :hover) .u-linkTarget {
   color: var(--link-hover-color);
 }

--- a/src/patterns/combos/labs/pen-preview.hbs
+++ b/src/patterns/combos/labs/pen-preview.hbs
@@ -14,7 +14,7 @@ default:
   <div class="Thumbnail u-block u-marginSidesMinusMd u-sm-marginSidesNone u-sm-borderRadius">
     <img class="u-sizeFull" src="{{url}}/image/small.png" alt="">
   </div>
-  <h4 class="u-linkBlockTarget u-marginTopXs u-sm-paddingRightSm">
+  <h4 class="u-linkTarget u-marginTopXs u-sm-paddingRightSm">
     {{title}}
   </h4>
   <p>

--- a/src/patterns/combos/speaking/future-event.hbs
+++ b/src/patterns/combos/speaking/future-event.hbs
@@ -19,7 +19,7 @@ default:
   <a href="{{url}}" class="u-flex u-flexAlignItemsCenter u-linkClean u-textInheritColor">
     {{#embed "patterns.components.calendar-date.base" event=this}}{{/embed}}
     <div class="u-marginLeftSm">
-      <h3 class="u-textLarger u-linkCleanTarget">{{name}}</h3>
+      <h3 class="u-textLarger u-linkTarget">{{name}}</h3>
       <p class="u-textNoWrap u-textBold">{{location}}</p>
       <p>
         Speaker:

--- a/src/patterns/combos/speaking/talk-preview.hbs
+++ b/src/patterns/combos/speaking/talk-preview.hbs
@@ -21,7 +21,7 @@ default:
     <div class="Thumbnail u-block u-marginSidesMinusMd u-sm-marginSidesNone u-sm-borderRadius">
       <img class="u-sizeFull" src="{{thumbnail}}" alt="{{alt}}">
     </div>
-    <h2 class="u-marginTopXs u-linkBlockTarget">
+    <h2 class="u-marginTopXs u-linkTarget">
       {{title}}
     </h2>
     <p class="u-textBold">By {{speaker}}</p>


### PR DESCRIPTION
This PR generalizes the `u-linkBlockTarget` class to `u-linkTarget`. The thinking is, since the "target" class is a child class of both `u-linkBlock` and `u-linkClean`, it didn't make sense to name it `u-linkBlockTarget` or `u-linkCleanTarget`.

This also address #170 

cc: @tylersticka @erikjung 
