### PR TITLE
Chore: Update manifest.json

### DIFF
--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -15,7 +15,7 @@
     }
   ],
   "theme_color": "#456BD9",
-  "background_color": "#FFFFFF",
+  "background_color": "#456BD9",
   "display": "standalone",
   "orientation": "natural",
   "start_url": "/",


### PR DESCRIPTION
This PR updates the `manifest.json` file to  match the `background_color` used in the [`cloudfour.com-wp` repo](https://github.com/cloudfour/cloudfour.com-wp/blob/master/manifest.json#L18).

Closes #381 