### PR TITLE
matching Our Work to other core pages

### DIFF
--- a/src/pages/pages/case-study-core.hbs
+++ b/src/pages/pages/case-study-core.hbs
@@ -1,79 +1,54 @@
 ---
 title: Case Study Core
-layout: toolkit.blank
-labels: latest
+layout: toolkit.default
+section:
+  heading: Our Work
+  subheading: We've built responsive web sites, JavaScript applications, hybrid apps, you name it—if it's mobile, we've built it.
+labels: 
+  - latest
 notes: |
   Work overview page.
-stylesheets:
-  - sandbox/sara-wip
 ---
 
-
-{{{embed "patterns.components.sky.base"}}}
-
-<main role="main" id="main">
-  {{#embed "patterns.components.sky.base" class="Sky--clouds"}}
-    {{#content "top"}}
-      {{! Intro }}
-      <div class="u-containProse u-md-spaceSidesNone u-spaceBottom3 u-spaceItems1 u-pad1">
-        <h1 class="u-textGrow5 u-sm-textGrow6">Our work</h1>
-        <p class="TextBlock u-sm-textGrow2">
-          We've built responsive web sites, JavaScript applications, hybrid apps, you name it—if it's mobile, we've built it.
-        </p>
-      </div>
-    {{/content}}
-  {{/embed}}
-
-  <div class="u-bgWhite">
-    <div class="u-containSpread u-pad1">
-
-    {{! The Work }}
-    {{#each drizzle.data.case-studies.contents.teasers}}
-        <div class="Grid Grid--alignMiddle Grid--withGutter u-padEnds6 Work">
-          <div class="Grid-cell u-sm-size3of4 u-md-size1of2 u-flexExpand u-md-spaceSidesNone">
-            {{{
-              embed "patterns.components.work-image.base"
-              class="WorkImage--tilt u-block u-md-size7of8 u-lg-size3of4 u-flexExpand"
-              includeDefs=@first
-              large=imageLarge
-              small=imageSmall
-            }}}
-          </div>
-          <div class="Grid-cell u-sm-size3of4 u-md-size5of12 u-spaceTop1 u-md-spaceTopNone u-flexExpand u-md-spaceNone">
-            <a href="" class="u-linkClean">
-              <h2>{{client}}</h2>
-            </a>
-            <p>
-              {{summary}}
-            </p>
-            <button class="Button Button--primary u-spaceTop2">
-              Read more
-              {{{
-                embed "patterns.components.icon.base"
-                iconid="arrow-right"
-                role="presentation"
-              }}}
-            </button>
-          </div>
-        </div>
-        <hr>
-    {{/each}}
-
-    {{! Logos }}
-    <div class="Grid Grid--alignCenter Grid--alignMiddle u-padEnds3 u-md-padEnds6">
-      {{#each drizzle.data.case-studies.contents.logos}}
-        <div class="Grid-cell u-size1of2 u-sm-size1of3 u-md-size1of4 u-textCenter">
-          <img src="{{this}}" class="u-pad03">
-        </div>
-      {{/each}}
+{{! The Work }}
+{{#each drizzle.data.case-studies.contents.teasers}}
+  <div class="Grid Grid--alignMiddle Grid--withGutter u-padEnds6 Work">
+    <div class="Grid-cell u-sm-size3of4 u-md-size1of2 u-flexExpand u-md-spaceSidesNone">
+    {{{
+      embed "patterns.components.work-image.base"
+      class="WorkImage--tilt u-block u-md-size7of8 u-lg-size3of4 u-flexExpand"
+      includeDefs=@first
+      large=imageLarge
+      small=imageSmall
+    }}}
     </div>
+    <div class="Grid-cell u-sm-size3of4 u-md-size5of12 u-spaceTop1 u-md-spaceTopNone u-flexExpand u-md-spaceNone">
+    <a href="" class="u-linkClean">
+      <h2>{{client}}</h2>
+    </a>
+    <p>
+      {{summary}}
+    </p>
+    <button class="Button Button--primary u-spaceTop2">
+      Read more
+      {{{
+      embed "patterns.components.icon.base"
+      iconid="arrow-right"
+      role="presentation"
+      }}}
+    </button>
+    </div>
+  </div>
+  <hr>
+{{/each}}
 
+{{! Logos }}
+<div class="Grid Grid--alignCenter Grid--alignMiddle u-padEnds3 u-md-padEnds6">
+  {{#each drizzle.data.case-studies.contents.logos}}
+  <div class="Grid-cell u-size1of2 u-sm-size1of3 u-md-size1of4 u-textCenter">
+    <img src="{{this}}" class="u-pad03">
   </div>
-  <div class="u-containSpread">
-    <hr class="u-spaceSides1 u-spaceEndsNone">
-    {{> toolkit.page-segue }}
-  </div>
+  {{/each}}
 </div>
-</main>
 
-{{> toolkit.global-footer }}
+

--- a/src/pages/pages/case-study-core.hbs
+++ b/src/pages/pages/case-study-core.hbs
@@ -12,7 +12,7 @@ notes: |
 
 {{! The Work }}
 {{#each drizzle.data.case-studies.contents.teasers}}
-  <div class="Grid Grid--alignMiddle Grid--withGutter u-padEnds6 Work">
+  <div class="Grid Grid--alignMiddle Grid--withGutter u-padEnds6">
     <div class="Grid-cell u-sm-size3of4 u-md-size1of2 u-flexExpand u-md-spaceSidesNone">
     {{{
       embed "patterns.components.work-image.base"


### PR DESCRIPTION
re: https://trello.com/c/rFdXFU9e/201-chore-make-case-studies-core-header-more-consistent-in-terms-of-spacing-and-font-size-with-other-section-headers#

I was going to just tackle the header but it looks like this pattern was made before we switched a few things around in the templates. I used `talk-core.hbs` as an example. 
Old heading:
![screen shot 2016-06-23 at 3 11 04 pm](https://cloud.githubusercontent.com/assets/1242871/16321975/db0414fa-3954-11e6-96b4-dbea4e3475af.png)

New heading:
![screen shot 2016-06-23 at 3 10 22 pm](https://cloud.githubusercontent.com/assets/1242871/16321983/e6352cb0-3954-11e6-9ecd-d10f8e9a3b16.png)

The subheading is pretty long compared to other pages, but I think it looks fine.
cc @tylersticka @nicolemors 