### PR TITLE
Styles for Device Lab Form

### DIFF
--- a/src/assets/toolkit/styles/components/cms-content.css
+++ b/src/assets/toolkit/styles/components/cms-content.css
@@ -9,3 +9,138 @@
   margin-right: calc(-1 * var(--cms-content-space));
   margin-left: calc(-1 * var(--cms-content-space));
 }
+
+/**
+ * Jetpack Device Lab Form Styles
+ */
+
+:root {
+  --JetpackInput-background-color: var(--color-white);
+  --JetpackInput-border-color: var(--color-gray);
+  --JetpackInput-border-color-focus: var(--color-blue);
+  --JetpackInput-border-radius: var(--control-radius);
+  --JetpackInput-border-width: var(--control-stroke);
+  --JetpackInput-color: var(--base-color);
+  --JetpackInput-disabled-opacity: var(--control-disabled-opacity);
+  --JetpackInput-padding: 0.5em 0.75em;
+  --JetpackInput-transition-duration: var(--motion-duration-lg);
+  --JetpackInput-transition-timing-function: var(--motion-timing-function-default);
+}
+
+/**
+ * 1. Most occurrences of this benefit from occupying the full width.
+ * 2. We aren't using a slightly more polished technique like text-indent due to
+ *    cross-browser edge cases where the rule would be ignored or would conflict
+ *    with platform-specific input type controls (search decorations, etc.).
+ * 3. Same `line-height` as `.Button` for easy alignment.
+ * 4. Unfortunately, Webkit won't play nice with our styles on some input types
+ *    unless we override its appearance.
+ * 5. Overrides specific `max-width` set in the JetPack style sheet.
+ */
+.CmsContent .comment-form input {
+  display: block; /* 1 */
+  box-sizing: border-box;
+  width: 100%; /* 1 */
+  max-width: 100%; /* 5 */
+  padding: var(--JetpackInput-padding);
+  font: inherit; /* 2 */
+  line-height: normal; /* 3 */
+  color: var(--JetpackInput-color);
+  border: var(--JetpackInput-border-width) solid var(--Input-border-color);
+  border-radius: var(--JetpackInput-border-radius);
+  background: var(--JetpackInput-background-color);
+  transition: all var(--JetpackInput-transition-duration) var(--Input-transition-timing-function);
+  -webkit-appearance: none; /* 4 */
+}
+
+.CmsContent .comment-form input:matches(:active, :hover) {
+  border-color: color(var(--JetpackInput-border-color) l(-15%));
+}
+
+.CmsContent .comment-form input:focus {
+  border-color: var(--JetpackInput-border-color-focus);
+  outline: none;
+}
+
+/**
+ * Jetpack Form Labels
+ */
+
+:root {
+  --JetpackLabel-color: var(--color-blue);
+  --JetpackLabel-font-weight: var(--font-weight-semibold);
+}
+
+.CmsContent .comment-form label {
+  color: var(--JetpackLabel-color);
+  font-weight: var(--JetpackLabel-font-weight);
+}
+
+/**
+ * Jetpack Form Button
+ */
+
+:root {
+  --JetpackButton-background-color: var(--color-blue);
+  --JetpackButton-color: var(--color-white);
+  --JetpackButton-border-radius: var(--control-radius);
+  --JetpackButton-border-width: var(--control-stroke);
+  --JetpackButton-font-weight: var(--font-weight-semibold);
+  --JetpackButton-padding: 0.5em 1em;
+  --JetpackButton-transition-duration: var(--motion-duration-lg);
+  --JetpackButton-transition-property: background-color, border-color, color;
+  --JetpackButton-transition-timing-function: var(--motion-timing-function-default);
+}
+
+/**
+ * 1. Normalize `box-sizing` across all elements that this component could be
+ *    applied to.
+ * 2. Inherit font styles from ancestor.
+ * 3. Set font weight to semibold.
+ * 4. Normalize `line-height`. For `input`, it can't be changed from `normal` in
+ *    Firefox 4+.
+ * 5. Make sure `input` will wrap text across multiple lines.
+ * 6. Prevent button text from being selectable.
+ * 7. Corrects inability to style clickable `input` types in iOS.
+ * Why so `!important`? The JetPack button is an `input`. Using `!important to override.
+ */
+.CmsContent .pushbutton-wide {
+  display: inline-block !important;
+  box-sizing: border-box !important; /* 1 */
+  padding: var(--JetpackButton-padding) !important;
+  font: inherit !important; /* 2 */
+  font-weight: var(--JetpackButton-font-weight) !important; /* 3 */
+  line-height: normal !important; /* 4 */
+  color: var(--JetpackButton-color) !important;
+  white-space: normal; /* 5 */
+  text-align: center;
+  text-decoration: none;
+  border-width: var(--JetpackButton-border-width)  !important;
+  border-style: solid  !important;
+  border-color: color(var(--JetpackButton-background-color) shade(10%))  !important;
+  border-radius: var(--JetpackButton-border-radius)  !important;
+  background-color: var(--JetpackButton-background-color)  !important;
+  background: transparent;
+  transition-duration: var(--JetpackButton-transition-duration);
+  transition-property: var(--JetpackButton-transition-property);
+  transition-timing-function: var(--JetpackButton-transition-timing-function);
+  cursor: pointer;
+  user-select: none; /* 6 */
+
+  -webkit-appearance: none; /* 7 */
+}
+
+.CmsContent .pushbutton-wide::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+.CmsContent .pushbutton-wide:focus {
+  outline: 1px dotted;
+  outline: 5px auto -webkit-focus-ring-color;
+}
+
+.CmsContent .pushbutton-wide:matches(:--enter) {
+  border-color: color(var(--JetpackButton-background-color) shade(5%)) !important;
+  background-color: color(var(--JetpackButton-background-color) l(+5%)) !important;
+}

--- a/src/assets/toolkit/styles/components/cms-content.css
+++ b/src/assets/toolkit/styles/components/cms-content.css
@@ -12,6 +12,7 @@
 
 /**
  * Jetpack Device Lab Form Styles
+ * TODO: Use mixins to keep this stuff DRY in the future.
  */
 
 :root {
@@ -67,12 +68,10 @@
  */
 
 :root {
-  --JetpackLabel-color: var(--color-blue);
   --JetpackLabel-font-weight: var(--font-weight-semibold);
 }
 
 .CmsContent .comment-form label {
-  color: var(--JetpackLabel-color);
   font-weight: var(--JetpackLabel-font-weight);
 }
 


### PR DESCRIPTION
RE: https://trello.com/c/WMM4cQ0r/264-style-device-lab-form

Added in styes for the JetPack Device Lab Form in the `.CmsContent` component.
`.comment-form` and `.pushbutton-wide` are both JetPack classes.

It should look like this:
<img width="649" alt="screen shot 2016-07-08 at 4 12 16 pm" src="https://cloud.githubusercontent.com/assets/1895290/16704343/b263bab4-452a-11e6-9da1-6158101e9c59.png">

@tylersticka 