### PR TITLE
Specify msapplication-config

### DIFF
--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -24,6 +24,7 @@
       <link rel="manifest" href="/manifest.json">
       <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#456BD9">
       <meta name="theme-color" content="#456BD9">
+      <meta name="msapplication-config" content="/browserconfig.xml">
     {{/block}}
   </head>
   <body class="{{bodyclass}}">


### PR DESCRIPTION
This is necessary to get the tile image working in Edge. This will also need to be done in WP-land.

See: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/101636/

## Before

![virtualbox_msedge - win10th2_19_07_2016_09_28_46](https://cloud.githubusercontent.com/assets/69633/16958193/6496d4de-4d94-11e6-824f-3deb6833dae8.png)

## After

(I don't know why the "after" added it to the top and not the bottom.)

![virtualbox_msedge - win10th2_19_07_2016_09_35_04](https://cloud.githubusercontent.com/assets/69633/16958196/696e2700-4d94-11e6-9c50-f98fcb228ddd.png)

---

@saralohr @mrgerardorodriguez @erikjung 

Fixes #319