### PR TITLE
Fix blockquote cite break issue

### DIFF
--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -193,6 +193,10 @@ blockquote cite {
   font-style: normal;
 }
 
+/**
+ * Precede citation with em dash and non-breaking space.
+ */
+
 blockquote cite::before {
-  content: var(--content-dash-em);
+  content: "—\00a0";
 }

--- a/src/pages/sandbox/tyler-what_sets_us_apart-c.hbs
+++ b/src/pages/sandbox/tyler-what_sets_us_apart-c.hbs
@@ -90,12 +90,7 @@ notes: |
             It’s not like you gather client requirements, go away and make something, then come back and ask for feedback. It’s constant iteration, constantly involving the client.
           </p>
           <footer>
-            <cite>
-              Michael Hallihan,
-              <a href="#">
-                Treasure Coast Hospice
-              </a>
-            </cite>
+            <cite>Michael Hallinan, <a href="#">Treasure Coast Hospice</a></cite>
           </footer>
         </blockquote>
       </div>

--- a/src/patterns/typography/blockquote.hbs
+++ b/src/patterns/typography/blockquote.hbs
@@ -16,8 +16,6 @@ sourceless: true
     you adjust the appearance of content based on its placement in the document.
   </p>
   <footer>
-    <cite>
-      <a href="//developer.mozilla.org">The Mozilla Developer Network</a>
-    </cite>
+    <cite><a href="//developer.mozilla.org">The Mozilla Developer Network</a></cite>
   </footer>
 </blockquote>


### PR DESCRIPTION
Line breaks were resulting in citation content breaking to new line without dash. This removes the whitespace and injects some via CSS to overcome the issue.

## Before

<img width="871" alt="screen shot 2016-06-28 at 4 19 35 pm" src="https://cloud.githubusercontent.com/assets/69633/16435604/26aa93e8-3d4c-11e6-9983-421bf8aaef91.png">

## After

<img width="866" alt="screen shot 2016-06-28 at 4 19 41 pm" src="https://cloud.githubusercontent.com/assets/69633/16435605/2a431e6c-3d4c-11e6-87b4-689afe3d76ec.png">

---

@saralohr @mrgerardorodriguez @nicolemors @aileenjeffries 