### PR TITLE
Use Array.from arrayFromSelector helper

### DIFF
--- a/src/assets/toolkit/scripts/lib/dom/core.js
+++ b/src/assets/toolkit/scripts/lib/dom/core.js
@@ -1,5 +1,18 @@
 'use strict';
 
-export function each (elementList, callback) {
-  Array.prototype.forEach.call(elementList, callback);
+/**
+ * Returns an array from a specified selector.
+ *
+ * @param {String} selectors - A string containing one or more CSS selectors
+ * separated by commas.
+ * @param {DOM} context - A DOM element providing context for query selection.
+ * Defaults to `document`.
+ * @return {Array}
+ */
+export function arrayFromSelector(selectors, context = document) {
+  if (!selectors) {
+    throw new TypeError('A "selectors" argument is required.');
+  }
+
+  return Array.from(context.querySelectorAll(selectors));
 }

--- a/src/assets/toolkit/scripts/toolkit.js
+++ b/src/assets/toolkit/scripts/toolkit.js
@@ -6,18 +6,14 @@
 
 import Modernizr from 'modernizr';
 import svgxuse from 'svgxuse';
-import {each} from './lib/dom/core';
+import {arrayFromSelector} from './lib/dom/core';
 import {FloatLabel} from './lib/component/float-label';
 import {Sky} from './lib/component/sky';
 import {ElasticTextarea} from './lib/component/elastic-textarea';
 
 (function() {
 
-  var floatLabels = document.querySelectorAll('.js-FloatLabel');
-  var skies = document.querySelectorAll('.Sky');
-  var textareas = document.querySelectorAll('.js-ElasticTextarea');
-
-  each(floatLabels, element => {
+  arrayFromSelector('.js-FloatLabel').map(element => {
     new FloatLabel(element, {
       eventName: Modernizr.oninput ? 'input' : 'keyup'
     });
@@ -27,7 +23,7 @@ import {ElasticTextarea} from './lib/component/elastic-textarea';
    * TODO: Make this smart enough to not just fail if `.Sky` has no nav.
    * Or better yet, hook it to a js-* class only when a nav is included.
    */
-  each(skies, element => {
+  arrayFromSelector('.Sky').map(element => {
     var menu = element.querySelector('.Sky-nav-menu');
     var toggle = element.querySelector('.Sky-nav-controls-skipToMenu');
 
@@ -40,7 +36,7 @@ import {ElasticTextarea} from './lib/component/elastic-textarea';
     }
   });
 
-  each(textareas, element => {
+  arrayFromSelector('.js-ElasticTextarea').map(element => {
     new ElasticTextarea(element, {
       eventName: Modernizr.oninput ? 'input' : 'keyup'
     });


### PR DESCRIPTION
This PR updates the `lib/dom/core.js` file by adding the `arrayFromSelector` helper in place of the original `each` helper. The `toolkit.js` file is updated to reflect this change. This work is part of the `lib` directory cleanup in #194.

---

cc: @tylersticka @erikjung @saralohr 
