### PR TITLE
Minimizing wrapping in the navigation

### DIFF
--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -40,6 +40,8 @@
 @custom-media --Sky-nav-expanded-viewport (width >= 36em);
 @custom-media --Sky-nav-full-viewport (width >= 56em);
 @custom-media --Sky-scene-full-viewport (--md-viewport);
+@custom-media --Sky-nav-logo-sm-min (width >= 64em);
+@custom-media --Sky-nav-logo-sm-max (width < 68em);
 
 /**
  * 1. Keep absolute-positioned elements from leaving this container.
@@ -110,13 +112,14 @@
  * 1. Align items vertically.
  * 2. We let items wrap initially because we want the menu to be above the
  *    other elements on narrow screens.
+ * 3. So the navigation can align right when desirable.
  */
 
 .Sky-nav {
   display: flex;
   align-items: center; /* 1 */
-  flex-wrap: wrap;
-  justify-content: space-between;
+  flex-wrap: wrap; /* 2 */
+  justify-content: space-between; /* 3 */
 }
 
 /**
@@ -215,19 +218,19 @@
   fill: var(--color-relative); /* 4 */
 }
 
-@media (width >= 64em) {
+@media (--Sky-nav-logo-sm-min) and (--Sky-nav-logo-sm-max) {
+/**
+ * In this viewport range, reducing the size of the logo slightly prevents orphaned
+ * nav items.
+ */
+
   .Sky-nav-logo-object {
     width: var(--Sky-nav-logo-size-sm);
     width: var(--Sky-nav-logo-size-sm);
   }
 }
 
-@media (width >= 68em) {
-  .Sky-nav-logo-object {
-    width: var(--Sky-nav-logo-size);
-    width: var(--Sky-nav-logo-size);
-  }
-}
+
 
 
 /**
@@ -262,7 +265,7 @@
  * 2. Remove the bump (since it won't be above anything at this point).
  * 3. Reset the background.
  * 4. To align right, this now needs to be last.
- * 5. Groups the last three links on a second line to avoid orphans.
+ * 5. Constraining the width keeps the last three links on a second line to avoid orphans.
  */
 
 @media (--Sky-nav-expanded-viewport) {
@@ -276,6 +279,10 @@
 }
 
 @media (--Sky-nav-full-viewport) {
+/**
+ * No need for a max width now that there's enough room for all nav items to fit on a line.
+ */ 
+
   .Sky-nav-menu {
     max-width: 100%;
   }
@@ -302,16 +309,19 @@
   .Sky-nav-menu-items {
     display: flex; /* 1 */
     margin: var(--Sky-nav-menu-space); /* 2 */
-    margin-left: 0;
+    margin-left: 0; /* 3 */
     flex-wrap: wrap; /* 4 */
     justify-content: flex-end; /* 5 */
   }
 }
 
 @media (--xl-viewport) {
+  /**
+   * Adds balance between the logo and nav when there's enough room.
+   */
+
   .Sky-nav-menu-items {
     margin: var(--Sky-nav-menu-space);
-    max-width: 100%;
   }
 }
 

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -43,8 +43,8 @@
 @custom-media --Sky-nav-expanded-viewport (width >= 36em);
 @custom-media --Sky-nav-full-viewport (width >= 48em);
 @custom-media --Sky-scene-full-viewport (--md-viewport);
-@custom-media --Sky-nav-font-sm (width >= 64em);
-@custom-media --Sky-nav-font-md (width < 80em);
+@custom-media --Sky-nav-font-size-sm-min (width >= 64em);
+@custom-media --Sky-nav-font-size-sm-max (width < 80em);
 
 /**
  * 1. Keep absolute-positioned elements from leaving this container.
@@ -353,7 +353,7 @@
   }
 }
 
-@media (--Sky-nav-font-sm)  and (--Sky-nav-font-md) {
+@media (--Sky-nav-font-size-sm-min)  and (--Sky-nav-font-size-sm-max) {
   /**
    * In this viewport range, the body font size increases enough to wrap the last
    * couple of nav items. This prevents the wrapping.

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -25,7 +25,8 @@
   --Sky-nav-menu-item-line-height: var(--line-height-xs);
   --Sky-nav-menu-item-transition-duration: var(--motion-duration-md);
   --Sky-nav-menu-item-transition-timing-function: var(--motion-timing-function-default);
-  --Sky-nav-menu-space: var(--space-xs);
+  --Sky-nav-menu-space: var(--space-sm) var(--space-xs);
+  --Sky-nav-menu-max: 30em;
 
   --Sky-scene-object-x-offset: calc(2 / 3 * 100%);
   --Sky-scene-object-x-offset-full: 75%;
@@ -204,7 +205,6 @@
   }
 }
 
-
 /**
  * 1. Most embeds are `inline-block` by default, which results in an unsightly
  *    bottom space. Yuck.
@@ -278,7 +278,7 @@
     padding-bottom: 0; /* 2 */
     background: transparent; /* 3 */
     order: 2; /* 4 */
-    max-width: 30em; /* 5 */
+    max-width: var(--Sky-nav-menu-max); /* 5 */
   }
 }
 
