### PR TITLE
Fix: Replace problematic Map instance with multi-dimensional array

### DIFF
--- a/src/assets/toolkit/scripts/lib/core/fn.js
+++ b/src/assets/toolkit/scripts/lib/core/fn.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const noop = () => {};
+
+export {
+  noop
+};

--- a/src/assets/toolkit/scripts/lib/fx/easing.js
+++ b/src/assets/toolkit/scripts/lib/fx/easing.js
@@ -8,13 +8,13 @@ import eases from 'eases';
 /**
  * Associates easing function sources w/ types
  */
-const sourcesByType = new Map([
+const sourcesByType = [
   // Array of points? Use BezierEasing to calculate.
   [Array, points => BezierEasing(...points)],
 
   // String alias? Use predefined ease calculations.
   [String, alias => eases[alias]]
-]);
+];
 
 class EaseFunction {
   /**
@@ -25,9 +25,10 @@ class EaseFunction {
    */
   static create (input) {
     const type = input.constructor;
-    const easerSource = sourcesByType.get(type);
-    if (easerSource) {
-      return easerSource(input);
+    const easerSource = sourcesByType.find(el => el[0] === type);
+    const easerFn = easerSource ? easerSource[1] : null;
+    if (easerFn) {
+      return easerFn(input);
     } else {
       throw `An easing function could not be created from ${input}.`;
     }

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -38,7 +38,7 @@
     {{/if}}
     {{#block "scripts"}}
       <!-- Polyfill service, see: https://cdn.polyfill.io/v2/docs/ -->
-      <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Object.assign,Array.from,Element.prototype.classList"></script>
+      <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Object.assign,Array.prototype.find,Array.from,Element.prototype.classList"></script>
       <script src="{{baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
       {{#each scripts}}
         <script src="{{baseurl}}/assets/toolkit/scripts/{{this}}.js"></script>


### PR DESCRIPTION
#324 

@tylersticka Wanna give this a whirl on your nicely installed IE11 VM?

**TL;DR** There was code using `Map`, which is not transformed by Babel, and is only partially supported by IE11. I'm guessing this was the issue.

/CC @mrgerardorodriguez 