### PR TITLE
adjusting speakerdeck icon viewbox

### DIFF
--- a/src/static/images/icons/speakerdeck.svg
+++ b/src/static/images/icons/speakerdeck.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -4 24 24">
   <path d="M22,5H2A2,2,0,0,0,0,7V17a2,2,0,0,0,2,2H22a2,2,0,0,0,2-2V7A2,2,0,0,0,22,5ZM10.13,15.46L2.87,12l7.26-3.46v6.92Zm3.49,0V8.54L20.88,12Z" transform="translate(0 -5)"/>
 </svg>


### PR DESCRIPTION
Even though I have a 24x24 viewbox on the speakerdeck icon, it wasn't vertically aligning nicely with text. By tweaking the viewbox, it now lines up more nicely. 
<img width="344" alt="screen shot 2016-07-11 at 4 07 36 pm" src="https://cloud.githubusercontent.com/assets/1242871/16749855/4cacae60-4782-11e6-951e-0ec58a3258ff.png">

cc @tylersticka specifically because you'll be able to tell me if this is the wrong way to fix this. 