@@ -288,7 +288,7 @@
  */ 
 
   .Sky-nav-menu {
-    max-width: 100%;
+    max-width: initial;
   }
 }
 

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -13,8 +13,8 @@
   --Sky-nav-controls-space-x: var(--space-md);
   --Sky-nav-controls-space-y: var(--space-xs);
   --Sky-nav-logo-color: var(--Sky-color);
-  --Sky-nav-logo-height: 5em;
-  --Sky-nav-logo-width: var(--Sky-nav-logo-height);
+  --Sky-nav-logo-size: 5em;
+  --Sky-nav-logo-size-sm: 4em;
   --Sky-nav-logo-padding: var(--Sky-nav-controls-space-y) var(--Sky-nav-controls-space-x);
   --Sky-nav-color-inactive: color(var(--Sky-background-color) s(+10%) l(90%));
 
@@ -22,12 +22,10 @@
   --Sky-nav-menu-item-border-color: color(var(--color-black) a(10%));
   --Sky-nav-menu-item-border-width: var(--control-stroke);
   --Sky-nav-menu-item-font-size: var(--font-size-md);
-  --Sky-nav-menu-item-font-size-sm: var(--font-size-sm);
   --Sky-nav-menu-item-line-height: var(--line-height-xs);
   --Sky-nav-menu-item-transition-duration: var(--motion-duration-md);
   --Sky-nav-menu-item-transition-timing-function: var(--motion-timing-function-default);
-  --Sky-nav-menu-space: var(--space-sm);
-  --Sky-nav-menu-space-tighter: var(--space-sm) calc(var(--space-sm) * 0.5);
+  --Sky-nav-menu-space: var(--space-xs);
 
   --Sky-scene-object-x-offset: calc(2 / 3 * 100%);
   --Sky-scene-object-x-offset-full: 75%;
@@ -40,8 +38,7 @@
 }
 
 @custom-media --Sky-nav-expanded-viewport (width >= 36em);
-@custom-media --Sky-nav-full-viewport (width >= 48em);
-@custom-media --Sky-nav-font-size-sm-max (width < 70em);
+@custom-media --Sky-nav-full-viewport (width >= 56em);
 @custom-media --Sky-scene-full-viewport (--md-viewport);
 
 /**
@@ -119,6 +116,7 @@
   display: flex;
   align-items: center; /* 1 */
   flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 /**
@@ -193,6 +191,13 @@
   padding: var(--Sky-nav-logo-padding);
 }
 
+@media (--lg-viewport) {
+  .Sky-nav-logo {
+    padding-left: var(--space-xs);
+  }
+}
+
+
 /**
  * 1. Most embeds are `inline-block` by default, which results in an unsightly
  *    bottom space. Yuck.
@@ -205,10 +210,25 @@
 
 .Sky-nav-logo-object {
   display: block; /* 1 */
-  width: var(--Sky-nav-logo-width); /* 2 */
-  height: var(--Sky-nav-logo-width); /* 3 */
+  width: var(--Sky-nav-logo-size); /* 2 */
+  height: var(--Sky-nav-logo-size); /* 3 */
   fill: var(--color-relative); /* 4 */
 }
