### PR TITLE
Omit color from a > code

### DIFF
--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -63,7 +63,7 @@ pre {
   overflow: auto;
 }
 
-*:not(pre) > code {
+*:not(pre, a) > code {
   color: var(--color-fuchsia);
 }
 


### PR DESCRIPTION
Makes these links feel a bit more intentional and seamless.

## Before

<img width="788" alt="screen shot 2016-07-25 at 12 44 23 pm" src="https://cloud.githubusercontent.com/assets/69633/17114889/c405712a-5265-11e6-9281-853e4e1abfa8.png">

## After

<img width="783" alt="screen shot 2016-07-25 at 12 44 09 pm" src="https://cloud.githubusercontent.com/assets/69633/17114885/c0526f38-5265-11e6-89cd-6d79c5442c04.png">

---

@erikjung @saralohr @mrgerardorodriguez 

Fixes #339