### PR TITLE
Remove eventName override for elastic textareas

### DIFF
--- a/src/assets/toolkit/scripts/toolkit.js
+++ b/src/assets/toolkit/scripts/toolkit.js
@@ -42,9 +42,7 @@ import 'prismjs/components/prism-scss';
   });
 
   u('.js-ElasticTextarea').map(element => {
-    new ElasticTextarea(element, {
-      eventName: 'keyup'
-    });
+    new ElasticTextarea(element);
   });
 
   var replyFormTemplate = document.getElementById('comment-replyForm-template');


### PR DESCRIPTION
The `input` event is extremely well-supported. Opera Mini is the only modern browser that doesn’t support it, but `keyup` won’t work as a fallback, so it’s unnecessary. Unlike the `FloatLabel` component, there is no perceivably UX degradation if the event fails to fire.

---

@mrgerardorodriguez @erikjung @saralohr 

Fixes #344