### PR TITLE
Global nav tweaks

### DIFF
--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -28,8 +28,8 @@
   --Sky-nav-menu-space: var(--space-sm);
 }
 
-@custom-media --Sky-nav-expanded-viewport (--sm-viewport);
-@custom-media --Sky-nav-full-viewport (--lg-viewport);
+@custom-media --Sky-nav-expanded-viewport (width >= 36em);
+@custom-media --Sky-nav-full-viewport (width >= 75em);
 
 /**
  * 1. Keep absolute-positioned elements from leaving this container.

--- a/src/patterns/components/sky/base.hbs
+++ b/src/patterns/components/sky/base.hbs
@@ -26,12 +26,12 @@ notes: |
           <nav class="Sky-nav-menu" role="navigation" id="menu">
             <ul class="Sky-nav-menu-items">
               <li><a class="Sky-nav-menu-item" href="/#main" aria-current>What We Do</a></li>
-              {{!-- <li><a class="Sky-nav-menu-item" href="/#main" aria-current>What Sets Us Apart</a></li> --}}
+              <li><a class="Sky-nav-menu-item" href="/">Our Approach</a></li>
               <li><a class="Sky-nav-menu-item" href="/">Our Work</a></li>
               <li><a class="Sky-nav-menu-item" href="/">Articles</a></li>
               <li><a class="Sky-nav-menu-item" href="/">Speaking</a></li>
               <li><a class="Sky-nav-menu-item" href="/">Labs</a></li>
-              <li><a class="Sky-nav-menu-item" href="/">Our Team</a></li>
+              <li><a class="Sky-nav-menu-item" href="/">Team</a></li>
             </ul>
           </nav>
       </header>

--- a/src/templates/toolkit/global-footer.hbs
+++ b/src/templates/toolkit/global-footer.hbs
@@ -1,9 +1,9 @@
-<footer class="u-containSpread u-pad1 u-spaceBottom" role="contentinfo">
-  <p>
-    <a href="/"><strong>Cloud Four, Inc.</strong></a>
-  </p>
+<footer class="u-containSpread u-padSides1 u-padTop2 u-padBottom3" role="contentinfo">
   <div class="Grid u-posRelative">
     <div class="Grid-cell u-sm-size1of2 u-md-size1of3">
+      <p>
+        <a href="/"><strong>Cloud Four, Inc.</strong></a>
+      </p>
       <p>
         208 SW 1st Ave, Suite 240<br>
         Portland, Oregon 97204 USA
@@ -31,11 +31,12 @@
     <nav class="Grid-cell u-spaceTop1 u-sm-spaceTopNone u-sm-size1of2 u-md-size1of3">
       <ul class="u-listUnstyled u-columns2">
         <li><a href="/">What We Do</a></li>
+        <li><a href="/">Our Approach</a></li>
         <li><a href="/">Our Work</a></li>
         <li><a href="/">Articles</a></li>
         <li><a href="/">Speaking</a></li>
         <li><a href="/">Labs</a></li>
-        <li><a href="/">Our Team</a></li>
+        <li><a href="/">Team</a></li>
         <li><a href="/">Patterns</a></li>
         <li><a href="/">Device Lab</a></li>
       </ul>

--- a/src/templates/toolkit/page-segue.hbs
+++ b/src/templates/toolkit/page-segue.hbs
@@ -1,12 +1,12 @@
 <div class="u-posRelative">
   <p class="u-pad1 u-size2of3">
     <span class="u-inlineBlock u-textGrow1 u-spaceRight u-textNoWrap">
-      Let's discuss your project!
+      Let&rsquo;s discuss your project!
     </span>
     <a class="Button Button--primary u-spaceEnds01 u-textNoWrap" href="mailto:info@cloudfour.com">
       {{{
         embed "patterns.components.icon.base"
-        class="Icon--large"
+        class="Icon--large u-spaceRight06"
         iconid="envelope"
         role="presentation"
       }}}


### PR DESCRIPTION
I was _one_ page too optimistic when I designed nav stuff last year. So close! 😆 

This makes some nav-related tweaks...

1. Adds the latest nav item to the header and footer. (I do not know if these labels are final.)
2. Adjusts the `--Sky-nav-*-viewport` media queries to account for this change.
3. Adjusts the global footer since we've toppled the symmetry of the footer nav.
4. Makes two small tweaks tot he page segue that were bugging me.

---

@saralohr @mrgerardorodriguez @nicolemors @aileenjeffries 