### PR TITLE
Remove .Button--secondary, tweak .Button default

### DIFF
--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -8,7 +8,7 @@
  */
 
 :root {
-  --Button-border-color: transparent;
+  --Button-border-color: var(--color-relative);
   --Button-border-radius: var(--control-radius);
   --Button-border-width: var(--control-stroke);
   --Button-disabled-opacity: var(--control-disabled-opacity);
@@ -147,29 +147,6 @@
 
 .Button--primary:active {
   background-color: color(var(--Button-primary-background-color) shade(10%));
-}
-
-/**
- * Modifier: secondary buttons
- */
-
-:root {
-  --Button-secondary-background-color: var(--color-gray);
-  --Button-secondary-color: inherit;
-}
-
-.Button--secondary,
-.Button--secondary:matches(:focus, :hover, :active) {
-  color: var(--Button-secondary-color);
-  background-color: var(--Button-secondary-background-color);
-}
-
-.Button--secondary:matches(:focus, :hover) {
-  background-color: color(var(--Button-secondary-background-color) l(+5%));
-}
-
-.Button--secondary:active {
-  background-color: color(var(--Button-secondary-background-color) shade(10%));
 }
 
 /**

--- a/src/assets/toolkit/styles/sandbox/tcs-blog-a.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-blog-a.css
@@ -67,10 +67,7 @@ img {
 .Button--heyNameMe {
   background: color(var(--color-navy) l(+30%));
   color: var(--color-white);
-}
-
-.Button--tertiary {
-  border-color: currentColor;
+  border-color: var(--color-null);
 }
 
 .Pagination {

--- a/src/assets/toolkit/styles/sandbox/tcs-blog-f.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-blog-f.css
@@ -88,10 +88,7 @@ img {
 .Button--heyNameMe {
   background: color(var(--color-navy) l(+30%));
   color: var(--color-white);
-}
-
-.Button--tertiary {
-  border-color: currentColor;
+  border-color: var(--color-null);
 }
 
 .Pagination {

--- a/src/assets/toolkit/styles/sandbox/tcs-events-a.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-events-a.css
@@ -121,10 +121,6 @@
   padding-top: var(--space-xs);
 }
 
-.Button--tertiary {
-  border-color: currentColor;
-}
-
 .PresenterInfo {
   background: color(var(--color-gray) a(50%));
   margin-left: calc(var(--space-md) * -1);

--- a/src/pages/sandbox/tyler-blog-b.hbs
+++ b/src/pages/sandbox/tyler-blog-b.hbs
@@ -139,7 +139,7 @@ notes: |
         {{/each}}
       </div>
       <p class="u-marginTopXl u-marginBottomLg">
-        <a class="Button Button--tertiary" href="#">
+        <a class="Button" href="#">
           <svg class="Icon" role="img">
             <use xlink:href="/assets/toolkit/images/icons.svg#arrow-left"/>
           </svg>
@@ -152,7 +152,7 @@ notes: |
         <ul class="u-listInline">
           {{#each drizzle.data.topics.contents}}
             <li class="u-marginBottomSm">
-              <a href="#" class="Button Button--tertiary">
+              <a href="#" class="Button">
                 {{@key}}
                 <span class="u-textGray">
                   {{.}}

--- a/src/pages/sandbox/tyler-blog-c.hbs
+++ b/src/pages/sandbox/tyler-blog-c.hbs
@@ -108,7 +108,7 @@ notes: |
             {{/each}}
           </div>
           <p>
-            <a class="Button Button--tertiary" href="#">
+            <a class="Button" href="#">
               <svg class="Icon" role="img">
                 <use xlink:href="/assets/toolkit/images/icons.svg#arrow-left"/>
               </svg>

--- a/src/pages/sandbox/tyler-talk.hbs
+++ b/src/pages/sandbox/tyler-talk.hbs
@@ -129,7 +129,7 @@ notes: |
         </p>
       </div>
       <p class="u-marginEndsLg">
-        <a class="Button Button--tertiary" href="#">
+        <a class="Button" href="#">
           <svg class="Icon" role="img">
             <use xlink:href="/assets/toolkit/images/icons.svg#arrow-left"/>
           </svg>

--- a/src/patterns/components/button/colors.hbs
+++ b/src/patterns/components/button/colors.hbs
@@ -23,12 +23,6 @@ notes: |
   {{/content}}
 {{/embed}}
 
-{{#embed "patterns.components.button.base" class="Button--secondary"}}
-  {{#content "content"}}
-    Secondary
-  {{/content}}
-{{/embed}}
-
 {{#embed "patterns.components.button.base" class="Button--inverse"}}
   {{#content "content"}}
     Inverse

--- a/src/patterns/components/button/disabled.hbs
+++ b/src/patterns/components/button/disabled.hbs
@@ -16,9 +16,3 @@ notes: |
     Disabled
   {{/content}}
 {{/embed}}
-
-{{#embed "patterns.components.button.base" class="Button--secondary" disabled=true}}
-  {{#content "content"}}
-    Disabled
-  {{/content}}
-{{/embed}}


### PR DESCRIPTION
We weren't using the default `.Button` styles or `.Button--secondary`. I introduced a simpler style in recent mockups that people seemed to like, which was only one CSS rule away from being the default.

This PR removes `.Button--secondary` and updates the default to work for those cases.
## Before

![screen shot 2016-05-13 at 4 15 45 pm](https://cloud.githubusercontent.com/assets/69633/15264237/0e63e950-1926-11e6-9719-70337b58f50d.png)
![screen shot 2016-05-13 at 4 15 48 pm](https://cloud.githubusercontent.com/assets/69633/15264240/1084f6c0-1926-11e6-9c6d-1030107f2590.png)
## After

![screen shot 2016-05-13 at 4 15 30 pm](https://cloud.githubusercontent.com/assets/69633/15264230/058c9a0c-1926-11e6-8807-fd500f6922fd.png)
![screen shot 2016-05-13 at 4 15 36 pm](https://cloud.githubusercontent.com/assets/69633/15264234/0aad5698-1926-11e6-99d2-4f6b0b4983eb.png)

---

@erikjung @saralohr @mrgerardorodriguez @nicolemors 
