### PR TITLE
Wip componentize trivia

### DIFF
--- a/src/assets/toolkit/scripts/lib/component/slideshow.js
+++ b/src/assets/toolkit/scripts/lib/component/slideshow.js
@@ -8,9 +8,12 @@ export class Slideshow {
     prevTrigger = element.querySelector('.js-Slideshow-prev'),
     currentCount = element.querySelector('.js-Slideshow-current'),
     totalCount = element.querySelector('.js-Slideshow-total'),
-    classNameVisible = 'is-visible',
-    classNameForward = 'slide-forward',
-    classNameBack = 'slide-back'
+    classIsVisible = 'is-visible',
+    classWasVisible = 'was-visible',
+    classForward = 'slide-forward',
+    classBack = 'slide-back',
+    classForwardAlt = 'slide-forward-alt',
+    classBackAlt = 'slide-back-alt'
   } = {}) {
 
     this.slides = Array.from(slides);
@@ -20,13 +23,17 @@ export class Slideshow {
 
     Object.assign(this, {
       element,
+      slideHolder,
       nextTrigger,
       prevTrigger,
       currentCount,
       totalCount,
-      classNameVisible,
-      classNameForward,
-      classNameBack
+      classIsVisible,
+      classWasVisible,
+      classForward,
+      classBack,
+      classForwardAlt,
+      classBackAlt
     });
 
     this.attachEvents();
@@ -43,20 +50,47 @@ export class Slideshow {
     // Update the navigation with the current slide number
     this.currentCount.innerHTML = slideToShow + 1;
 
+    // Remove previously applied directional class
+    this.slideHolder.classList.remove(this.classForward, this.classBack, this.classForwardAlt, this.classBackAlt);
+
+    // This triggers a reflow which gives a fresh start
+    // for adding back the same class name so the same animation
+    // can re-run
+    this.slideHolder.offsetWidth;
+
+    // Add new directional class to slide container
+    if (direction == 'forward') {
+      // Alternate class names to apply a different animation since you can't
+      // run the same animation twice in a row
+      // if (this.counter % 2) {
+      //   this.slideHolder.classList.add(this.classForward);
+      // } else {
+      //   this.slideHolder.classList.add(this.classForwardAlt);
+      // }
+      this.slideHolder.classList.add(this.classForward);
+    } else {
+      // if (this.counter % 2) {
+      //   this.slideHolder.classList.add(this.classBack);
+      // } else {
+      //   this.slideHolder.classList.add(this.classBackAlt);
+      // }
+      this.slideHolder.classList.add(this.classBack);
+    }
+
+    this.slides.forEach(slide => {
+      slide.classList.remove(this.classWasVisible);
+    });
+
     // Remove class names from all items
     this.slides.forEach(slide => {
-      slide.classList.remove(this.classNameVisible, this.classNameForward, this.classNameBack);
+      if (slide.classList.contains(this.classIsVisible)) {
+        slide.classList.remove(this.classIsVisible);
+        slide.classList.add(this.classWasVisible);
+      }
     });
 
     // Add current class to current item
-    this.slides[slideToShow].classList.add(this.classNameVisible);
-
-    // Add forward or back class depending on direction
-    if (direction == 'forward') {
-      this.slides[slideToShow].classList.add(this.classNameForward);
-    } else if (direction == 'back') {
-      this.slides[slideToShow].classList.add(this.classNameBack);
-    }
+    this.slides[slideToShow].classList.add(this.classIsVisible);
   }
 
 

--- a/src/assets/toolkit/scripts/lib/component/slideshow.js
+++ b/src/assets/toolkit/scripts/lib/component/slideshow.js
@@ -53,9 +53,8 @@ export class Slideshow {
     // Remove previously applied directional class
     this.slideHolder.classList.remove(this.classForward, this.classBack, this.classForwardAlt, this.classBackAlt);
 
-    // This triggers a reflow which gives a fresh start
-    // for adding back the same class name so the same animation
-    // can re-run
+    // Trigger a reflow which gives a fresh start to the element, so we can add
+    // back the same class that runs the same animation
     this.slideHolder.offsetWidth;
 
     // Add new directional class to slide container
@@ -77,11 +76,12 @@ export class Slideshow {
       this.slideHolder.classList.add(this.classBack);
     }
 
+    // Remove `was-visible` class
     this.slides.forEach(slide => {
       slide.classList.remove(this.classWasVisible);
     });
 
-    // Remove class names from all items
+    // Find slide that has class `is-visible`, and replace it with `was-visible`
     this.slides.forEach(slide => {
       if (slide.classList.contains(this.classIsVisible)) {
         slide.classList.remove(this.classIsVisible);
@@ -89,7 +89,7 @@ export class Slideshow {
       }
     });
 
-    // Add current class to current item
+    // Add `is-visible` class to current item
     this.slides[slideToShow].classList.add(this.classIsVisible);
   }
 

--- a/src/assets/toolkit/scripts/lib/component/slideshow.js
+++ b/src/assets/toolkit/scripts/lib/component/slideshow.js
@@ -1,19 +1,19 @@
 'use strict';
 
-export class FactSlider {
+export class Slideshow {
   constructor (element, {
-    facts = element.querySelectorAll('.js-FunFact'),
-    nextTrigger = element.querySelector('.js-FunFact-next'),
-    prevTrigger = element.querySelector('.js-FunFact-prev'),
-    currentCount = element.querySelector('.js-FunFact-current'),
-    totalCount = element.querySelector('.js-FunFact-total'),
+    slides = element.querySelectorAll('.js-Slideshow-slide'),
+    nextTrigger = element.querySelector('.js-Slideshow-next'),
+    prevTrigger = element.querySelector('.js-Slideshow-prev'),
+    currentCount = element.querySelector('.js-Slideshow-current'),
+    totalCount = element.querySelector('.js-Slideshow-total'),
     className = 'is-visible'
   } = {}) {
 
-    this.facts = Array.from(facts);
-    this.numFacts = this.facts.length;
+    this.slides = Array.from(slides);
+    this.numSlides = this.slides.length;
     this.counter = 0;
-    totalCount.innerHTML = this.numFacts;
+    totalCount.innerHTML = this.numSlides;
 
     Object.assign(this, {
       element,
@@ -29,18 +29,18 @@ export class FactSlider {
 
   showCurrent () {
     // Get the index of the current item
-    const factToShow = Math.abs(this.counter % this.numFacts);
+    const slideToShow = Math.abs(this.counter % this.numSlides);
 
     // Remove current class from all items
-    this.facts.forEach(fact => {
-      fact.classList.remove(this.className);
+    this.slides.forEach(slide => {
+      slide.classList.remove(this.className);
     });
 
     // Add current class to current item
-    this.facts[factToShow].classList.add(this.className);
+    this.slides[slideToShow].classList.add(this.className);
 
     // Update the navigation with the current slide number
-    this.currentCount.innerHTML = factToShow + 1;
+    this.currentCount.innerHTML = slideToShow + 1;
   }
 
 

--- a/src/assets/toolkit/scripts/lib/component/slideshow.js
+++ b/src/assets/toolkit/scripts/lib/component/slideshow.js
@@ -2,12 +2,15 @@
 
 export class Slideshow {
   constructor (element, {
+    slideHolder = element.querySelector('.js-Slideshow-slides'),
     slides = element.querySelectorAll('.js-Slideshow-slide'),
     nextTrigger = element.querySelector('.js-Slideshow-next'),
     prevTrigger = element.querySelector('.js-Slideshow-prev'),
     currentCount = element.querySelector('.js-Slideshow-current'),
     totalCount = element.querySelector('.js-Slideshow-total'),
-    className = 'is-visible'
+    classNameVisible = 'is-visible',
+    classNameForward = 'slide-forward',
+    classNameBack = 'slide-back'
   } = {}) {
 
     this.slides = Array.from(slides);
@@ -21,26 +24,39 @@ export class Slideshow {
       prevTrigger,
       currentCount,
       totalCount,
-      className
+      classNameVisible,
+      classNameForward,
+      classNameBack
     });
 
     this.attachEvents();
   }
 
-  showCurrent () {
+  showCurrent (direction) {
     // Get the index of the current item
-    const slideToShow = Math.abs(this.counter % this.numSlides);
-
-    // Remove current class from all items
-    this.slides.forEach(slide => {
-      slide.classList.remove(this.className);
-    });
-
-    // Add current class to current item
-    this.slides[slideToShow].classList.add(this.className);
+    if (this.counter > 0) {
+      var slideToShow = (this.counter % this.numSlides);
+    } else {
+      var slideToShow = (this.counter % this.numSlides) ? ((this.counter % this.numSlides) + this.numSlides) : 0;
+    }
 
     // Update the navigation with the current slide number
     this.currentCount.innerHTML = slideToShow + 1;
+
+    // Remove class names from all items
+    this.slides.forEach(slide => {
+      slide.classList.remove(this.classNameVisible, this.classNameForward, this.classNameBack);
+    });
+
+    // Add current class to current item
+    this.slides[slideToShow].classList.add(this.classNameVisible);
+
+    // Add forward or back class depending on direction
+    if (direction == 'forward') {
+      this.slides[slideToShow].classList.add(this.classNameForward);
+    } else if (direction == 'back') {
+      this.slides[slideToShow].classList.add(this.classNameBack);
+    }
   }
 
 
@@ -49,13 +65,13 @@ export class Slideshow {
     this.nextTrigger.addEventListener('click', event => {
       event.preventDefault();
       this.counter++;
-      this.showCurrent();
+      this.showCurrent('forward');
     });
 
     this.prevTrigger.addEventListener('click', event => {
       event.preventDefault();
       this.counter--;
-      this.showCurrent();
+      this.showCurrent('back');
     });
   }
 }

--- a/src/assets/toolkit/scripts/lib/component/slideshow1.js
+++ b/src/assets/toolkit/scripts/lib/component/slideshow1.js
@@ -1,0 +1,103 @@
+'use strict';
+
+export class Slideshow {
+  constructor (element, {
+    slideHolder = element.querySelector('.js-Slideshow-slides'),
+    slides = element.querySelectorAll('.js-Slideshow-slide'),
+    nextTrigger = element.querySelector('.js-Slideshow-next'),
+    prevTrigger = element.querySelector('.js-Slideshow-prev'),
+    currentCount = element.querySelector('.js-Slideshow-current'),
+    totalCount = element.querySelector('.js-Slideshow-total'),
+    className = 'is-visible'
+  } = {}) {
+
+    this.slides = Array.from(slides);
+    this.numSlides = this.slides.length;
+    this.counter = 0;
+    totalCount.innerHTML = this.numSlides;
+
+    Object.assign(this, {
+      element,
+      slideHolder,
+      nextTrigger,
+      prevTrigger,
+      currentCount,
+      totalCount,
+      className
+    });
+
+    this.attachEvents();
+  }
+
+  updateCurrent () {
+    if (this.counter > 0) {
+      var currentSlide = (this.counter % this.numSlides);
+    } else {
+      var currentSlide = (this.counter % this.numSlides) ? ((this.counter % this.numSlides) + this.numSlides) : 0;
+    }
+
+    // Update the navigation with the current slide number
+    this.currentCount.innerHTML = currentSlide + 1;
+  }
+
+  getCurrentPosition (el) {
+    const transformMatrix = getComputedStyle(el).transform;
+    const slideHolderWidth = el.offsetWidth;
+    var matrixValues = transformMatrix.split('(')[1],
+    matrixValues = matrixValues.split(')')[0],
+    matrixValues = matrixValues.split(',');
+    const translateX = matrixValues[4];
+    const currentPosition = this.convertToPercent(translateX, slideHolderWidth);
+    return currentPosition;
+  }
+
+  convertToPercent(el, base) {
+    const percent = (el / base) * 100;
+    return percent;
+  }
+
+  slide(direction) {
+
+    // Reset the position
+    // if ((this.counter != 0) && (this.counter % this.numSlides) == 0) {
+    //   console.log('Start over');
+    //   var currentPosition = 100;
+    // } else {
+    //   var currentPosition = this.getCurrentPosition(this.slideHolder);
+    // }
+    //
+    if ((this.counter == -1) && (direction == 1)) {
+      var increment = (this.counter % this.numSlides + this.numSlides) * -100;
+    } else {
+      var increment = direction * 100;
+    }
+
+    var currentPosition = this.getCurrentPosition(this.slideHolder);
+
+    const newPosition = Number(currentPosition) + Number(increment);
+    this.slideHolder.style.transform = 'translateX(' + newPosition + '%)';
+
+    console.log(this.counter);
+    console.log(this.numSlides);
+    console.log('Old position:' + currentPosition);
+    console.log('Direction: ' + direction);
+    console.log('Increment:' + increment);
+    console.log('New position:' + newPosition);
+  }
+
+  attachEvents () {
+    this.nextTrigger.addEventListener('click', event => {
+      event.preventDefault();
+      this.counter++;
+      this.updateCurrent();
+      this.slide(-1);
+    });
+
+    this.prevTrigger.addEventListener('click', event => {
+      event.preventDefault();
+      this.counter--;
+      this.updateCurrent();
+      this.slide(1);
+    });
+  }
+}

--- a/src/assets/toolkit/scripts/lib/component/slideshow1.js
+++ b/src/assets/toolkit/scripts/lib/component/slideshow1.js
@@ -8,7 +8,9 @@ export class Slideshow {
     prevTrigger = element.querySelector('.js-Slideshow-prev'),
     currentCount = element.querySelector('.js-Slideshow-current'),
     totalCount = element.querySelector('.js-Slideshow-total'),
-    className = 'is-visible'
+    classForward = 'slide-forward',
+    classForwardReset = 'slide-forwardReset',
+    classBack = 'slide-back'
   } = {}) {
 
     this.slides = Array.from(slides);
@@ -23,7 +25,9 @@ export class Slideshow {
       prevTrigger,
       currentCount,
       totalCount,
-      className
+      classForward,
+      classForwardReset,
+      classBack
     });
 
     this.attachEvents();
@@ -56,33 +60,60 @@ export class Slideshow {
     return percent;
   }
 
+  findKeyframesRule(rule) {
+    var ss = document.styleSheets;
+    console.log(ss);
+    for (var j = 0; j < ss[1].cssRules.length; ++j) {
+      if (ss[1].cssRules[j].type == window.CSSRule.WEBKIT_KEYFRAMES_RULE &&
+      ss[1].cssRules[j].name == rule) {
+        return ss[1].cssRules[j]; }
+    }
+    return null;
+  }
+
   slide(direction) {
 
-    // Reset the position
-    // if ((this.counter != 0) && (this.counter % this.numSlides) == 0) {
-    //   console.log('Start over');
-    //   var currentPosition = 100;
-    // } else {
-    //   var currentPosition = this.getCurrentPosition(this.slideHolder);
-    // }
-    //
-    if ((this.counter == -1) && (direction == 1)) {
-      var increment = (this.counter % this.numSlides + this.numSlides) * -100;
+    // Remove previously applied directional class
+    this.slideHolder.classList.remove(this.classForward, this.classBack);
+
+    // Add new directional class to slide container
+    if (direction == -1) {
+      this.slideHolder.classList.add(this.classForward);
     } else {
-      var increment = direction * 100;
+      this.slideHolder.classList.add(this.classBack);
     }
 
-    var currentPosition = this.getCurrentPosition(this.slideHolder);
+    // Reset the position when going forward
+    if (((this.counter % this.numSlides) == 0) && (direction == -1)) {
+      var currentPosition = 100;
+      this.slideHolder.classList.add(this.classForwardReset);
+    }
+    // Reset the position when going back
+    else if ((
+      // counter > 0
+      ((this.counter % this.numSlides) == (this.numSlides - 1)) ||
+      // counter < 0
+      ((this.counter % this.numSlides) == -1)) &&
+      // Going back
+      (direction == 1)) {
+      var currentPosition = -(this.numSlides * 100);
+    } else {
+      var currentPosition = this.getCurrentPosition(this.slideHolder);
+    }
+
+    var increment = direction * 100;
 
     const newPosition = Number(currentPosition) + Number(increment);
+
     this.slideHolder.style.transform = 'translateX(' + newPosition + '%)';
 
-    console.log(this.counter);
-    console.log(this.numSlides);
-    console.log('Old position:' + currentPosition);
+    console.log('Counter: ' + this.counter);
+    console.log('Number of slides: ' + this.numSlides);
+    console.log('Old position: ' + currentPosition);
     console.log('Direction: ' + direction);
-    console.log('Increment:' + increment);
-    console.log('New position:' + newPosition);
+    console.log('Increment: ' + increment);
+    console.log('New position: ' + newPosition);
+    console.log('END' + '\n\n');
   }
 
   attachEvents () {

--- a/src/assets/toolkit/scripts/toolkit.js
+++ b/src/assets/toolkit/scripts/toolkit.js
@@ -8,7 +8,7 @@ import {arrayFromSelector} from './lib/dom/core';
 import {FloatLabel} from './lib/component/float-label';
 import {Sky} from './lib/component/sky';
 import {ElasticTextarea} from './lib/component/elastic-textarea';
-import {FactSlider} from './lib/component/fact-slider';
+import {Slideshow from './lib/component/slideshow';
 
 /**
  * Syntax highlighting
@@ -20,8 +20,8 @@ import 'prismjs/components/prism-scss';
 
 (function() {
 
-  arrayFromSelector('.js-FunFacts').map(element => {
-    new FactSlider(element);
+  arrayFromSelector('.js-Slideshow').map(element => {
+    new Slideshow(element);
   });
 
   arrayFromSelector('.js-FloatLabel').map(element => {

--- a/src/assets/toolkit/scripts/toolkit.js
+++ b/src/assets/toolkit/scripts/toolkit.js
@@ -8,7 +8,7 @@ import {arrayFromSelector} from './lib/dom/core';
 import {FloatLabel} from './lib/component/float-label';
 import {Sky} from './lib/component/sky';
 import {ElasticTextarea} from './lib/component/elastic-textarea';
-import {Slideshow from './lib/component/slideshow';
+import {Slideshow} from './lib/component/slideshow';
 
 /**
  * Syntax highlighting

--- a/src/assets/toolkit/styles/components/index.css
+++ b/src/assets/toolkit/styles/components/index.css
@@ -12,6 +12,7 @@
 @import "./input-group.css";
 @import "./pagination.css";
 @import "./sky.css";
+@import "./slideshow.css";
 @import "./table.css";
 @import "./textblock.css";
 @import "./thumbnail.css";

--- a/src/assets/toolkit/styles/components/slideshow.css
+++ b/src/assets/toolkit/styles/components/slideshow.css
@@ -2,13 +2,47 @@
   overflow: hidden;
 }
 
+.Slideshow-slides {
+  /* Uncomment these if using slideshow1 */
+  /*transform: translateX(0);
+  transition: transform 500ms ease;*/
+}
+
 .Slideshow-slide {
   flex: 1 0 100% !important;
-  opacity: 0;
-  transition: opacity ease 500ms;
 }
 
 .Slideshow-slide.is-visible {
+  /* Comment this out if using slideshow1 */
   order: -1;
-  opacity: 1;
+}
+
+.Slideshow-slide.is-visible.slide-forward {
+  animation-name: slide-forward;
+  animation-duration: 500ms;
+  animation-timing-function: ease;
+}
+
+.Slideshow-slide.is-visible.slide-back {
+  animation-name: slide-back;
+  animation-duration: 500ms;
+  animation-timing-function: ease;
+}
+
+@keyframes slide-forward {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slide-back {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
 }

--- a/src/assets/toolkit/styles/components/slideshow.css
+++ b/src/assets/toolkit/styles/components/slideshow.css
@@ -4,37 +4,66 @@
 
 .Slideshow-slides {
   /* Uncomment these if using slideshow1 */
-  /*transform: translateX(0);
-  transition: transform 500ms ease;*/
+  /*transform: translateX(0);*/
 }
 
 .Slideshow-slide {
   flex: 1 0 100% !important;
 }
 
-.Slideshow-slide.is-visible {
-  /* Comment this out if using slideshow1 */
+.slide-forward .was-visible,
+.slide-forward-alt .was-visible {
+  order: -2;
+}
+.slide-forward .is-visible,
+.slide-forward-alt .is-visible {
   order: -1;
 }
 
-.Slideshow-slide.is-visible.slide-forward {
+.slide-back .was-visible,
+.slide-back-alt .was-visible {
+  order: -1;
+}
+.slide-back .is-visible,
+.slide-back-alt .is-visible {
+  order: -2;
+}
+
+.slide-forward {
   animation-name: slide-forward;
   animation-duration: 500ms;
   animation-timing-function: ease;
+  transform: translateX(-100%);
 }
 
-.Slideshow-slide.is-visible.slide-back {
+.slide-forward-alt {
+  animation-name: slide-forward-alt;
+  animation-duration: 500ms;
+  animation-timing-function: ease;
+  transform: translateX(-100%);
+}
+
+.slide-back {
   animation-name: slide-back;
   animation-duration: 500ms;
   animation-timing-function: ease;
+  transform: translateX(0%);
 }
+
+.slide-back-alt {
+  animation-name: slide-back-alt;
+  animation-duration: 500ms;
+  animation-timing-function: ease;
+  transform: translateX(0%);
+}
+
 
 @keyframes slide-forward {
   from {
-    transform: translateX(100%);
+    transform: translateX(0%);
   }
   to {
-    transform: translateX(0);
+    transform: translateX(-100%);
   }
 }
 
@@ -43,6 +72,24 @@
     transform: translateX(-100%);
   }
   to {
-    transform: translateX(0);
+    transform: translateX(0%);
+  }
+}
+
+@keyframes slide-forward-alt {
+  from {
+    transform: translateX(0%);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes slide-back-alt {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0%);
   }
 }

--- a/src/assets/toolkit/styles/components/slideshow.css
+++ b/src/assets/toolkit/styles/components/slideshow.css
@@ -1,0 +1,14 @@
+.Slideshow {
+  overflow: hidden;
+}
+
+.Slideshow-slide {
+  flex: 1 0 100% !important;
+  opacity: 0;
+  transition: opacity ease 500ms;
+}
+
+.Slideshow-slide.is-visible {
+  order: -1;
+  opacity: 1;
+}

--- a/src/assets/toolkit/styles/utils/display.css
+++ b/src/assets/toolkit/styles/utils/display.css
@@ -60,4 +60,16 @@
   .u-lg-block {
     display: block !important;
   }
+
+  .u-lg-inlineBlock {
+    display: inline-block !important;
+  }
+
+  .u-lg-unhideVisually {
+    clip: auto !important;
+    width: auto !important;
+    height: auto !important;
+    position: static !important;
+    overflow: inherit !important;
+  }
 }

--- a/src/assets/toolkit/styles/utils/position.css
+++ b/src/assets/toolkit/styles/utils/position.css
@@ -1,5 +1,13 @@
 @import "suitcss-utils-position";
 
+.u-posAbsoluteMiddle {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 0;
+  left: 0;
+}
+
 /**
  * Additional positioning utilities
  *

--- a/src/assets/toolkit/styles/utils/text.css
+++ b/src/assets/toolkit/styles/utils/text.css
@@ -17,6 +17,16 @@
 }
 
 /**
+ * Responsive text alignment
+ */
+
+@media (--sm-viewport) {
+  .u-sm-textLeft {
+    text-align: left !important;
+  }
+}
+
+/**
  * Utilities for adjusting text size using modular scale
  *
  * @see http://blog.cloudfour.com/responsive-guide-to-type-sizing/

--- a/src/pages/pages/team-single.hbs
+++ b/src/pages/pages/team-single.hbs
@@ -5,8 +5,6 @@ labels:
   - latest
 notes: |
   Individual team member bio and related content.
-stylesheets:
- - sandbox/sara-wip
 ---
 
 <div class="u-spaceItems1 u-cf">
@@ -59,9 +57,9 @@ stylesheets:
 
 {{! Fun Facts }}
 <div class="u-md-size2of3">
-  <aside class="u-bgGray u-padSides5 u-padEnds2 u-lg-padSides1 u-pullSides1 u-spaceTop4 u-posRelative u-flex FunFacts js-FunFacts">
+  <aside class="u-bgGray u-padSides5 u-padEnds2 u-lg-padSides1 u-pullSides1 u-spaceTop4 u-posRelative u-flex Slideshow js-Slideshow">
     {{#each drizzle.data.fun-facts.contents.aileen}}
-      <div class="Grid Grid--withGutter Grid--alignMiddle FunFact js-FunFact u-spaceRight5 {{#if @first}} is-visible{{/if}} u-flexExpand u-flexJustifyCenter u-sm-flexJustifyStart">
+      <div class="Grid Grid--withGutter Grid--alignMiddle Slideshow-slide js-Slideshow-slide u-spaceRight5 {{#if @first}} is-visible{{/if}} u-flexExpand u-flexJustifyCenter u-sm-flexJustifyStart">
         <div class="Grid-cell u-size1of2 u-sm-size1of4 u-lg-size1of5">
           <div class="Thumbnail Thumbnail--circle u-block">
             <img class="u-sizeFull" src="{{image}}" alt="">
@@ -74,9 +72,9 @@ stylesheets:
       </div>
     {{/each}}
 
-    <ul class="u-listInline u-spaceSides03 u-flexJustifyBetween  u-flexAlignContentCenter u-lg-flexJustifyEnd u-posAbsoluteMiddle u-lg-spaceRight2">
+    <ul class="u-listInline u-spaceSides03 u-flexJustifyBetween  u-flexAlignContentCenter u-lg-flexJustifyEnd u-posAbsoluteCenter u-lg-spaceRight2">
       <li class="u-spaceLeft05">
-        <a class="u-linkClean js-FunFact-prev" href="">
+        <a class="u-linkClean js-Slideshow-prev" href="">
           <span class="u-hiddenVisually">Previous Fun Fact</span>
           <svg viewBox="0 0 24 24" class="Icon u-textGrow3" role="presentation">
             <circle r="12" cx="12" cy="12" fill="#fff"/>
@@ -87,12 +85,12 @@ stylesheets:
       <li>
         <span class="u-hiddenVisually u-lg-unhideVisually u-lg-inlineBlock u-textShrink1">
           <span class="u-hiddenVisually">Current Fun Fact:</span>
-          <span class="js-FunFact-current">1</span> of
-          <span class="js-FunFact-total"></span>
+          <span class="js-Slideshow-current">1</span> of
+          <span class="js-Slideshow-total"></span>
         </span>
       </li>
       <li>
-        <a class="u-linkClean js-FunFact-next" href="">
+        <a class="u-linkClean js-Slideshow-next" href="">
           <span class="u-hiddenVisually">Next Fun Fact</span>
           <svg viewBox="0 0 24 24" class="Icon u-textGrow3" role="presentation">
             <circle r="12" cx="12" cy="12" fill="#fff"/>
@@ -102,6 +100,7 @@ stylesheets:
       </li>
     </ul>
   </aside>
+
 </div>
 
 

--- a/src/pages/pages/team-single.hbs
+++ b/src/pages/pages/team-single.hbs
@@ -57,50 +57,8 @@ notes: |
 
 {{! Fun Facts }}
 <div class="u-md-size2of3">
-  <aside class="u-bgGray u-padSides5 u-padEnds2 u-lg-padSides1 u-pullSides1 u-spaceTop4 u-posRelative u-flex Slideshow js-Slideshow">
-    {{#each drizzle.data.fun-facts.contents.aileen}}
-      <div class="Grid Grid--withGutter Grid--alignMiddle Slideshow-slide js-Slideshow-slide u-spaceRight5 {{#if @first}} is-visible{{/if}} u-flexExpand u-flexJustifyCenter u-sm-flexJustifyStart">
-        <div class="Grid-cell u-size1of2 u-sm-size1of4 u-lg-size1of5">
-          <div class="Thumbnail Thumbnail--circle u-block">
-            <img class="u-sizeFull" src="{{image}}" alt="">
-          </div>
-        </div>
-        <div class="Grid-cell u-sm-size3of4 u-lg-size1of2 u-spaceItems06 u-textCenter u-sm-textLeft u-spaceTop01 u-sm-spaceTopNone">
-          <h4 class="u-md-textGrow1">Did you know&hellip;?</h4>
-          <p>{{fact}}</p>
-        </div>
-      </div>
-    {{/each}}
-
-    <ul class="u-listInline u-spaceSides03 u-flexJustifyBetween  u-flexAlignContentCenter u-lg-flexJustifyEnd u-posAbsoluteCenter u-lg-spaceRight2">
-      <li class="u-spaceLeft05">
-        <a class="u-linkClean js-Slideshow-prev" href="">
-          <span class="u-hiddenVisually">Previous Fun Fact</span>
-          <svg viewBox="0 0 24 24" class="Icon u-textGrow3" role="presentation">
-            <circle r="12" cx="12" cy="12" fill="#fff"/>
-            {{svg "icons/arrow-left" width="12" height="12" x="6" y="6"}}
-          </svg>
-        </a>
-      </li>
-      <li>
-        <span class="u-hiddenVisually u-lg-unhideVisually u-lg-inlineBlock u-textShrink1">
-          <span class="u-hiddenVisually">Current Fun Fact:</span>
-          <span class="js-Slideshow-current">1</span> of
-          <span class="js-Slideshow-total"></span>
-        </span>
-      </li>
-      <li>
-        <a class="u-linkClean js-Slideshow-next" href="">
-          <span class="u-hiddenVisually">Next Fun Fact</span>
-          <svg viewBox="0 0 24 24" class="Icon u-textGrow3" role="presentation">
-            <circle r="12" cx="12" cy="12" fill="#fff"/>
-            {{svg "icons/arrow-right" width="12" height="12" x="6" y="6"}}
-          </svg>
-        </a>
-      </li>
-    </ul>
-  </aside>
-
+  {{#embed "patterns.components.slideshow.base" }}
+  {{/embed}}
 </div>
 
 

--- a/src/patterns/components/slideshow/base.hbs
+++ b/src/patterns/components/slideshow/base.hbs
@@ -1,17 +1,19 @@
-<div class="u-bgGray u-padSides5 u-padEnds2 u-lg-padSides1 u-pullSides1 u-spaceTop4 u-posRelative u-flex Slideshow js-Slideshow">
-  {{#each drizzle.data.fun-facts.contents.aileen}}
-    <div class="Grid Grid--withGutter Grid--alignMiddle Slideshow-slide js-Slideshow-slide u-spaceRight5 {{#if @first}} is-visible{{/if}} u-flexExpand u-flexJustifyCenter u-sm-flexJustifyStart">
-      <div class="Grid-cell u-size1of2 u-sm-size1of4 u-lg-size1of5">
-        <div class="Thumbnail Thumbnail--circle u-block">
-          <img class="u-sizeFull" src="{{image}}" alt="">
+<div class="u-bgGray u-posRelative Slideshow js-Slideshow u-pullSides1">
+  <ul class="u-flex u-listUnstyled Slideshow-slides js-Slideshow-slides u-padEnds2">
+    {{#each drizzle.data.fun-facts.contents.aileen}}  
+      <li class="Grid Grid--withGutter Grid--alignMiddle Slideshow-slide js-Slideshow-slide u-flexExpand u-flexJustifyCenter u-sm-flexJustifyStart u-padSides5 {{#if @first}}is-visible{{/if}}">
+        <div class="Grid-cell u-size1of2 u-sm-size1of4 u-lg-size1of5">
+          <div class="Thumbnail Thumbnail--circle u-block">
+            <img class="u-sizeFull" src="{{image}}" alt="">
+          </div>
         </div>
-      </div>
-      <div class="Grid-cell u-sm-size3of4 u-lg-size1of2 u-spaceItems06 u-textCenter u-sm-textLeft u-spaceTop01 u-sm-spaceTopNone">
-        <h4 class="u-md-textGrow1">Did you know&hellip;?</h4>
-        <p>{{fact}}</p>
-      </div>
-    </div>
-  {{/each}}
+        <div class="Grid-cell u-sm-size3of4 u-lg-size1of2 u-spaceItems06 u-textCenter u-sm-textLeft u-spaceTop01 u-sm-spaceTopNone">
+          <h4 class="u-md-textGrow1">Did you know&hellip;?</h4>
+          <p>{{fact}}</p>
+        </div>
+      </li>
+    {{/each}}
+  </ul>
 
   <ul class="u-listInline u-spaceSides03 u-flexJustifyBetween  u-flexAlignContentCenter u-lg-flexJustifyEnd u-posAbsoluteMiddle u-lg-spaceRight2">
     <li class="u-spaceLeft05">

--- a/src/patterns/components/slideshow/base.hbs
+++ b/src/patterns/components/slideshow/base.hbs
@@ -1,0 +1,43 @@
+<div class="u-bgGray u-padSides5 u-padEnds2 u-lg-padSides1 u-pullSides1 u-spaceTop4 u-posRelative u-flex Slideshow js-Slideshow">
+  {{#each drizzle.data.fun-facts.contents.aileen}}
+    <div class="Grid Grid--withGutter Grid--alignMiddle Slideshow-slide js-Slideshow-slide u-spaceRight5 {{#if @first}} is-visible{{/if}} u-flexExpand u-flexJustifyCenter u-sm-flexJustifyStart">
+      <div class="Grid-cell u-size1of2 u-sm-size1of4 u-lg-size1of5">
+        <div class="Thumbnail Thumbnail--circle u-block">
+          <img class="u-sizeFull" src="{{image}}" alt="">
+        </div>
+      </div>
+      <div class="Grid-cell u-sm-size3of4 u-lg-size1of2 u-spaceItems06 u-textCenter u-sm-textLeft u-spaceTop01 u-sm-spaceTopNone">
+        <h4 class="u-md-textGrow1">Did you know&hellip;?</h4>
+        <p>{{fact}}</p>
+      </div>
+    </div>
+  {{/each}}
+
+  <ul class="u-listInline u-spaceSides03 u-flexJustifyBetween  u-flexAlignContentCenter u-lg-flexJustifyEnd u-posAbsoluteMiddle u-lg-spaceRight2">
+    <li class="u-spaceLeft05">
+      <a class="u-linkClean js-Slideshow-prev" href="">
+        <span class="u-hiddenVisually">Previous Fun Fact</span>
+        <svg viewBox="0 0 24 24" class="Icon u-textGrow3" role="presentation">
+          <circle r="12" cx="12" cy="12" fill="#fff"/>
+          {{svg "icons/arrow-left" width="12" height="12" x="6" y="6"}}
+        </svg>
+      </a>
+    </li>
+    <li>
+      <span class="u-hiddenVisually u-lg-unhideVisually u-lg-inlineBlock u-textShrink1">
+        <span class="u-hiddenVisually">Current Fun Fact:</span>
+        <span class="js-Slideshow-current">1</span> of
+        <span class="js-Slideshow-total"></span>
+      </span>
+    </li>
+    <li>
+      <a class="u-linkClean js-Slideshow-next" href="">
+        <span class="u-hiddenVisually">Next Fun Fact</span>
+        <svg viewBox="0 0 24 24" class="Icon u-textGrow3" role="presentation">
+          <circle r="12" cx="12" cy="12" fill="#fff"/>
+          {{svg "icons/arrow-right" width="12" height="12" x="6" y="6"}}
+        </svg>
+      </a>
+    </li>
+  </ul>
+</div>


### PR DESCRIPTION
This isn't quite ready for a PR, but I wanted to get opinions on a couple different options for the slideshow animation:

Currently, adding a `slide-forward` or `slide-back` class to the parent `ul` triggers an animation on the element. For each click forward or back, the above classes are removed, and then re-added depending on the direction. If the class ends up being the same, it is not read as a change, since the end result is the same, and the animation does not run again.

I found a few ways around this, and tried out a couple of these that seemed the least offensive.

One is to trigger a reflow by checking the element's width. (this is what is currently in place)

The other is to alternate the class names being added, with the alternate class name running an identical animation under a different name. (this is present but commented out currently)

So, the question is: is it better to reflow, or have some bloat in the CSS? (we could use mixins to make it maintainable, but still adds bloat to the final output) Or, something else altogether?

I got ideas from [this article](https://css-tricks.com/restart-css-animation/).

NOTE: You can ignore `slideshow1.js`. This is an alternate version I was working that didn't come to fruition. I'll remove it before final PR.

cc @tylersticka @erikjung @mrgerardorodriguez 
