### PR TITLE
Feature: Notifications activated/deactivate button

### DIFF
--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -36,6 +36,9 @@
   --color-orange: #f26941;
   --color-green: #35c98d;
   --color-fuchsia: #f14ca3;
+
+  /* State colors */
+  --color-red: #bf0000;
 }
 
 /**

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -211,3 +211,40 @@
 .Button--positive:active {
   background-color: color(var(--Button-positive-background-color) shade(10%));
 }
+
+/**
+ * Modifier: Notifications buttons
+ */
+
+:root {
+  --Button-notifications-color: var(--color-white);
+  --Button-activate-background-color: var(--color-green);
+  --Button-deactivate-background-color: var(--color-red);
+}
+
+.Button--notifications {
+  color: var(--Button-notifications-color);
+  border-color: color(var(--Button-activate-background-color) shade(10%));
+  background-color: var(--Button-activate-background-color);
+}
+
+.Button--notifications:matches(:--enter) {
+  border-color: color(var(--Button-deactivate-background-color) shade(10%));
+  background-color: var(--Button-deactivate-background-color);
+}
+
+.Button--notifications .Button-deactivateMessage {
+  display: none;
+}
+
+.Button--notifications:matches(:--enter) .Button-deactivateMessage {
+  display: block;
+}
+
+.Button--notifications .Button-activateMessage {
+  display: block;
+}
+
+.Button--notifications:matches(:--enter) .Button-activateMessage {
+  display: none;
+}

--- a/src/patterns/components/button/notifications.hbs
+++ b/src/patterns/components/button/notifications.hbs
@@ -4,7 +4,7 @@ notes: |
   Modifier class for the notifications activated/deactivate button.
 ---
 
-{{#embed "patterns.components.button.base" class="Button--notifications Button--positive"}}
+{{#embed "patterns.components.button.base" class="Button--notifications"}}
   {{#content "content"}}
     <span class="Button-deactivateMessage">
       {{svg "icons/close" class="Icon"}}

--- a/src/patterns/components/button/notifications.hbs
+++ b/src/patterns/components/button/notifications.hbs
@@ -1,0 +1,18 @@
+---
+name: Notifications Activated/Deactivate Button
+notes: |
+  Modifier class for the notifications activated/deactivate button.
+---
+
+{{#embed "patterns.components.button.base" class="Button--notifications Button--positive"}}
+  {{#content "content"}}
+    <span class="Button-deactivateMessage">
+      {{svg "icons/close" class="Icon"}}
+      Mute Notifications
+    </span>
+    <span class="Button-activateMessage">
+      {{svg "icons/check" class="Icon"}}
+      Notifications
+    </span>
+  {{/content}}
+{{/embed}}


### PR DESCRIPTION
## Overview

![notifications-btn](https://cloud.githubusercontent.com/assets/459757/20409778/bfa621a0-accf-11e6-9c15-5412b7c2acf7.gif)

This PR adds a button to be used with the Web Push Notifications UI. This helps make it more clear on hover that you will _mute_ notifications by clicking the button.

---

cc: @erikjung @tylersticka @nicolemors @saralohr @aileenjeffries @grigs 