### PR TITLE
Add u-scrollX utility, simplify Table component

### DIFF
--- a/src/assets/toolkit/styles/components/table.css
+++ b/src/assets/toolkit/styles/components/table.css
@@ -10,8 +10,6 @@
 
 .Table {
   width: 100%;
-  display: block;
-  overflow-x: auto;
 }
 
 .Table :matches(th, td) {

--- a/src/assets/toolkit/styles/utils/index.css
+++ b/src/assets/toolkit/styles/utils/index.css
@@ -8,6 +8,7 @@
 @import "./link.css";
 @import "./list.css";
 @import "./offset.css";
+@import "./scroll.css";
 @import "./size.css";
 @import "./space.css";
 @import "./position.css";

--- a/src/assets/toolkit/styles/utils/scroll.css
+++ b/src/assets/toolkit/styles/utils/scroll.css
@@ -1,0 +1,9 @@
+/**
+ * Horizontal overflow scrolling
+ */
+
+.u-scrollX {
+  max-width: 100% !important;
+  overflow-x: auto !important;
+  -webkit-overflow-scrolling: touch;
+}

--- a/src/patterns/utilities/scroll.hbs
+++ b/src/patterns/utilities/scroll.hbs
@@ -1,0 +1,28 @@
+---
+name: Scroll
+notes: |
+  Utility for preventing horizontal overflow while allowing a scrollbar to
+  still access the overflowing content. Works well for wrapping tables with
+  a lot of columns.
+---
+
+<div class="u-scrollX">
+  <table class="Table Table--ruled">
+    <thead>
+      <tr>
+        {{#iterate 15}}
+          <th>{{capitalize (random "word")}}</th>
+        {{/iterate}}
+      </tr>
+    </thead>
+    <tbody>
+      {{#iterate 3}}
+        <tr>
+          {{#iterate 15}}
+            <td>{{random "word"}}</td>
+          {{/iterate}}
+        </tr>
+      {{/iterate}}
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
Our technique for overflow scrolling of tables meant tables no longer honored `width: 100%`.

As @saralohr mentioned in her issue (#359), we really only had two options... a container with `overflow-x: auto;` or some sort of modifier on the element itself.

I started by creating a modifier, but the point at which overflow-scrolling should apply seemed entirely dependent on the content. The only good way to do it would be to create breakpoint-specific iterations of the modifier, which seemed like overkill when a single, wrapping utility would serve the same purpose.

![u-scrollx](https://cloud.githubusercontent.com/assets/69633/17419766/be16f428-5a53-11e6-925f-28a1ea60da2f.gif)

---

@saralohr @erikjung @mrgerardorodriguez 

Fixes #359