### PR TITLE
Move base iframe styles to FlexEmbed component

### DIFF
--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -79,8 +79,3 @@ pre {
 img {
   max-width: 100%;
 }
-
-iframe {
-  width: 100%;
-  height: 100%;
-}

--- a/src/assets/toolkit/styles/components/flex-embed.css
+++ b/src/assets/toolkit/styles/components/flex-embed.css
@@ -1,1 +1,10 @@
 @import "suitcss-components-flex-embed";
+
+/**
+ * Nested iframes should fill their container
+ */
+
+.FlexEmbed-content > iframe {
+  height: 100%;
+  width: 100%;
+}


### PR DESCRIPTION
Allows other iframe embeds to continue to manage their own size and aspect ratio.

## Before

<img width="872" alt="screen shot 2016-07-25 at 11 32 00 am" src="https://cloud.githubusercontent.com/assets/69633/17112636/b41e5e20-525b-11e6-9bd6-10c0190f229b.png">

## After

<img width="774" alt="screen shot 2016-07-25 at 12 32 33 pm" src="https://cloud.githubusercontent.com/assets/69633/17114469/efcfd05e-5263-11e6-97ec-e3a939533cb6.png">

---

@mrgerardorodriguez @saralohr @erikjung 

Fixes #338 

Related: #285 #281