### PR TITLE
Support optimization of CSS and JS

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var env = require('gulp-util').env;
+
 module.exports = {
   copy: {
     src: './src/static/**/*',
@@ -9,7 +11,8 @@ module.exports = {
   'css:toolkit': {
     src: './src/assets/toolkit/{styles,styles/sandbox}/*.css',
     dest: './dist/assets/toolkit/styles',
-    name: 'css:toolkit'
+    name: 'css:toolkit',
+    optimize: !env.dev
   },
 
   'css:drizzle': {
@@ -20,6 +23,7 @@ module.exports = {
   },
 
   js: {
+    optimize: !env.dev,
     plugins: {
       webpack: {
         entry: {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,6 @@
   "scripts": {
     "prestart": "npm install",
     "start": "gulp --dev",
-    "build": "npm prestart && gulp"
+    "build": "npm run prestart && gulp"
   }
 }


### PR DESCRIPTION
Running `npm start` will run our Gulp tasks in development mode, without compression (as always).

WIth these changes (which ape how we did things on our last WP project), we now use that boolean to determine whether or not to optimize assets.

Running `npm run build` (or any of the `gulp` tasks without the `--dev` flag) will minify the assets.

I also corrected the `build` script definition as it had an error (was missing the `run` argument).

---

@mrgerardorodriguez @saralohr 