+
+@media (width >= 64em) {
+  .Sky-nav-logo-object {
+    width: var(--Sky-nav-logo-size-sm);
+    width: var(--Sky-nav-logo-size-sm);
+  }
+}
+
+@media (width >= 68em) {
+  .Sky-nav-logo-object {
+    width: var(--Sky-nav-logo-size);
+    width: var(--Sky-nav-logo-size);
+  }
+}
+
 
 /**
  * 1. Hidden by default.
@@ -241,7 +261,8 @@
  * 1. At large enough screens, make the menu _always_ visible.
  * 2. Remove the bump (since it won't be above anything at this point).
  * 3. Reset the background.
- * 4. Reset the order.
+ * 4. To align right, this now needs to be last.
+ * 5. Groups the last three links on a second line to avoid orphans.
  */
 
 @media (--Sky-nav-expanded-viewport) {
@@ -249,7 +270,14 @@
     display: block; /* 1 */
     padding-bottom: 0; /* 2 */
     background: transparent; /* 3 */
-    order: 0; /* 4 */
+    order: 2; /* 4 */
+    max-width: 30em; /* 5 */
+  }
+}
+
+@media (--Sky-nav-full-viewport) {
+  .Sky-nav-menu {
+    max-width: 100%;
   }
 }
 
@@ -274,9 +302,16 @@
   .Sky-nav-menu-items {
     display: flex; /* 1 */
     margin: var(--Sky-nav-menu-space); /* 2 */
-    margin-left: 0; /* 3 */
+    margin-left: 0;
     flex-wrap: wrap; /* 4 */
     justify-content: flex-end; /* 5 */
+  }
+}
+
+@media (--xl-viewport) {
+  .Sky-nav-menu-items {
+    margin: var(--Sky-nav-menu-space);
+    max-width: 100%;
   }
 }
 
@@ -341,39 +376,6 @@
   }
 }
 
-@media (--Sky-nav-full-viewport) {
-  /**
-   * Tightening the left and right padding on nav item links allows for the nav items to
-   * fit on one line and avoids orphans. Since the containing list items also spread out at this 
-   * breakpoint, the space between nav item links is maximized.
-   */
-
-  .Sky-nav-menu-item {
-    padding: var(--Sky-nav-menu-space-tighter);
-  }
-}
-
-@media (--Sky-nav-full-viewport) and (--Sky-nav-font-size-sm-max) {
-  /**
-   * In this viewport range, the body font size increases enough to wrap the last
-   * couple of nav items. This prevents the wrapping.
-   */
-
-  .Sky-nav-menu-item {
-    font-size: var(--Sky-nav-menu-item-font-size-sm);
-  }
-}
-
-@media (--lg-viewport) {
-  /**
-   * On larger screens, the nav links are spaced out from each other and this provides
-   * visual balance by adding space between the nav and logo.
-   */
-
-  .Sky-nav-menu-items {
-    margin-left: var(--Sky-nav-menu-space);
-  }
-}
 
 /**
  * Sky scene

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -22,10 +22,13 @@
   --Sky-nav-menu-item-border-color: color(var(--color-black) a(10%));
   --Sky-nav-menu-item-border-width: var(--control-stroke);
   --Sky-nav-menu-item-font-size: var(--font-size-md);
+  --Sky-nav-menu-item-font-size-sm: var(--font-size-sm);
   --Sky-nav-menu-item-line-height: var(--line-height-xs);
   --Sky-nav-menu-item-transition-duration: var(--motion-duration-md);
   --Sky-nav-menu-item-transition-timing-function: var(--motion-timing-function-default);
-  --Sky-nav-menu-space: var(--space-sm);
+  --Sky-nav-menu-item-space: var(--space-sm);
+  --Sky-nav-menu-item-space-tighter: var(--space-sm) calc(var(--space-sm) * 0.5);
+  --Sky-nav-menu-space: var(--space-sm) var(--space-sm) var(--space-sm) 0;
 
   --Sky-scene-object-x-offset: calc(2 / 3 * 100%);
   --Sky-scene-object-x-offset-full: 75%;
@@ -38,7 +41,7 @@
 }
 
 @custom-media --Sky-nav-expanded-viewport (width >= 36em);
-@custom-media --Sky-nav-full-viewport (width >= 75em);
+@custom-media --Sky-nav-full-viewport (width >= 48em);
 @custom-media --Sky-scene-full-viewport (--md-viewport);
 
 /**
@@ -304,7 +307,7 @@
 
 .Sky-nav-menu-item {
   display: block; /* 1 */
