### PR TITLE
Prevent horizontal scrollbars when 100vw is used

### DIFF
--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -14,6 +14,17 @@ th {
 }
 
 /**
+ * Restrict horizontal scrolling
+ *
+ * Necessary evil for using 100vw with visible scrollbars
+ */
+
+html,
+body {
+  overflow-x: hidden;
+}
+
+/**
  * Base body styles
  */
 


### PR DESCRIPTION
Because we live in a malevolent universe, viewport units do not subtract visible scrollbar dimensions from their output. This change prevents horizontal scrollbars from displaying when the `u-release` class is in use and a vertical scrollbar is visible.
## Before

![screen shot 2016-05-24 at 1 55 13 pm](https://cloud.githubusercontent.com/assets/69633/15520048/3b1d7632-21b9-11e6-9ad4-31cad7931984.png)
## After

![screen shot 2016-05-24 at 1 55 01 pm](https://cloud.githubusercontent.com/assets/69633/15520052/449f8204-21b9-11e6-916e-51e5771b2c58.png)

---

@saralohr @mrgerardorodriguez @erikjung 
