### PR TITLE
rounding month heading corners to fix #298

### DIFF
--- a/src/assets/toolkit/styles/components/calendar-date.css
+++ b/src/assets/toolkit/styles/components/calendar-date.css
@@ -29,6 +29,7 @@
   min-height: var(--CalendarDate-min-height);
   min-width: var(--CalendarDate-min-width);
   text-align: center;
+  overflow: hidden; /* round top corners of inner header */
 }
 
 .CalendarDate-header {

--- a/src/assets/toolkit/styles/components/calendar-date.css
+++ b/src/assets/toolkit/styles/components/calendar-date.css
@@ -18,6 +18,9 @@
   --CalendarDate-body-range-font-size: var(--font-size-md);
 }
 
+/**
+ * 1. rounds top corners of inner header
+ */
 .CalendarDate {
   background: var(--CalendarDate-background);
   border: var(--CalendarDate-border-width) solid currentColor;
@@ -29,7 +32,7 @@
   min-height: var(--CalendarDate-min-height);
   min-width: var(--CalendarDate-min-width);
   text-align: center;
-  overflow: hidden; /* round top corners of inner header */
+  overflow: hidden; /* 1 */
 }
 
 .CalendarDate-header {


### PR DESCRIPTION
re: https://github.com/cloudfour/cloudfour.com-patterns/issues/298

Hopefully, I'm not under thinking this - adding `overflow:hidden` to the containing element rounds the top corners of the pink heading in our calendar dates. 

<img width="256" alt="screen shot 2016-07-11 at 12 21 02 pm" src="https://cloud.githubusercontent.com/assets/1242871/16743636/2fc9f5b6-4762-11e6-82b8-959ad5cce009.png">


cc @tylersticka @nicolemors @saralohr @mrgerardorodriguez 