### PR TITLE
Add workaround for `FlexEmbed-content` when using `wp_oembed_get()`

### DIFF
--- a/src/assets/toolkit/styles/components/flex-embed.css
+++ b/src/assets/toolkit/styles/components/flex-embed.css
@@ -9,6 +9,7 @@
  *
  * @see https://codex.wordpress.org/Function_Reference/wp_oembed_get
  * @see https://github.com/suitcss/components-flex-embed/blob/master/lib/flex-embed.css#L66-L73
+ * @see https://github.com/cloudfour/cloudfour.com-wp/pull/91#discussion-diff-69822034
  */
 .FlexEmbed > iframe {
   bottom: 0;

--- a/src/assets/toolkit/styles/components/flex-embed.css
+++ b/src/assets/toolkit/styles/components/flex-embed.css
@@ -1,1 +1,20 @@
 @import "suitcss-components-flex-embed";
+
+/**
+ * The wp_oembed_get() does not allow us to add the `FlexEmbed-content` class
+ * to the embedded iframe. This is a workaround (hack) to get the flex embed
+ * to work in this situation. This means the `FlexEmbed-content` CSS rules
+ * are duplicated, unfortunately, but I failed to find a different solution.
+ *
+ *
+ * @see https://codex.wordpress.org/Function_Reference/wp_oembed_get
+ * @see https://github.com/suitcss/components-flex-embed/blob/master/lib/flex-embed.css#L66-L73
+ */
+.FlexEmbed > iframe {
+  bottom: 0;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}


### PR DESCRIPTION
## Overview

There exists content on the WP site that takes advantage of the [oEmbed](http://oembed.com/) format. WordPress offers a handy [`wp_oembed_get()`](https://codex.wordpress.org/Function_Reference/wp_oembed_get) function that allows us to pass a URL to the content returning the proper embed code from the specific provider.

## The Challenge

The challenge lies in making sure the oEmbed content that is embedded uses the `FlexEmbed` classes properly. The [SUIT CSS `FlexEmbed`](https://github.com/suitcss/components-flex-embed) component expects a `FlexEmbed-content` CSS class to be added onto the `<iframe>` of the embedded content to work properly. This cannot be done using the `wp_oembed_get()` function. We are only allowed to set the `height` and/or `width` attributes for the embedded `<iframe>`.

## The Proposed Solution

The proposed solution is this PR. I will be the first to admit that his is a hack and is not DRY. If this solution feels _too_ hacky, I am open to ideas/suggestions/conversations on how to overcome his challenge in a much more elegant fashion. 😉 

Some thoughts...
- Should this be part of the patterns repo? Feels forced/unnecessary.
- Should the `>` combinator be used?

---

cc: @saralohr @tylersticka 