### PR TITLE
Graceful degradation for FloatLabel events

### DIFF
--- a/src/assets/toolkit/scripts/lib/component/float-label.js
+++ b/src/assets/toolkit/scripts/lib/component/float-label.js
@@ -2,26 +2,32 @@
 
 export class FloatLabel {
   /**
+   * @see https://mathiasbynens.be/notes/oninput
    * @param {DOM} element
    * @param {Object} options
    * @param {String} options.inputElement - Reference to input within element.
-   * @param {String} options.eventName - Event that will trigger updates.
    * @param {String} options.className - Class applied to `element` when `inputElement` is empty.
    */
   constructor(element, {
     inputElement = element.querySelector('input, textarea'),
-    eventName = 'input',
     className = 'is-empty'
   } = {}) {
     // Assign properties
     Object.assign(this, {
       element,
       inputElement,
-      eventName,
       className
     });
-    // Listen for event and update
-    this.element.addEventListener(this.eventName, this.update.bind(this));
+    // Fallback event handler
+    var keyUpHandler = () => this.update();
+    // Ideal event handler, will remove the other one if supported
+    var inputHandler = () => {
+      this.element.removeEventListener('keyup', keyUpHandler);
+      this.update();
+    };
+    // Attach events
+    this.element.addEventListener('input', inputHandler);
+    this.element.addEventListener('keyup', keyUpHandler);
     // Run first update now
     this.update();
   }

--- a/src/assets/toolkit/scripts/toolkit.js
+++ b/src/assets/toolkit/scripts/toolkit.js
@@ -20,9 +20,7 @@ import 'prismjs/components/prism-scss';
 (function() {
 
   arrayFromSelector('.js-FloatLabel').map(element => {
-    new FloatLabel(element, {
-      eventName: 'keyup'
-    });
+    new FloatLabel(element);
   });
 
   /**

--- a/src/patterns/combos/blog/post-comment-form.hbs
+++ b/src/patterns/combos/blog/post-comment-form.hbs
@@ -10,18 +10,22 @@ order: 5
     type="textarea"
     label="Message"
     inputclass="js-ElasticTextarea"
-    inputid="commentform-message"}}{{/embed}}
+    inputid="comment"}}{{/embed}}
   <div class="Grid Grid--withGutter">
     <div class="Grid-cell u-sm-size1of2">
       {{#embed "patterns.components.input.float-label.base"
         label="Name"
-        inputid="commentform-name"}}{{/embed}}
+        inputid="name"
+        inputname="name"
+        autocomplete="name"}}{{/embed}}
     </div>
     <div class="Grid-cell u-spaceTop1 u-sm-spaceTopNone u-sm-size1of2">
       {{#embed "patterns.components.input.float-label.base"
         label="Email"
         type="email"
-        inputid="commentform-email"}}{{/embed}}
+        inputid="email"
+        inputname="email"
+        autocomplete="home email"}}{{/embed}}
     </div>
     <div class="Grid-cell u-spaceTop1">
       {{#embed "patterns.components.button.base" class="Button--default u-block u-sizeFull"}}

--- a/src/patterns/components/input/float-label/base.hbs
+++ b/src/patterns/components/input/float-label/base.hbs
@@ -5,9 +5,9 @@ hidden: true
   {{#block "content"}}
     <label class="FloatLabel-label" for="{{inputid}}">{{label}}</label>
     {{#compare type "===" "textarea"}}
-      <textarea class="Input {{inputclass}}" id="{{inputid}}">{{value}}</textarea>
+      <textarea class="Input {{inputclass}}" id="{{inputid}}" {{#if inputname}}name="{{inputname}}"{{/if}} {{#if autocomplete}}autocomplete="{{autocomplete}}"{{/if}}>{{value}}</textarea>
     {{else}}
-      <input class="Input {{inputclass}}" id="{{inputid}}" type="{{defaultTo type "text"}}" value="{{value}}">
+      <input class="Input {{inputclass}}" id="{{inputid}}" {{#if inputname}}name="{{inputname}}"{{/if}} {{#if autocomplete}}autocomplete="{{autocomplete}}"{{/if}} type="{{defaultTo type "text"}}" value="{{value}}">
     {{/compare}}
   {{/block}}
 </div>


### PR DESCRIPTION
When we decided to move away from Modernizr for solutions that didn't block the page load, we lost their `oninput` event check. Our solution at the time was to overtly specify the `keyup` event for float labels, which seemed a fine solution.

But as described in #311, that event will only fire when keys are literally pushed, at least in some browsers. This meant that alternative means of filling out the forms, such as autofill or pasting text from a right-click, would not trigger the active state consistently.

This PR removes the `eventName` option from our `FloatLabel` component, instead using [a very simple technique](https://mathiasbynens.be/notes/oninput) for detecting `oninput` support and falling back to `keyup` otherwise.

To appropriately test this, I added [autofill attributes](https://cloudfour.com/thinks/autofill-what-web-devs-should-know-but-dont/) for the `name` and `email` fields of our comment form. But for some reason I'm having trouble triggering autofill in Firefox and Edge... I followed instructions for both browsers, but neither wants to cooperate. I'm hoping that @grigs can help me out since he wrote that post.

## Steps to test

1. Check out this branch locally.
2. Run `npm start`
3. Navigate to [http://localhost:3000/pages/blog-single-article.html#commentform](http://localhost:3000/pages/blog-single-article.html#commentform) or [http://10.0.2.2:3000/pages/blog-single-article.html#commentform](http://10.0.2.2:3000/pages/blog-single-article.html#commentform) in VirtualBox
4. Try autofilling the form fields

---

@grigs @mrgerardorodriguez @erikjung @saralohr 

Fixes #311