### PR TITLE
Update patterns `manifest.json`

### DIFF
--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -18,5 +18,6 @@
   "background_color": "#FFFFFF",
   "display": "browser",
   "orientation": "natural",
-  "start_url": "/"
+  "start_url": "/",
+  "gcm_sender_id": "482941778795"
 }


### PR DESCRIPTION
This PR updates the `manifest.json` file as it was [accidentally updated](https://github.com/cloudfour/cloudfour.com-wp/pull/338) in the wrong repo. This adds the GCM Sender ID needed for the web push notifications to work on Chrome.

FWIW, this has happened in the past: https://github.com/cloudfour/cloudfour.com-patterns/pull/325

---

cc: @nicolemors @tylersticka @erikjung 