### PR TITLE
Make table scroll horizontally when it overflows

### DIFF
--- a/src/assets/toolkit/styles/components/table.css
+++ b/src/assets/toolkit/styles/components/table.css
@@ -10,6 +10,8 @@
 
 .Table {
   width: 100%;
+  display: block;
+  overflow-x: auto;
 }
 
 .Table :matches(th, td) {


### PR DESCRIPTION
![table-overflow](https://cloud.githubusercontent.com/assets/9888467/16748822/4420843a-477b-11e6-9f43-3a2ee44abd23.gif)

cc @tylersticka @mrgerardorodriguez @aileenjeffries 

Fixes Issue #301 
