### PR TITLE
Add u-listColumns utility + example

### DIFF
--- a/src/assets/toolkit/styles/utils/list.css
+++ b/src/assets/toolkit/styles/utils/list.css
@@ -32,3 +32,16 @@
   margin-left: calc(var(--space-md) / 2);
   margin-right: calc(var(--space-md) / 2);
 }
+
+/**
+ * Columns and lists sometimes don't play well together if markers are visible.
+ * This fixes that.
+ */
+
+ .u-listColumns {
+   padding-left: 0;
+ }
+
+ .u-listColumns > li {
+   margin-left: var(--list-marker-padding);
+ }

--- a/src/pages/pages/blog-single-article.hbs
+++ b/src/pages/pages/blog-single-article.hbs
@@ -201,6 +201,27 @@ class Bread {
     </ol>
   </section>
 
+  <section class="u-borderTopMd u-padTop1 u-spaceItems1">
+    <header>
+      <h4>Responsive Images 101 Series</h4>
+    </header>
+    <ol class="u-listColumns u-sm-columns2">
+      <li><a href="#">Definitions</a></li>
+      <li><a href="#">Img Required</a></li>
+      <li><a href="#">Srcset Display Density</a></li>
+      <li><a href="#">Srcset Width Descriptors</a></li>
+      <li><a href="#">Sizes</a></li>
+      <li><a href="#">Picture Element</a></li>
+      <li><a href="#">Type</a></li>
+      <li><a href="#">CSS Responsive Images</a></li>
+      <li><a href="#">Image breakpoints</a></li>
+      <li>
+        <span class="u-hiddenVisually">Currently Viewing:</span>
+        <b>Conclusion</b>
+      </li>
+    </ol>
+  </section>
+
   <footer class="u-spaceItems4 u-spaceTop4">
     {{{
       embed "patterns.combos.blog.post-byline"


### PR DESCRIPTION
Allows lists with markers still visible to use CSS columns without breaking visually.

## Without New Class

![screen shot 2016-06-30 at 10 00 02 am](https://cloud.githubusercontent.com/assets/69633/16496968/7f3a0bb6-3ea9-11e6-81c4-fef796f110e8.png)

## With New Class

![screen shot 2016-06-30 at 9 59 54 am](https://cloud.githubusercontent.com/assets/69633/16496973/82eef14a-3ea9-11e6-9a2e-1232f485ac16.png)

---

@saralohr @mrgerardorodriguez 