### PR TITLE
Add vendor styles for Jetpack Markdown footnotes

### DIFF
--- a/src/assets/toolkit/styles/components/footnote-link.css
+++ b/src/assets/toolkit/styles/components/footnote-link.css
@@ -10,39 +10,45 @@
   --FootnoteLink-padding: 0 calc(var(--ms-6) * 1em);
 }
 
-/**
- * Override color defaults for all states
- */
+@define-mixin makeFootnoteLinkComponent {
+  /**
+   * Override color defaults for all states
+   */
 
-.FootnoteLink,
-.FootnoteLink:matches(:--enter, :active) {
-  color: var(--FootnoteLink-color);
+  &,
+  &:matches(:--enter, :active) {
+    color: var(--FootnoteLink-color);
+  }
+
+  /**
+   * 1. Maintain a circular shape even for narrow text contents.
+   * 2. If the text is wider than the minimum, make sure it still has some
+   *    padding so it doesn't appear to drift outside of the rounded sides.
+   * 3. Once computed, this value should be equal to the min-width to default
+   *    to a circular shape with centered text.
+   */
+
+  & {
+    display: inline-block;
+    min-width: var(--FootnoteLink-min-width); /* 1 */
+    padding: var(--FootnoteLink-padding); /* 2 */
+    font-size: var(--FootnoteLink-font-size);
+    line-height: var(--FootnoteLink-line-height); /* 3 */
+    text-align: center;
+    text-decoration: none;
+    border-radius: var(--FootnoteLink-border-radius);
+    background: var(--FootnoteLink-background-color);
+  }
+
+  /**
+   * Change the background color on hover or focus
+   */
+
+  &:matches(:--enter) {
+    background-color: color(var(--FootnoteLink-background-color) l(+5%));
+  }
 }
-
-/**
- * 1. Maintain a circular shape even for narrow text contents.
- * 2. If the text is wider than the minimum, make sure it still has some
- *    padding so it doesn't appear to drift outside of the rounded sides.
- * 3. Once computed, this value should be equal to the min-width to default
- *    to a circular shape with centered text.
- */
 
 .FootnoteLink {
-  display: inline-block;
-  min-width: var(--FootnoteLink-min-width); /* 1 */
-  padding: var(--FootnoteLink-padding); /* 2 */
-  font-size: var(--FootnoteLink-font-size);
-  line-height: var(--FootnoteLink-line-height); /* 3 */
-  text-align: center;
-  text-decoration: none;
-  border-radius: var(--FootnoteLink-border-radius);
-  background: var(--FootnoteLink-background-color);
-}
-
-/**
- * Change the background color on hover or focus
- */
-
-.FootnoteLink:matches(:--enter) {
-  background-color: color(var(--FootnoteLink-background-color) l(+5%));
+  @mixin makeFootnoteLinkComponent;
 }

--- a/src/assets/toolkit/styles/utils/bg.css
+++ b/src/assets/toolkit/styles/utils/bg.css
@@ -2,10 +2,14 @@
   background-color: var(--color-white);
 }
 
-.u-bgGray,
-.u-bgGrayTarget:target {
+@define-mixin makeBgGrayUtility {
   background-color: color(
     var(--color-gray)
     blend(var(--color-white) 50%)
   );
+}
+
+.u-bgGray,
+.u-bgGrayTarget:target {
+  @mixin makeBgGrayUtility;
 }

--- a/src/assets/toolkit/styles/vendor/index.css
+++ b/src/assets/toolkit/styles/vendor/index.css
@@ -1,2 +1,3 @@
+@import "./jetpack-markdown.css";
 @import "./prism.css";
 @import "./wordpress.css";

--- a/src/assets/toolkit/styles/vendor/jetpack-markdown.css
+++ b/src/assets/toolkit/styles/vendor/jetpack-markdown.css
@@ -1,0 +1,58 @@
+/**
+ * Jetpack Markdown Customization
+ */
+
+/**
+ * Footnote links
+ *
+ * Jetpack doesn't expose any theming options, but Markdown syntax is soooo
+ * much nicer to write with, so we embrace some rather shameful styles to
+ * make that work.
+ */
+
+/**
+ * Apply the FootnoteLink component's styles to elements that are clearly
+ * meant to be footnote links.
+ */
+sup[id^="fnref-"] a {
+  @mixin makeFootnoteLinkComponent;
+}
+
+/**
+ * Apply spacing above the footnote list (which is preceded by a rule), taking
+ * into account the margin+padding that the individual items will have.
+ */
+
+.footnotes > ol {
+  margin-top: calc(var(--ms-1)  * 1rem);
+}
+
+/**
+ * Customize the items themselves.
+ *
+ * 1. Give some spacing between, but not a lot since they'll have padding.
+ * 2. Give them padding so they'll look nicer when highlighted.
+ */
+
+.footnotes > ol > li {
+  margin-top: calc(var(--ms-3)  * 1rem); /* 1 */
+  padding: calc(var(--ms-3) * 1rem) calc(var(--ms-6) * 1rem); /* 2 */
+}
+
+/**
+ * Highlight footnotes when navigated to, mimicing the style of u-bgGrayTarget.
+ */
+
+.footnotes > ol > li:target {
+  @mixin makeBgGrayUtility;
+}
+
+/**
+ * Remove the underline on the return links. We aren't going to swap the unicode
+ * character with an SVG icon here (which will bloat our stylesheet), but this
+ * sets us up to do that if we so choose.
+ */
+
+.footnotes a[href^="#fnref-"] {
+  text-decoration: none;
+}


### PR DESCRIPTION
This begins to address cloudfour/cloudfour.com-wp#255 by customizing the markup [Jetpack Markdown](https://en.support.wordpress.com/markdown-quick-reference/) outputs for footnotes.

I went this route after confirming that there are no documented filters for the footnotes, and any that existed in the underlying library are not exposed in a way we could modify without rolling our own plugin.

The only thing it does not do is replace the unicode character with our SVG icon. This is possible, but it would represent the bulk of the styles, and filtering for the unicode character is one of the few things we can do relatively easily from our WP theme if we desire.

## Before

<img width="805" alt="screen shot 2016-07-18 at 3 36 14 pm" src="https://cloud.githubusercontent.com/assets/69633/16932948/c8dc893e-4cfe-11e6-9b08-46adab442b3c.png">

## After

<img width="824" alt="screen shot 2016-07-18 at 3 35 58 pm" src="https://cloud.githubusercontent.com/assets/69633/16932949/cce80a12-4cfe-11e6-87c6-1cc7b660bb02.png">


---

@saralohr @mrgerardorodriguez @erikjung @grigs 

See: cloudfour/cloudfour.com-wp#255