### PR TITLE
Fix attachment icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 npm-debug.log
+.svgsus

--- a/src/static/images/icons/attachment.svg
+++ b/src/static/images/icons/attachment.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" width="24" height="24">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
   <path d="M5.7,16.89L14.18,8.4A2,2,0,0,1,17,8.4h0a2,2,0,0,1,0,2.83L8.17,20.07a4,4,0,0,1-5.66,0h0a4,4,0,0,1,0-5.66l9.9-9.9a6,6,0,0,1,8.49,0h0a6,6,0,0,1,0,8.49l-6.72,6.72" fill="none" stroke="currentColor" stroke-width="2"/>
 </svg>


### PR DESCRIPTION
This PR removes a duplicate `width` and `height` attribute from the attachment icon, which was making this SVG invalid.

It also adds `.svgsus`' icon set preference file to the `.gitignore`, because that's how I found this issue.

---

@saralohr @nicolemors @erikjung @gerardo-rodriguez 