### PR TITLE
Specify flex-basis for Sky-nav-logo

### DIFF
--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -19,6 +19,7 @@
   --Sky-nav-logo-padding: var(--Sky-nav-controls-space-y) var(--Sky-nav-controls-space-x);
 
   --Sky-nav-menu-background-image: linear-gradient(to bottom, var(--Sky-background-color-dark), var(--Sky-background-color));
+  --Sky-nav-menu-count: 6;
   --Sky-nav-menu-item-border-color: color(var(--color-black) a(10%));
   --Sky-nav-menu-item-border-width: var(--control-stroke);
   --Sky-nav-menu-item-font-size: var(--font-size-md);
@@ -154,11 +155,13 @@
 }
 
 /**
- * Logo
+ * 1. Helps balance the logo visually next to other nav items, especially at
+ *    wider viewport sizes.
  */
 
 .Sky-nav-logo {
   padding: var(--Sky-nav-logo-padding);
+  flex: 1 1 calc(100% / (var(--Sky-nav-menu-count) + 1)); /* 1 */
 }
 
 /**


### PR DESCRIPTION
Helps balance the logo visually amongst other nav items.
## Before

![screencapture-localhost-3000-sandbox-tyler-labs-a-html-1463613849906](https://cloud.githubusercontent.com/assets/69633/15378168/f043e6ca-1d15-11e6-9ac6-299482d17ab4.png)
## After

![screencapture-localhost-3000-sandbox-tyler-labs-a-html-1463614188710](https://cloud.githubusercontent.com/assets/69633/15378170/f331ddce-1d15-11e6-86c3-78be6352e802.png)

---

@saralohr @mrgerardorodriguez 
