### PR TITLE
Update `suitcss-utils-size` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "suitcss-utils-link": "^1.0.1",
     "suitcss-utils-offset": "^1.0.0",
     "suitcss-utils-position": "^1.0.1",
-    "suitcss-utils-size": "^1.0.2",
+    "suitcss-utils-size": "^2.0.0",
     "suitcss-utils-text": "^1.0.0",
     "umbrellajs": "^2.6.4"
   },


### PR DESCRIPTION
In the process of working in @nicolemors' work for v2 of the notifications UI, I found that we needed to be running the latest version, `2.0.0`, of the `suitcss-utils-size` dependency. I was having a challenge applying the `u-hidden` class so I dug deeper. As it turns out, [they removed the `display` property from `u-sizeFull` in `2.0.0`](https://github.com/suitcss/utils-size/pull/36) which resolves the problem I was running into. 

In version `1.0.2`, the `u-hidden` styles would be overridden by the `u-sizeFull` styles, which was causing issues.

---

cc: @nicolemors @erikjung @tylersticka 