### PR TITLE
Fix: Gulpfile regression

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,8 @@ gulp.task('css', ['css:drizzle', 'css:toolkit']);
 
 // Register custom JS task
 gulp.task('js', () => {
-  const {rollup: baseconfig, bundles} = config.js;
+  const baseconfig = config.js.rollup;
+  const bundles = config.js.bundles;
   const rollups = bundles.map(opts => {
     const config = Object.assign({}, baseconfig, opts);
     return rollup(config).then(bundle => bundle.write(config));


### PR DESCRIPTION
Our Netlify deployments still run on Node 4, so this bit of ES2015 was breaking them.