### PR TITLE
Update FootnoteLink, add u-bgGrayTarget

### DIFF
--- a/src/assets/toolkit/styles/components/footnote-link.css
+++ b/src/assets/toolkit/styles/components/footnote-link.css
@@ -1,43 +1,48 @@
 /** @define FootnoteLink */
 
+:root {
+  --FootnoteLink-background-color: var(--color-blue);
+  --FootnoteLink-border-radius: calc(var(--FootnoteLink-min-width) / 2);
+  --FootnoteLink-color: var(--color-white);
+  --FootnoteLink-font-size: var(--font-size-xs);
+  --FootnoteLink-line-height: var(--ms2);
+  --FootnoteLink-min-width: calc(var(--FootnoteLink-line-height) * 1em);
+  --FootnoteLink-padding: 0 calc(var(--ms-6) * 1em);
+}
+
 /**
- * 1. Base size on ratio. TODO: can we use `--font-size-md`?
- * 2. If we used `50%`, wider elements would look like ovals. Using a value
- *    based on the size (1) will maintain more of a pill shape.
- * 3. Base offset on `line-height` (since this will be used to avoid unnecessary
- *    shifts in `line-height`).
+ * Override color defaults for all states
  */
 
-:root {
-  --FootnoteLink-size: calc(var(--ms-ratio) * 1em); /* 1 */
-  --FootnoteLink-border-radius: calc(var(--FootnoteLink-size) / 2); /* 2 */
-  --FootnoteLink-line-height-offset: calc((var(--line-height-md) - 1) / -2em); /* 3 */
-
-  --FootnoteLink-border-color: var(--color-gray);
-  --FootnoteLink-border-width: var(--border-width-sm);
-  --FootnoteLink-font-weight: var(--font-weight-semibold);
-  --FootnoteLink-padding: 0 0.25em;
-  --FootnoteLink-transition-duration: var(--motion-duration-lg);
-  --FootnoteLink-transition-timing-function: var(--motion-timing-function-default);
-
-  --FootnoteLink-hover-border-color: var(--color-relative);
+.FootnoteLink,
+.FootnoteLink:matches(:--enter, :active) {
+  color: var(--FootnoteLink-color);
 }
+
+/**
+ * 1. Maintain a circular shape even for narrow text contents.
+ * 2. If the text is wider than the minimum, make sure it still has some
+ *    padding so it doesn't appear to drift outside of the rounded sides.
+ * 3. Once computed, this value should be equal to the min-width to default
+ *    to a circular shape with centered text.
+ */
 
 .FootnoteLink {
-  position: relative;
-  margin: var(--FootnoteLink-line-height-offset) 0;
   display: inline-block;
-  min-width: var(--FootnoteLink-size);
-  padding: var(--FootnoteLink-padding);
-  font-weight: var(--FootnoteLink-font-weight);
-  line-height: var(--FootnoteLink-size);
+  min-width: var(--FootnoteLink-min-width); /* 1 */
+  padding: var(--FootnoteLink-padding); /* 2 */
+  font-size: var(--FootnoteLink-font-size);
+  line-height: var(--FootnoteLink-line-height); /* 3 */
   text-align: center;
   text-decoration: none;
-  border: var(--FootnoteLink-border-width) solid var(--FootnoteLink-border-color);
   border-radius: var(--FootnoteLink-border-radius);
-  transition: all var(--FootnoteLink-transition-duration) var(--FootnoteLink-transition-timing-function);
+  background: var(--FootnoteLink-background-color);
 }
 
-.FootnoteLink:matches(:focus, :hover) {
-  border-color: var(--FootnoteLink-hover-border-color);
+/**
+ * Change the background color on hover or focus
+ */
+
+.FootnoteLink:matches(:--enter) {
+  background-color: color(var(--FootnoteLink-background-color) l(+5%));
 }

--- a/src/assets/toolkit/styles/utils/bg.css
+++ b/src/assets/toolkit/styles/utils/bg.css
@@ -2,7 +2,8 @@
   background-color: var(--color-white);
 }
 
-.u-bgGray {
+.u-bgGray,
+.u-bgGrayTarget:target {
   background-color: color(
     var(--color-gray)
     blend(var(--color-white) 50%)

--- a/src/patterns/components/footnote-link/example.hbs
+++ b/src/patterns/components/footnote-link/example.hbs
@@ -1,6 +1,7 @@
 ---
 name: Example
 sourceless: true
+previewClass: u-spaceItems1
 ---
 
 <p>
@@ -17,25 +18,29 @@ sourceless: true
   srcset.<sup><a class="FootnoteLink" href="#demo-fn-2" id="demo-fn-ref-2" title="Jump to footnote">2</a></sup>
 </p>
 
-<h4>Footnotes</h4>
+<hr>
 
-<ol>
-  <li id="demo-fn-1">
+<ol class="u-spaceItems1">
+  <li class="u-bgGrayTarget u-padSides03 u-padEnds06" id="demo-fn-1">
     How quickly we forget web-safe colors, Lynda Weinman’s multiple books on web
     graphics, and the way different images formats compress. And it’s not
     getting any simpler. Images on the web are inherently complex.
     <a href="#demo-fn-ref-1" title="Return to reference">
-      <svg class="Icon">
-        <use xlink:href="{{baseurl}}/assets/toolkit/images/icons.svg#return" />
-      </svg>
+      {{{
+        embed "patterns.components.icon.base"
+        iconid="return"
+        role="presentation"
+      }}}
     </a>
   </li>
-  <li id="demo-fn-2">
+  <li class="u-bgGrayTarget u-padSides03 u-pad06" id="demo-fn-2">
     Unless we’re providing different image formats which we will cover later.
     <a href="#demo-fn-ref-2" title="Return to reference">
-      <svg class="Icon">
-        <use xlink:href="{{baseurl}}/assets/toolkit/images/icons.svg#return" />
-      </svg>
+      {{{
+        embed "patterns.components.icon.base"
+        iconid="return"
+        role="presentation"
+      }}}
     </a>
   </li>
 </ol>

--- a/src/patterns/components/footnote-link/overview.hbs
+++ b/src/patterns/components/footnote-link/overview.hbs
@@ -4,8 +4,9 @@ notes: |
   Friendly, more tappable style for links to footnotes from prose content.
 links:
   "W3C: Common idioms": http://www.w3.org/TR/html5/common-idioms.html#footnotes
+  "Markdown Extra: Footnotes": https://michelf.ca/projects/php-markdown/extra/#footnotes
 ---
 
 <a class="FootnoteLink" href="#" id="fn-foo-1" title="Jump to footnote">1</a>
 <a class="FootnoteLink" href="#" id="fn-foo-2" title="Jump to footnote">2</a>
-<a class="FootnoteLink" href="#" id="fn-foo-3" title="Jump to footnote">3</a>
+<a class="FootnoteLink" href="#" id="fn-foo-10" title="Jump to footnote">10</a>


### PR DESCRIPTION
This PR updates the existing `.FootnoteLink` pattern and examples to match what @nicolemors introduced in her prototype.

There is a significant caveat. In researching footnote solutions for WordPress, I wasn't able to find one that mimicked the behavior of her prototype (which uses a custom `counter-increment` and links entire phrases). I had based my original markup on what Automattic's Markdown plugin supported. While I think the prototyped technique is a valuable one, it would likely require that we write our own footnote plugin, and I'm not sure that's something we want to prioritize in the near future.

I also added a `.u-bgGrayTarget` utility. This does the same thing as `.u-bgGray`, but only for the `:target` state.
## Before

![screen shot 2016-05-19 at 3 34 25 pm](https://cloud.githubusercontent.com/assets/69633/15411779/376b8712-1dd7-11e6-8bbb-4657fd2d3473.png)
## After

![screen shot 2016-05-19 at 3 34 11 pm](https://cloud.githubusercontent.com/assets/69633/15411781/3ac5b162-1dd7-11e6-94c3-5e99d75e867a.png)

---

@saralohr @mrgerardorodriguez @nicolemors @erikjung 

Closes #160 
