### PR TITLE
Feature: Plain button

### DIFF
--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -235,3 +235,25 @@
 .Button--negative:active {
   background-color: color(var(--Button-negative-background-color) shade(10%));
 }
+
+/**
+ * Modifier: plain button
+ */
+
+:root {
+  --Button-plain-color: var(--color-blue);
+}
+
+.Button--plain {
+  color: var(--Button-plain-color);
+}
+
+.Button--plain:--enter {
+  color: color(var(--Button-plain-color) l(+10%));
+  border-color: color(var(--Button-plain-color) l(+10%));
+}
+
+.Button--plain:active {
+  color: color(var(--Button-plain-color) shade(10%));
+  border-color: color(var(--Button-plain-color) shade(10%));
+}

--- a/src/patterns/components/button/colors-dark.hbs
+++ b/src/patterns/components/button/colors-dark.hbs
@@ -1,6 +1,6 @@
 ---
 name: Dark Color Modifiers
-order: 3
+order: 4
 previewClass: Sky
 notes: |
   Modifier classes specifically for dark backgrounds.

--- a/src/patterns/components/button/colors.hbs
+++ b/src/patterns/components/button/colors.hbs
@@ -1,6 +1,6 @@
 ---
 name: Color Modifiers
-order: 2
+order: 3
 notes: |
   Modifier classes can be used to apply different colors.
 ---

--- a/src/patterns/components/button/disabled.hbs
+++ b/src/patterns/components/button/disabled.hbs
@@ -1,6 +1,6 @@
 ---
 name: Disabled Button
-order: 3
+order: 5
 notes: |
   It gets disabled by way of the `[disabled]` attribute.
 ---

--- a/src/patterns/components/button/plain.hbs
+++ b/src/patterns/components/button/plain.hbs
@@ -1,0 +1,12 @@
+---
+name: Plain Button
+order: 2
+notes: |
+  Modifier class can be used for a plain, no background-color button. This modifier enhances the basic button with `:hover`, `:focus` and `:active` color changes.
+---
+
+<a class="Button Button--plain" href="#">Link</a>
+
+<button class="Button Button--plain" type="button">Button</button>
+
+<input class="Button Button--plain" type="submit" value="Input">


### PR DESCRIPTION
Re: #379 

## Overview

This PR adds a "plain" button (`Button--plain`) modifier. This modifier enhances the "basic" button by adding color changes on each of `:hover`, `:focus` & `:active` for `<a>`, `<button>` and `<input>` elements.

(The animated GIF makes it look like the `background-color` changes to a grayish color. Don't fall for the lies!!)

![plain-button](https://cloud.githubusercontent.com/assets/459757/20682944/012f53e8-b55f-11e6-9d12-891fdb1c942f.gif)

---

cc: @tylersticka @erikjung 