### PR TITLE
Inherit border-radius from thumbnail

### DIFF
--- a/src/assets/toolkit/styles/components/thumbnail.css
+++ b/src/assets/toolkit/styles/components/thumbnail.css
@@ -60,6 +60,16 @@
 }
 
 /**
+ * iOS Safari on high-resolution devices sometimes rounds images and elements
+ * differently, resulting in a hard edge for some modifiers. This forces images
+ * to inherit `border-radius`, it helps smooth out those errors.
+ */
+
+.Thumbnail > img {
+  border-radius: inherit;
+}
+
+/**
  * Modifiers
  */
 


### PR DESCRIPTION
Small change to the `Thumbnail` component to fix some rounding errors in iOS Safari.

I first attempted to solve this by moving the percentage sizing utilities to containing elements, but this was inconsistent (would solve for some sizes and not others). This CSS change seems to fix it everywhere.

## Before

![](https://cloud.githubusercontent.com/assets/459757/16784896/df7dea84-483f-11e6-86c6-3b06b08f3393.png)

## After

![simulator screen shot jul 19 2016 11 38 02 am](https://cloud.githubusercontent.com/assets/69633/16962266/ba4e6228-4da5-11e6-98e2-b0ccbc1acf4c.png)

---

@saralohr @mrgerardorodriguez @erikjung @aileenjeffries 

Fixes #315