### PR TITLE
Add SCSS syntax highlighting

### DIFF
--- a/src/assets/toolkit/scripts/toolkit.js
+++ b/src/assets/toolkit/scripts/toolkit.js
@@ -15,6 +15,7 @@ import {FactSlider} from './lib/component/fact-slider';
  */
 import 'prismjs';
 import 'prismjs/components/prism-handlebars';
+import 'prismjs/components/prism-scss';
 
 (function() {
 

--- a/src/pages/pages/blog-single-article.hbs
+++ b/src/pages/pages/blog-single-article.hbs
@@ -74,6 +74,14 @@ notes: |
   }
 }</code></pre>
 
+  <pre><code class="language-scss">$font-stack: sans-serif;
+$primary-color: #333;
+
+@mixin reset-type() {
+  font: 100% $font-stack;
+  color: $primary-color;
+}</code></pre>
+
   <pre><code class="language-handlebars">&lt;ul class=&quot;Example&quot;&gt;
   \{{#each items 'another' hashValue=false}}
     &lt;li&gt;Whoa!!&lt;/li&gt;


### PR DESCRIPTION
This PR includes Prism's SCSS component for syntax highlighting.

![screen shot 2016-06-29 at 7 32 07 pm](https://cloud.githubusercontent.com/assets/69633/16475053/37acc6a4-3e30-11e6-9ce9-510a7fadcfeb.png)

---

@saralohr @mrgerardorodriguez @grigs 