### PR TITLE
Specify text-decoration-skip property

### DIFF
--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -40,6 +40,7 @@ body {
 a {
   text-decoration: underline;
   color: var(--link-color);
+  -webkit-text-decoration-skip: ink;
 }
 
 a:matches(:active, :focus, :hover) {


### PR DESCRIPTION
Allows descenders and other glyphs to disrupt underlines.

In @erikjung's original issue describing this problem (#323), he wonders whether or not it makes sense to omit or incorporate the necessary `suitcss-base`/`normalize.css` fixes directly. I commented out `suitcss-base` and noticed numerous regressions, which gave me cold feet. If we think a refactor like that is a good idea, I think it should be tackled as a separate issue.

## Screenshots (Safari)

### Before

<img width="646" alt="screen shot 2016-07-19 at 9 15 52 am" src="https://cloud.githubusercontent.com/assets/69633/16957625/0415c608-4d92-11e6-8413-79317eb9fa8a.png">

### After

<img width="640" alt="screen shot 2016-07-19 at 9 15 38 am" src="https://cloud.githubusercontent.com/assets/69633/16957628/08fb2c9e-4d92-11e6-89d4-f88463b7b399.png">

---

@erikjung @saralohr @mrgerardorodriguez @aileenjeffries 

Fixes #323