### PR TITLE
Add styles for WP generated classes

### DIFF
--- a/src/assets/toolkit/styles/components/figure.css
+++ b/src/assets/toolkit/styles/components/figure.css
@@ -7,7 +7,8 @@
 
 /**
  * A container for visual media with accompanying caption text. Intended to be
- * used with `<figure>` and `<figcaption>`. Defined as a mixin so as to be easily reused for Wordpress generated classes for `<figure>` and `<figcaption>`
+ * used with `<figure>` and `<figcaption>`.
+ * Defined as mixins to be easily reused for Wordpress generated classes.
  *
  * 1. Self-contain and center images.
  */

--- a/src/assets/toolkit/styles/components/figure.css
+++ b/src/assets/toolkit/styles/components/figure.css
@@ -7,12 +7,12 @@
 
 /**
  * A container for visual media with accompanying caption text. Intended to be
- * used with `<figure>` and `<figcaption>`.
+ * used with `<figure>` and `<figcaption>`. Defined as a mixin so as to be easily reused for Wordpress generated classes for `<figure>` and `<figcaption>`
  *
  * 1. Self-contain and center images.
  */
 
-.Figure {
+@define-mixin Figure {
   display: block;
 
   & > img { /* 1 */
@@ -23,9 +23,17 @@
   }
 }
 
-.Figure-caption {
+.Figure {
+  @mixin Figure;
+}
+
+@define-mixin Figure-caption {
   color: var(--Figure-caption-color);
   font-style: var(--Figure-caption-font-style);
   margin-top: var(--Figure-caption-margin);
   text-align: var(--Figure-caption-text-align);
+}
+
+.Figure-caption {
+  @mixin Figure-caption;
 }

--- a/src/assets/toolkit/styles/toolkit.css
+++ b/src/assets/toolkit/styles/toolkit.css
@@ -1,3 +1,4 @@
 @import "./base/index.css";
 @import "./components/index.css";
 @import "./utils/index.css";
+@import "./vendor/wordpress.css";

--- a/src/assets/toolkit/styles/vendor/wordpress.css
+++ b/src/assets/toolkit/styles/vendor/wordpress.css
@@ -1,0 +1,92 @@
+/* Wordpress generated classes */
+
+.aligncenter,
+div.aligncenter,
+a img.aligncenter {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.alignright,
+a img.alignright {
+  float:right;
+  margin-left: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.alignleft,
+a img.alignleft {
+  float: left;
+  margin-right: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+/* Image scaling
+ * Make sure images with WordPress-added height and width
+ * attributes are scaled correctly
+ */
+
+img[class*="align"],
+img[class*="wp-image-"] {
+  height: auto;
+}
+
+/* `wp-caption` is the class Wordpress applies to a figure element.
+ *  1. Reuse `.Figure` component styles.
+ *  2. Override the `width` inline style  applied to `wp-caption` by Wordpress
+ */
+
+.wp-caption {
+  @mixin Figure; /* 1 */
+  width: 100% !important; /* 2 */
+}
+
+/**
+ * Override the inline fixed width and height styles applied by wordpress
+ */
+
+.wp-caption img {
+  width: auto !important;
+  max-width: 100% !important;
+  height: auto !important;
+}
+
+/* Reuse styles from the `.Figure-caption` pattern.
+ *  1. By default reduce text size.
+ */
+
+.wp-caption-text {
+  @mixin Figure-caption;
+  font-size: calc(1em * var(--ms-1)); /* 1 */
+}
+
+/* Text meant only for screen readers. */
+
+.screen-reader-text {
+  clip: rect(1px, 1px, 1px, 1px);
+  position: absolute !important;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+}
+
+.screen-reader-text:focus {
+  background-color: #f1f1f1;
+  border-radius: 3px;
+  box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+  clip: auto !important;
+  color: #21759b;
+  display: block;
+  font-size: 14px;
+  font-size: 0.875rem;
+  font-weight: bold;
+  height: auto;
+  left: 5px;
+  line-height: normal;
+  padding: 15px 23px 14px;
+  text-decoration: none;
+  top: 5px;
+  width: auto;
+  z-index: 100000; /* Above WP toolbar. */
+}

--- a/src/assets/toolkit/styles/vendor/wordpress.css
+++ b/src/assets/toolkit/styles/vendor/wordpress.css
@@ -1,4 +1,7 @@
-/* Wordpress generated classes */
+/**
+ * Wordpress generated classes
+ * https://codex.wordpress.org/CSS#WordPress_Generated_Classes
+ */
 
 .aligncenter,
 div.aligncenter,
@@ -22,7 +25,8 @@ a img.alignleft {
   margin-bottom: var(--space-sm);
 }
 
-/* Image scaling
+/**
+ * Image scaling
  * Make sure images with WordPress-added height and width
  * attributes are scaled correctly
  */
@@ -32,7 +36,8 @@ img[class*="wp-image-"] {
   height: auto;
 }
 
-/* `wp-caption` is the class Wordpress applies to a figure element.
+/**
+ * `wp-caption` is the class Wordpress applies to a figure element.
  *  1. Reuse `.Figure` component styles.
  *  2. Override the `width` inline style  applied to `wp-caption` by Wordpress
  */
@@ -43,7 +48,7 @@ img[class*="wp-image-"] {
 }
 
 /**
- * Override the inline fixed width and height styles applied by wordpress
+ * Override the fixed width and height attributes applied by wordpress
  */
 
 .wp-caption img {
@@ -52,7 +57,8 @@ img[class*="wp-image-"] {
   height: auto !important;
 }
 
-/* Reuse styles from the `.Figure-caption` pattern.
+/**
+ * Reuse styles from the `.Figure-caption` pattern.
  *  1. By default reduce text size.
  */
 


### PR DESCRIPTION
This PR adds styles for the WP generated classes, and accounts for some width and height inline styles and attributes applied by Wordpress that make for images that don't scale proportionally (or, at all).

For the `.Figure` component, I made it a mixin so that these styles could be applied to the WP `<figure>` class, oddly named `wp-caption` (I believe it's named this because images are only wrapped in a `<figure>` element if they have been provided a caption within the WP media dialogue).

cc @mrgerardorodriguez @tylersticka @erikjung @aileenjeffries 