### PR TITLE
Don't wrap code blocks

### DIFF
--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -66,11 +66,6 @@ pre {
   color: var(--color-fuchsia);
 }
 
-/**
- * TODO: Revise once we know how this will or won't interact with
- * our syntax highlighting solution.
- */
-
 pre {
   background: var(--color-navy);
   color: var(--color-white);

--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -124,10 +124,6 @@ code {
   word-wrap: normal;
 }
 
-pre > code {
-  white-space: pre-wrap;
-}
-
 /**
  * Lists
  */


### PR DESCRIPTION
In practice, this didn't work so great with our content.

Now, code blocks with very long lines will scroll horizontally.

---

@saralohr @mrgerardorodriguez 

Fixes #272