### PR TITLE
Remove default hyphenation

### DIFF
--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -13,15 +13,13 @@
  *
  * 1. Base font style for everything
  * 2. Allow long words (links) to brake at arbitrary points
- * 3. Auto-hyphens by default (assuming removal for specific elements)
- * 4. Prevent automatic size adjustments on orientation change
+ * 3. Prevent automatic size adjustments on orientation change
  */
 
 body {
   font: var(--base-font); /* 1 */
   word-wrap: break-word; /* 2 */
-  hyphens: auto; /* 3 */
-  text-size-adjust: none; /* 4 */
+  text-size-adjust: none; /* 3 */
 }
 
 /**


### PR DESCRIPTION
Without smarter hyphenation in browsers and more predictable justified text, this just isn't as readable. I like that it maintains more consistently boxy shapes of text, but that's not worth the readability tradeoffs. It is text, after all!

This only affects Firefox and Safari. Screenshots below are from Firefox, which has the unique distinction of _not_ breaking "date-sensitive" at the hyphen for some reason. _Oh, Firefox, you card..._

## Before

![screen shot 2016-06-30 at 5 55 41 pm](https://cloud.githubusercontent.com/assets/69633/16508868/28ac38da-3eec-11e6-955e-6947b25c3d4c.png)

## After

![screen shot 2016-06-30 at 5 56 02 pm](https://cloud.githubusercontent.com/assets/69633/16508871/2c29bd8e-3eec-11e6-912c-b24b0ba2a1b6.png)

---

@saralohr @mrgerardorodriguez @aileenjeffries @megnotarte 

Fixes #269