-  padding: var(--Sky-nav-menu-space); /* 2 */
+  padding: var(--Sky-nav-menu-item-space); /* 2 */
   font-size: var(--Sky-nav-menu-item-font-size);
   line-height: var(--Sky-nav-menu-item-line-height);
   white-space: nowrap; /* 3 */
@@ -315,6 +318,7 @@
 }
 
 @media (--Sky-nav-expanded-viewport) {
+
   /**
    * When the nav is horizontal, ditch those dividers.
    */
@@ -333,6 +337,36 @@
 
   .Sky-nav-menu-items:hover .Sky-nav-menu-item:not(:hover) {
     color: var(--Sky-nav-color-inactive);
+  }
+}
+
+@media (--Sky-nav-full-viewport) {
+  /**
+   * Tightening the left and right padding on nav item links allows for the nav items fit on 
+   * one line and avoids orphans. Since the containing list items also spread out at this 
+   * breakpoint, the space between nav item links is maximized.
+   */
+  .Sky-nav-menu-item {
+    padding: var(--Sky-nav-menu-item-space-tighter);
+  }
+}
+
+@media (--lg-viewport) {
+  /**
+   * In this viewport range, the body font size increases enough to wrap the last
+   * couple of nav items. This prevents the wrapping.
+   */
+  .Sky-nav-menu-item {
+    font-size: var(--Sky-nav-menu-item-font-size-sm);
+  }
+}
+
+@media (--xl-viewport) {
+  /**
+   * Back to default font size behavior now that there's enough room.
+   */
+  .Sky-nav-menu-item {
+    font-size: var(--Sky-nav-menu-item-font-size);
   }
 }
 

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -28,7 +28,7 @@
   --Sky-nav-menu-item-transition-timing-function: var(--motion-timing-function-default);
   --Sky-nav-menu-item-space: var(--space-sm);
   --Sky-nav-menu-item-space-tighter: var(--space-sm) calc(var(--space-sm) * 0.5);
-  --Sky-nav-menu-space: var(--space-sm) var(--space-sm) var(--space-sm) 0;
+  --Sky-nav-menu-space: var(--space-sm);
 
   --Sky-scene-object-x-offset: calc(2 / 3 * 100%);
   --Sky-scene-object-x-offset-full: 75%;
@@ -42,9 +42,8 @@
 
 @custom-media --Sky-nav-expanded-viewport (width >= 36em);
 @custom-media --Sky-nav-full-viewport (width >= 48em);
-@custom-media --Sky-scene-full-viewport (--md-viewport);
-@custom-media --Sky-nav-font-size-sm-min (width >= 64em);
 @custom-media --Sky-nav-font-size-sm-max (width < 80em);
+@custom-media --Sky-scene-full-viewport (--md-viewport);
 
 /**
  * 1. Keep absolute-positioned elements from leaving this container.
@@ -267,16 +266,18 @@
 /**
  * 1. At large sizes, display elements in a row.
  * 2. Add some extra whitespace all around.
- * 3. Let items wrap if they overflow.
- * 4. Align items to the right end of the container.
+ * 3. Saves some room on narrow screens to reduce wrapping.
+ * 4. Let items wrap if they overflow.
+ * 5. Align items to the right end of the container.
  */
 
 @media (--Sky-nav-expanded-viewport) {
   .Sky-nav-menu-items {
     display: flex; /* 1 */
     margin: var(--Sky-nav-menu-space); /* 2 */
-    flex-wrap: wrap; /* 3 */
-    justify-content: flex-end; /* 4 */
+    margin-left: 0; /* 4 */
+    flex-wrap: wrap; /* 4 */
+    justify-content: flex-end; /* 5 */
   }
 }
 
