### PR TITLE
Fix for gap below clouds in Safari

### DIFF
--- a/src/assets/toolkit/images/sky-clouds.svg
+++ b/src/assets/toolkit/images/sky-clouds.svg
@@ -1,15 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 24" width="420" height="24" preserveAspectRatio="none">
   <g fill="#fff">
-    <circle cx="0" cy="45" r="36"/>
-    <circle cx="41" cy="38" r="25"/>
-    <circle cx="86" cy="46" r="36"/>
-    <circle cx="125" cy="31" r="25"/>
-    <circle cx="158" cy="42" r="25"/>
-    <circle cx="200" cy="46" r="36"/>
-    <circle cx="244" cy="28" r="25"/>
-    <circle cx="280" cy="45" r="36"/>
-    <circle cx="330" cy="48" r="36"/>
-    <circle cx="372" cy="42" r="25"/>
-    <circle cx="420" cy="45" r="36"/>
+    <circle cx="0" cy="43" r="37"/>
+    <circle cx="41" cy="37" r="25"/>
+    <circle cx="86" cy="45" r="36"/>
+    <circle cx="125" cy="30" r="25"/>
+    <circle cx="158" cy="41" r="25"/>
+    <circle cx="200" cy="45" r="36"/>
+    <circle cx="244" cy="27" r="25"/>
+    <circle cx="280" cy="44" r="36"/>
+    <circle cx="330" cy="47" r="36"/>
+    <circle cx="372" cy="40" r="25"/>
+    <circle cx="420" cy="43" r="37"/>
+    <!-- Fix for 1px gap below in some browsers -->
+    <rect x="0" y="23" width="420" height="1" shape-rendering="crispEdges"/>
   </g>
 </svg>


### PR DESCRIPTION
Thanks to @erikjung for pointing out to me that in Safari, a sliver of sky was visible just beneath the clouds:

![screen shot 2016-05-12 at 2 18 36 pm](https://cloud.githubusercontent.com/assets/69633/15230834/a4fa4952-184c-11e6-878a-28f020ef5ee2.png)

The problem is due to differences in the way that various browsers render vector imagery. Safari is a bit more aggressive about its anti-aliasing, a problem that worsens with proportional units that are computing to values that aren't rounding to the nearest pixel.

One solution would have been to overshoot the `background-position`, using something like `101%` instead of `bottom`. The problem with that solution is that it leaves a lot of potential for the fluffy cloud intersections to drift _below_ the bottom edge of the container.

Another CSS-based solution would be to add a `-1px` top margin to the adjacent element. I used this technique for [Responsive Field Day](https://www.responsivefieldday.com/), but it never sat right with me... it made it more difficult to modify element margins, and it always felt icky adding a layout style to a completely separate element.

After doing some digging, I chanced upon an SVG attribute I'd never heard of... [`shape-rendering`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering):

> The creator of SVG content might want to provide a hint about what tradeoffs to make as the browser renders `<path>` element or basic shapes. The `shape-rendering` attribute provides these hints.

If I set `shape-rendering` to `crispEdges` on the whole asset, it eliminates the gap but makes the fluffy clouds look a lot less fluffy:

![screen shot 2016-05-12 at 2 27 30 pm](https://cloud.githubusercontent.com/assets/69633/15231041/b867dc06-184d-11e6-9a7c-981d514b4880.png)

But you can also define `shape-rendering` for specific elements. So I added a `1px` rectangle to the very bottom of the asset, bumping all the clouds up just a tad to compensate.

And voilà: 

![screen shot 2016-05-12 at 2 18 56 pm](https://cloud.githubusercontent.com/assets/69633/15231084/e8f42f8c-184d-11e6-8744-c1ebfa0679cb.png)

The more you know... 🌈 🌟 

---

@erikjung @saralohr @nicolemors @aileenjeffries @mrgerardorodriguez 
