### PR TITLE
WIP: Home prototype header

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "ignore": ["gsap"]
 }

--- a/config.js
+++ b/config.js
@@ -33,7 +33,10 @@ module.exports = {
             './src/assets/drizzle/scripts/drizzle.js',
           // Common toolkit scripts
           'toolkit/scripts/toolkit':
-            './src/assets/toolkit/scripts/toolkit.js'
+            './src/assets/toolkit/scripts/toolkit.js',
+          // Homepage animation
+          'toolkit/scripts/home-animation':
+            './src/assets/toolkit/scripts/home-animation.js'
         },
         output: {
           path: './dist/assets',
@@ -61,7 +64,7 @@ module.exports = {
         notify: false,
         online: false,
         open: false,
-        server: {baseDir: './dist'}
+        server: { baseDir: './dist' }
       }
     }
   },
@@ -77,8 +80,12 @@ module.exports = {
         tasks: ['js']
       },
       {
-        match: ['./src/assets/toolkit/{images,icons}/**/*'],
-        tasks: ['images', 'icons']
+        match: ['./src/assets/toolkit/icons/**/*'],
+        tasks: ['icons']
+      },
+      {
+        match: ['./src/static/**/*'],
+        tasks: ['copy']
       },
       {
         match: ['./src/{data,pages,patterns,templates}/**/*'],

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-config-xo-space": "^0.12.0",
     "eslint-plugin-babel": "^3.2.0",
     "feature.js": "^1.0.0",
+    "gsap": "^1.18.5",
     "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",
     "gulp-svg-sprite": "^1.2.9",

--- a/src/assets/toolkit/scripts/home-animation.js
+++ b/src/assets/toolkit/scripts/home-animation.js
@@ -5,7 +5,11 @@
  * See: https://github.com/greensock/GreenSock-JS/issues/71
  */
 
-import TweenMax from 'gsap';
+import TweenLite from 'gsap/src/uncompressed/TweenLite';
+import TimelineMax from 'gsap/src/uncompressed/TimelineMax';
+import EasePack from 'gsap/src/uncompressed/easing/EasePack';
+import CSSPlugin from 'gsap/src/uncompressed/plugins/CSSPlugin';
+import AttrPlugin from 'gsap/src/uncompressed/plugins/AttrPlugin';
 
 /**
  * Settings
@@ -49,7 +53,7 @@ const dom = (function (nodeList) {
   return result;
 })(document.querySelectorAll('*[id]'));
 
-TweenMax.set('.js-scaleIn', {
+TweenLite.set('.js-scaleIn', {
   visibility: 'visible',
   scale: 0,
   transformOrigin: '50% 50%'

--- a/src/assets/toolkit/scripts/home-animation.js
+++ b/src/assets/toolkit/scripts/home-animation.js
@@ -39,7 +39,6 @@ const timelines = {
 
 const dom = (function (nodeList) {
   const result = {};
-  nodeList = Array.prototype.slice.call(nodeList);
 
   for (let i = 0; i < nodeList.length; i++) {
     let node = nodeList[i];

--- a/src/assets/toolkit/scripts/home-animation.js
+++ b/src/assets/toolkit/scripts/home-animation.js
@@ -1,0 +1,296 @@
+/**
+ * GSAP is powerful and performant, but its organization is a little old-school.
+ * This imports a bunch of functions to the global scope.
+ *
+ * See: https://github.com/greensock/GreenSock-JS/issues/71
+ */
+
+import TweenMax from 'gsap';
+
+/**
+ * Settings
+ */
+
+const settings = {
+  morph: {
+    delay: '+=1',
+    duration: 0.5,
+    ease: Elastic.easeOut.config(0.5, 0.4)
+  }
+};
+
+/**
+ * Timelines
+ */
+
+const timelines = {
+  morph: new TimelineMax({
+    repeat: -1
+  })
+};
+
+/**
+ * Elements
+ */
+
+const dom = (function (nodeList) {
+  const result = {};
+  nodeList = Array.prototype.slice.call(nodeList);
+
+  for (let i = 0; i < nodeList.length; i++) {
+    let node = nodeList[i];
+    let id = node.getAttribute('id');
+
+    if (id) {
+      result[id] = node;
+    }
+  }
+
+  return result;
+})(document.querySelectorAll('*[id]'));
+
+TweenMax.set('.js-scaleIn', {
+  visibility: 'visible',
+  scale: 0,
+  transformOrigin: '50% 50%'
+});
+
+/**
+ * Device morphing
+ */
+
+timelines.morph.addLabel('toTablet', settings.morph.delay);
+
+timelines.morph.to(dom.bezel, settings.morph.duration, {
+  attr: {
+    x: 94,
+    y: 66,
+    width: 132,
+    height: 188
+  },
+  ease: settings.morph.ease
+}, 'toTablet');
+
+timelines.morph.to(dom.screenMaskMain, settings.morph.duration, {
+  attr: {
+    x: 100,
+    y: 80,
+    width: 120,
+    height: 160
+  },
+  ease: settings.morph.ease
+}, 'toTablet');
+
+timelines.morph.addLabel('toTabletLandscape', settings.morph.delay);
+
+timelines.morph.to([dom.bezel, dom.screenMaskMain], settings.morph.duration, {
+  attr: {
+    transform: 'rotate(-90 160 160)'
+  },
+  ease: Back.easeInOut.config(1.7)
+}, 'toTabletLandscape');
+
+timelines.morph.set(dom.bezel, {
+  attr: {
+    transform: 'rotate(0)',
+    x: 66,
+    y: 94,
+    width: 188,
+    height: 132
+  }
+});
+
+timelines.morph.set(dom.screenMaskMain, {
+  attr: {
+    transform: 'rotate(0)',
+    x: 80,
+    y: 100,
+    width: 160,
+    height: 120
+  }
+});
+
+timelines.morph.addLabel('toLaptop', settings.morph.delay);
+
+timelines.morph.to(dom.bezel, settings.morph.duration, {
+  attr: {
+    x: 64,
+    y: 78,
+    width: 192,
+    height: 132,
+    rx: 3,
+    ry: 3
+  },
+  ease: settings.morph.ease
+}, 'toLaptop');
+
+timelines.morph.to(dom.screenMaskMain, settings.morph.duration, {
+  attr: {
+    x: 70,
+    y: 84,
+    width: 180,
+    height: 120
+  },
+  ease: settings.morph.ease
+}, 'toLaptop');
+
+timelines.morph.to(dom.keyboard, settings.morph.duration, {
+  scale: 1,
+  ease: settings.morph.ease
+}, 'toLaptop');
+
+timelines.morph.addLabel('toTV', settings.morph.delay);
+
+timelines.morph.to(dom.keyboard, settings.morph.duration / 2, {
+  scale: 0,
+  transformOrigin: '50% 0'
+}, 'toTV');
+
+timelines.morph.to(dom.bezel, settings.morph.duration, {
+  attr: {
+    x: -4,
+    y: 63,
+    width: 328,
+    height: 194,
+    rx: 1,
+    ry: 1
+  },
+  ease: settings.morph.ease
+}, 'toTV');
+
+timelines.morph.to(dom.screenMaskMain, settings.morph.duration, {
+  attr: {
+    x: 0,
+    y: 67,
+    width: 320,
+    height: 180
+  },
+  ease: settings.morph.ease
+}, 'toTV');
+
+timelines.morph.to(dom.remote, settings.morph.duration, {
+  rotation: '-15deg',
+  scale: 1,
+  ease: settings.morph.ease
+}, 'toTV');
+
+timelines.morph.addLabel('toAudio', settings.morph.delay);
+
+timelines.morph.to(dom.remote, settings.morph.duration / 4, {
+  scale: 0,
+  transformOrigin: '0 0'
+}, 'toAudio');
+
+timelines.morph.to(dom.bezel, settings.morph.duration / 4, {
+  attr: {
+    x: 160,
+    y: 160,
+    width: 0,
+    height: 0
+  }
+}, 'toAudio');
+
+timelines.morph.to(dom.screenMaskMain, settings.morph.duration, {
+  attr: {
+    x: 117,
+    y: 127,
+    width: 86,
+    height: 86,
+    rx: 43,
+    ry: 43
+  },
+  ease: settings.morph.ease
+}, 'toAudio');
+
+timelines.morph.to(dom.screenMaskPointer, settings.morph.duration, {
+  attr: {
+    points: '110 196 160 146 160 196'
+  },
+  ease: settings.morph.ease
+}, 'toAudio');
+
+timelines.morph.to(dom.headphones, settings.morph.duration, {
+  scale: 1,
+  ease: settings.morph.ease
+}, 'toAudio');
+
+timelines.morph.addLabel('toWatch', settings.morph.delay);
+
+timelines.morph.to(dom.screenMaskPointer, settings.morph.duration / 2, {
+  attr: {
+    points: '160 160 160 160 160 160'
+  }
+}, 'toWatch');
+
+timelines.morph.to(dom.headphones, settings.morph.duration / 2, {
+  scale: 0
+}, 'toWatch');
+
+timelines.morph.to(dom.bezel, settings.morph.duration, {
+  attr: {
+    x: 134,
+    y: 130,
+    width: 52,
+    height: 60,
+    rx: 8,
+    ry: 8
+  },
+  ease: settings.morph.ease
+}, 'toWatch');
+
+timelines.morph.to(dom.screenMaskMain, settings.morph.duration / 4, {
+  attr: {
+    rx: 2,
+    ry: 2
+  }
+}, 'toWatch');
+
+timelines.morph.to(dom.screenMaskMain, settings.morph.duration, {
+  attr: {
+    x: 140,
+    y: 136,
+    width: 40,
+    height: 48
+  },
+  ease: settings.morph.ease
+}, 'toWatch');
+
+timelines.morph.to(dom.watchband, settings.morph.duration, {
+  scale: 1,
+  ease: settings.morph.ease
+}, 'toWatch');
+
+timelines.morph.addLabel('toPhone', settings.morph.delay);
+
+timelines.morph.to(dom.watchband, settings.morph.duration / 2, {
+  scale: 0
+}, 'toPhone');
+
+timelines.morph.to(dom.bezel, settings.morph.duration, {
+  attr: {
+    x: 127,
+    y: 92,
+    width: 66,
+    height: 136,
+    rx: 6,
+    ry: 6
+  },
+  ease: settings.morph.ease
+}, 'toPhone');
+
+timelines.morph.to(dom.screenMaskMain, settings.morph.duration / 4, {
+  attr: {
+    rx: 0,
+    ry: 0
+  }
+}, 'toWatch');
+
+timelines.morph.to(dom.screenMaskMain, settings.morph.duration, {
+  attr: {
+    x: 130,
+    y: 107,
+    width: 60,
+    height: 106
+  },
+  ease: settings.morph.ease
+}, 'toPhone');

--- a/src/pages/sandbox/tyler-home-a.hbs
+++ b/src/pages/sandbox/tyler-home-a.hbs
@@ -1,0 +1,22 @@
+---
+title: Home A
+layout: toolkit.blank
+labels:
+  - inprogress
+notes: |
+  With responsive devices SVG animation.
+---
+
+{{{embed "patterns.components.sky.base"}}}
+
+<main role="main" id="main">
+  {{#embed "patterns.components.sky.base" class="Sky--clouds"}}
+    {{#content "top"}}
+      <object data="/images/sandbox/home-animation.svg" type="image/svg+xml" style="width: 100%; height: 20em;">
+
+      </object>
+    {{/content}}
+  {{/embed}}
+</main>
+
+{{> toolkit.global-footer }}

--- a/src/pages/sandbox/tyler-home-a.hbs
+++ b/src/pages/sandbox/tyler-home-a.hbs
@@ -12,9 +12,32 @@ notes: |
 <main role="main" id="main">
   {{#embed "patterns.components.sky.base" class="Sky--clouds"}}
     {{#content "top"}}
-      <object data="/images/sandbox/home-animation.svg" type="image/svg+xml" style="width: 100%; height: 20em;">
-
-      </object>
+      <div class="Grid Grid--alignMiddle">
+        <div class="Grid-cell u-md-size1of2 u-md-flexOrderLast">
+          <object data="/images/sandbox/home-animation.svg" type="image/svg+xml" style="width: 100%; height: 20em;">
+            {{! TODO: Fallback (GIF, maybe?) }}
+          </object>
+        </div>
+        <div class="Grid-cell u-md-size1of2">
+          <div class="u-padSides1 u-padBottom1 u-md-padRightNone u-md-padEnds1 u-md-padBottom4 u-spaceItems1">
+            <h1 class="u-textGrow2 u-sm-textGrow4">
+              We design and develop res&shy;ponsive web&shy;sites and prog&shy;ressive <span class="u-textNoWrap">web apps.</span>
+            </h1>
+            <p class="u-sm-textGrow1">
+              We scout the frontier of the web to find practical uses for new technology, helping organizations build things right the first time.
+              <a href="#">
+                Learn more
+                {{{
+                  embed "patterns.components.icon.base"
+                  iconid="arrow-right"
+                  class="u-spaceLeft06"
+                  role="presentation"
+                }}}
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
     {{/content}}
   {{/embed}}
 </main>

--- a/src/static/images/sandbox/home-animation.svg
+++ b/src/static/images/sandbox/home-animation.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+  viewBox="0 0 320 320" width="320" height="320">
+  <defs>
+    <style>
+      .u-hidden {
+        visibility: hidden;
+      }
+
+      .u-fillDark {
+        fill: #0F1C3F;
+      }
+
+      .u-fillMid {
+        fill: #DBE5EA;
+      }
+
+      .u-fillLight {
+        fill: white;
+      }
+
+      .u-strokeMid {
+        fill: none;
+        stroke: #DBE5EA;
+      }
+    </style>
+
+    <mask id="screenMask">
+      <rect id="screenMaskMain" class="u-fillLight" x="130" y="107" width="60" height="106" rx="0" ry="0" transform="rotate(0)"/>
+      <polygon id="screenMaskPointer" class="u-fillLight" points="160 160 160 160 160 160"/>
+    </mask>
+
+  </defs>
+
+  <g id="keyboard" class="u-hidden js-scaleIn">
+    <polygon class="u-fillMid" points="67 216 253 216 283 256 37 256"/>
+    <rect class="u-fillDark" x="37" y="256" width="246" height="4"/>
+    <polygon class="u-fillLight" points="128 241 192 241 198 256 198 258 122 258 122 256"/>
+  </g>
+
+  <path id="headphones" class="u-hidden u-fillDark js-scaleIn" d="M248,138.94a88,88,0,1,0-176,0V205a16,16,0,0,0,16,16h8a8,8,0,0,0,8-8V173a8,8,0,0,0-8-8H88V138.94a72,72,0,1,1,144,0V165h-8a8,8,0,0,0-8,8v40a8,8,0,0,0,8,8h8a16,16,0,0,0,16-16V138.94Z"/>
+
+  <path id="watchband" class="u-hidden u-fillMid js-scaleIn" d="M188,148H178V130l-3.4-18.72a4,4,0,0,0-3.94-3.28H149.34a4,4,0,0,0-3.94,3.28L142,130v60l3.4,18.72a4,4,0,0,0,3.94,3.28h21.32a4,4,0,0,0,3.94-3.28L178,190V157h10a2,2,0,0,0,2-2v-5A2,2,0,0,0,188,148Z"/>
+
+  <rect id="bezel" class="u-fillDark" x="127" y="92" width="66" height="136" rx="6" ry="6" transform="rotate(0)"/>
+
+  <g id="screen" mask="url(#screenMask)">
+    <rect class="u-fillLight" width="100%" height="100%"/>
+  </g>
+
+  <g id="remote" class="u-hidden js-scaleIn">
+    <rect class="u-fillDark" x="236" y="216" width="36" height="88" rx="4" ry="4"/>
+    <circle class="u-strokeMid" stroke-width="4" cx="254" cy="242" r="9"/>
+    <circle class="u-fillMid" cx="245" cy="264" r="3"/>
+    <circle class="u-fillMid" cx="254" cy="264" r="3"/>
+    <circle class="u-fillMid" cx="263" cy="264" r="3"/>
+  </g>
+
+  <script xlink:href="/assets/toolkit/scripts/home-animation.js"/>
+</svg>


### PR DESCRIPTION
This PR adds a WIP home prototype to the sandbox that showcases the current state of the homepage animation and accompanying header text.

The animation is entirely separate from the rest of the toolkit. The imagery exists in an external SVG, which then references a JS file that is separate from our main `toolkit.js`.

For performance and, honestly, usability of constructing a timeline-based animation, I chose to use GSAP. This means the animation JavaScript adds up to a whopping `318kb` uncompressed. This compresses down to `138kb` with Uglify, and further down to `37kb` when gzipped. The gzipped SVG is only `918b`, so we're looking at a total `38kb` transferred for the animation currently, which seems like a reasonable amount to load (and far lighter than the average full-bleed photo).

![home-2016-06-15-0934](https://cloud.githubusercontent.com/assets/69633/16089265/20bf17d2-32df-11e6-9be6-b1b4b740aac5.gif)

---

@saralohr @nicolemors @erikjung @mrgerardorodriguez 