### PR TITLE
Feature: Add "negative" button modifier

### DIFF
--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -36,6 +36,9 @@
   --color-orange: #f26941;
   --color-green: #35c98d;
   --color-fuchsia: #f14ca3;
+
+  /* Other colors */
+  --color-red: #bf0000;
 }
 
 /**

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -211,3 +211,27 @@
 .Button--positive:active {
   background-color: color(var(--Button-positive-background-color) shade(10%));
 }
+
+/**
+ * Modifier: negative button
+ */
+
+:root {
+  --Button-negative-background-color: var(--color-red);
+  --Button-negative-color: var(--color-white);
+}
+
+.Button--negative {
+  color: var(--Button-negative-color);
+  border-color: color(var(--Button-negative-background-color) shade(10%));
+  background-color: var(--Button-negative-background-color);
+}
+
+.Button--negative:matches(:--enter) {
+  border-color: color(var(--Button-negative-background-color) shade(5%));
+  background-color: color(var(--Button-negative-background-color) l(+5%));
+}
+
+.Button--negative:active {
+  background-color: color(var(--Button-negative-background-color) shade(10%));
+}

--- a/src/patterns/components/button/colors.hbs
+++ b/src/patterns/components/button/colors.hbs
@@ -22,3 +22,9 @@ notes: |
     Positive
   {{/content}}
 {{/embed}}
+
+{{#embed "patterns.components.button.base" class="Button--negative"}}
+  {{#content "content"}}
+    Negative
+  {{/content}}
+{{/embed}}


### PR DESCRIPTION
## Overview

Per the suggestion @erikjung made in https://github.com/cloudfour/cloudfour.com-patterns/pull/374#pullrequestreview-9134146, this PR adds a "negative" button modifier.

<img width="739" alt="screen shot 2016-11-17 at 3 14 17 pm" src="https://cloud.githubusercontent.com/assets/459757/20411931/a3a838d6-acd8-11e6-874d-83408da04bb2.png">

---

cc: @erikjung 