### PR TITLE
Add width/height to base iframe

### DIFF
--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -78,3 +78,8 @@ pre {
 img {
   max-width: 100%;
 }
+
+iframe {
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
Re: https://github.com/cloudfour/cloudfour.com-patterns/pull/281

This adds a base `width` and `height` to the `<iframe>` element. This allows the `FlexEmbed` component to be happy.

---

cc: @erikjung @tylersticka @saralohr 