### PR TITLE
[WIP] Breakup font-family styles

### DIFF
--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -112,8 +112,10 @@
   --font-size-lg: calc(var(--ms2) * 1em);
   --font-size-xl: calc(var(--ms3) * 1em);
 
-  --font-family-default: "Source Sans Pro", Tahoma, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --font-family-mono: "Source Code Pro", Monaco, Consolas, "Lucida Console", "Andale Mono", monospace;
+  --font-family-default-fallbacks: Tahoma, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-family-default: "Source Sans Pro", var(--font-family-default-fallbacks);
+  --font-family-mono-fallbacks: Monaco, Consolas, "Lucida Console", "Andale Mono", monospace;
+  --font-family-mono: "Source Code Pro", var(--font-family-mono-fallbacks);
 
   --font-weight-normal: 400;
   --font-weight-semibold: 600;
@@ -148,8 +150,14 @@
 :root {
   --base-background: var(--color-gray);
   --base-color: var(--color-black);
-  --base-font: var(--font-size-sm)/var(--line-height-md) var(--font-family-default);
+  --base-font-size: var(--font-size-sm);
+  --base-line-height: var(--line-height-md);
+  --base-font-family: var(--font-family-default-fallbacks);
   --base-margin: var(--space-md);
+}
+
+:root {
+  --body-font-family: var(--font-family-default);
 }
 
 /**

--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -112,10 +112,8 @@
   --font-size-lg: calc(var(--ms2) * 1em);
   --font-size-xl: calc(var(--ms3) * 1em);
 
-  --font-family-default-fallbacks: Tahoma, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --font-family-default: "Source Sans Pro", var(--font-family-default-fallbacks);
-  --font-family-mono-fallbacks: Monaco, Consolas, "Lucida Console", "Andale Mono", monospace;
-  --font-family-mono: "Source Code Pro", var(--font-family-mono-fallbacks);
+  --font-family-default: "Source Sans Pro", Tahoma, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-family-mono: "Source Code Pro", Monaco, Consolas, "Lucida Console", "Andale Mono", monospace;
 
   --font-weight-normal: 400;
   --font-weight-semibold: 600;
@@ -126,7 +124,8 @@
   --line-height-md: var(--ms2);
   --line-height-lg: var(--ms3);
 
-  --heading-font: var(--font-weight-bold) var(--font-size-sm) var(--font-family-default);
+  --heading-font-weight: var(--font-weight-bold);
+  --heading-font-size: var(--font-size-sm);
 
   --code-font: var(--font-size-sm) var(--font-family-mono);
 }
@@ -152,12 +151,8 @@
   --base-color: var(--color-black);
   --base-font-size: var(--font-size-sm);
   --base-line-height: var(--line-height-md);
-  --base-font-family: var(--font-family-default-fallbacks);
+  --base-font-family: var(--font-family-default);
   --base-margin: var(--space-md);
-}
-
-:root {
-  --body-font-family: var(--font-family-default);
 }
 
 /**

--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -31,7 +31,7 @@ body {
  * See https://www.filamentgroup.com/lab/font-events.html
  */
 .fonts-loaded body {
-  font-family: var(--body-font-family);
+  font-family: var(--base-font-family);
 }
 
 /**
@@ -39,7 +39,8 @@ body {
  */
 
 :--headings {
-  font: var(--heading-font);
+  font-weight: var(--heading-font-weight);
+  font-size: var(--heading-font-size);
 }
 
 /**

--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -17,9 +17,21 @@
  */
 
 body {
-  font: var(--base-font); /* 1 */
+  font-size: var(--base-font-size); /* 1 */
+  line-height: var(--base-line-height); /* 1 */
   word-wrap: break-word; /* 2 */
   text-size-adjust: none; /* 3 */
+}
+
+/**
+ * FOUT control. This class is added once fonts are loaded to prevent
+ * the double-FOUT that can occur from setting font styles prior to loading
+ * the target font.
+ *
+ * See https://www.filamentgroup.com/lab/font-events.html
+ */
+.fonts-loaded body {
+  font-family: var(--body-font-family);
 }
 
 /**

--- a/src/templates/default.hbs
+++ b/src/templates/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="{{htmlclass}}">
+<html class="{{htmlclass}} fonts-loaded">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Related to: https://github.com/cloudfour/cloudfour.com-wp/pull/332

This changes the way `font-family` is applied to the body. Instead of setting our webfont (`Source Sans Pro`) on the `body` by default, we now require a `.fonts-loaded` class to be applied on a parent (`<html>`).

The reasoning behind this can be read here: https://www.filamentgroup.com/lab/font-events.html

It's related to the FOUT + FOIT that occurs when the browser is applying CSS and encounters an element trying to use a font defined by `@font-face`. By default, the font `url(...)` will be downloaded only when first needed: as soon as an element with `font-family: Source Sans Pro` is found. This can result in the following sequence:

0. FOUT when page is loading, prior to the `@font-face` definitions
0. FOIT after the `@font-face` definitions, when a font is needed to render but has yet to load
0. Expected font presentation

By making it so that a class must be added in order to apply the `font-family`, the sequence can instead be simplified to:

0. FOUT when page is loading, prior to the `@font-face` definitions
0. Expected font presentation, after dynamically loading the fonts with JS and adding the `fonts-loaded` class.

### Pros
- We can make the initial paint time a bit faster by deferring the loading of our `@font-face` CSS from Google.
- We can eliminate the secondary FOIT by manually loading the font and applying the `font-family` rule only after the associated font is loaded (and there should be no initial FOUT either after the fonts are cached).

### Cons 
- We need JS to apply our webfonts (similar to with TypeKit)
- More complexity in both JS and CSS

Thoughts?