@@ -353,7 +354,7 @@
   }
 }
 
-@media (--Sky-nav-font-size-sm-min)  and (--Sky-nav-font-size-sm-max) {
+@media (--Sky-nav-full-viewport) and (--Sky-nav-font-size-sm-max) {
   /**
    * In this viewport range, the body font size increases enough to wrap the last
    * couple of nav items. This prevents the wrapping.
@@ -361,6 +362,17 @@
 
   .Sky-nav-menu-item {
     font-size: var(--Sky-nav-menu-item-font-size-sm);
+  }
+}
+
+@media (--lg-viewport) {
+  /**
+   * On larger screens, the nav links are spaced out from each other and this provides
+   * visual balance by adding space between the nav and logo.
+   */
+
+  .Sky-nav-menu-items {
+    margin-left: var(--Sky-nav-menu-space);
   }
 }
 

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -43,6 +43,8 @@
 @custom-media --Sky-nav-expanded-viewport (width >= 36em);
 @custom-media --Sky-nav-full-viewport (width >= 48em);
 @custom-media --Sky-scene-full-viewport (--md-viewport);
+@custom-media --Sky-nav-font-sm (width >= 64em);
+@custom-media --Sky-nav-font-md (width < 80em);
 
 /**
  * 1. Keep absolute-positioned elements from leaving this container.
@@ -351,7 +353,7 @@
   }
 }
 
-@media (--lg-viewport) {
+@media (--Sky-nav-font-sm)  and (--Sky-nav-font-md) {
   /**
    * In this viewport range, the body font size increases enough to wrap the last
    * couple of nav items. This prevents the wrapping.
@@ -359,16 +361,6 @@
 
   .Sky-nav-menu-item {
     font-size: var(--Sky-nav-menu-item-font-size-sm);
-  }
-}
-
-@media (--xl-viewport) {
-  /**
-   * Back to default font size behavior now that there's enough room.
-   */
-
-  .Sky-nav-menu-item {
-    font-size: var(--Sky-nav-menu-item-font-size);
   }
 }
 

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -318,7 +318,6 @@
 }
 
 @media (--Sky-nav-expanded-viewport) {
-
   /**
    * When the nav is horizontal, ditch those dividers.
    */
@@ -346,6 +345,7 @@
    * one line and avoids orphans. Since the containing list items also spread out at this 
    * breakpoint, the space between nav item links is maximized.
    */
+
   .Sky-nav-menu-item {
     padding: var(--Sky-nav-menu-item-space-tighter);
   }
@@ -356,6 +356,7 @@
    * In this viewport range, the body font size increases enough to wrap the last
    * couple of nav items. This prevents the wrapping.
    */
+
   .Sky-nav-menu-item {
     font-size: var(--Sky-nav-menu-item-font-size-sm);
   }
@@ -365,6 +366,7 @@
   /**
    * Back to default font size behavior now that there's enough room.
    */
+
   .Sky-nav-menu-item {
     font-size: var(--Sky-nav-menu-item-font-size);
   }

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -341,8 +341,8 @@
 
 @media (--Sky-nav-full-viewport) {
   /**
-   * Tightening the left and right padding on nav item links allows for the nav items fit on 
-   * one line and avoids orphans. Since the containing list items also spread out at this 
+   * Tightening the left and right padding on nav item links allows for the nav items to
+   * fit on one line and avoids orphans. Since the containing list items also spread out at this 
    * breakpoint, the space between nav item links is maximized.
    */
 

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -40,7 +40,7 @@
 @custom-media --Sky-nav-expanded-viewport (width >= 36em);
 @custom-media --Sky-nav-full-viewport (width >= 56em);
 @custom-media --Sky-scene-full-viewport (--md-viewport);
-@custom-media --Sky-nav-logo-sm-min (width >= 64em);
+@custom-media --Sky-nav-logo-sm-min (--lg-viewport);
 @custom-media --Sky-nav-logo-sm-max (width < 68em);
 
 /**

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -234,9 +234,6 @@
   }
 }
 
-
-
-
 /**
  * 1. Hidden by default.
  * 2. Add a bit of space between this the last nav item and the logo and menu

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -194,7 +194,11 @@
   padding: var(--Sky-nav-logo-padding);
 }
 
-@media (--lg-viewport) {
+@media (--Sky-nav-logo-sm-min) {
+/**
+ * Reducing the left padding on the logo balances it with the right margin on the nav.
+ */
+
   .Sky-nav-logo {
     padding-left: var(--space-xs);
   }
@@ -226,7 +230,7 @@
 
   .Sky-nav-logo-object {
     width: var(--Sky-nav-logo-size-sm);
-    width: var(--Sky-nav-logo-size-sm);
+    height: var(--Sky-nav-logo-size-sm);
   }
 }
 
@@ -385,7 +389,6 @@
     color: var(--Sky-nav-color-inactive);
   }
 }
-
 
 /**
  * Sky scene

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -26,9 +26,8 @@
   --Sky-nav-menu-item-line-height: var(--line-height-xs);
   --Sky-nav-menu-item-transition-duration: var(--motion-duration-md);
   --Sky-nav-menu-item-transition-timing-function: var(--motion-timing-function-default);
-  --Sky-nav-menu-item-space: var(--space-sm);
-  --Sky-nav-menu-item-space-tighter: var(--space-sm) calc(var(--space-sm) * 0.5);
   --Sky-nav-menu-space: var(--space-sm);
+  --Sky-nav-menu-space-tighter: var(--space-sm) calc(var(--space-sm) * 0.5);
 
   --Sky-scene-object-x-offset: calc(2 / 3 * 100%);
   --Sky-scene-object-x-offset-full: 75%;
@@ -42,7 +41,7 @@
 
 @custom-media --Sky-nav-expanded-viewport (width >= 36em);
 @custom-media --Sky-nav-full-viewport (width >= 48em);
-@custom-media --Sky-nav-font-size-sm-max (width < 80em);
+@custom-media --Sky-nav-font-size-sm-max (width < 70em);
 @custom-media --Sky-scene-full-viewport (--md-viewport);
 
 /**
@@ -275,7 +274,7 @@
   .Sky-nav-menu-items {
     display: flex; /* 1 */
     margin: var(--Sky-nav-menu-space); /* 2 */
-    margin-left: 0; /* 4 */
+    margin-left: 0; /* 3 */
     flex-wrap: wrap; /* 4 */
     justify-content: flex-end; /* 5 */
   }
@@ -310,7 +309,7 @@
 
 .Sky-nav-menu-item {
   display: block; /* 1 */
-  padding: var(--Sky-nav-menu-item-space); /* 2 */
+  padding: var(--Sky-nav-menu-space); /* 2 */
   font-size: var(--Sky-nav-menu-item-font-size);
   line-height: var(--Sky-nav-menu-item-line-height);
   white-space: nowrap; /* 3 */
@@ -350,7 +349,7 @@
    */
 
   .Sky-nav-menu-item {
-    padding: var(--Sky-nav-menu-item-space-tighter);
+    padding: var(--Sky-nav-menu-space-tighter);
   }
 }
 


### PR DESCRIPTION
I made some small adjustments to the navigation to reduce awkward wrapping. What I did:
- removed the left margin on the ul with the class name of `Sky-nav-menu-items`.
- reduced the breakpoint for the `--Sky-nav-full-viewport` variable from 65em to 45em (the point where all nav items fit in one line)
- At this same breakpoint, I reduced the left and right padding on the links from 1em to 0.5em. This also helps to get everything on one line in smaller screens. Because the list items space out at this breakpoint, the screen size range where the links are actually only 0.5em + 0.5em away from each other is very brief and they quickly expand outward. 
- In the lg breakpoint, I switched the font size from md to sm, because the font size increase was wrapping links again. I increased the font size back to md at the xl breakpoint because there's enough room. 

![nav](https://cloud.githubusercontent.com/assets/1242871/16822792/e9faec1c-4913-11e6-96c6-87e46937c6f9.gif)
 
cc @nicolemors @saralohr @grigs @erikjung @mrgerardorodriguez but who I am kidding, it's gonna be @tylersticka reviewing this. :)