### PR TITLE
Feature: Refactor button

### DIFF
--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -8,7 +8,8 @@
  */
 
 :root {
-  --Button-border-color: var(--color-relative);
+  --Button-color: var(--color-blue);
+  --Button-border-color: var(--color-blue);
   --Button-border-radius: var(--control-radius);
   --Button-border-width: var(--control-stroke);
   --Button-disabled-opacity: var(--control-disabled-opacity);
@@ -31,6 +32,7 @@
  * 7. Corrects inability to style clickable `input` types in iOS.
  */
 @define-mixin Button {
+  color: var(--Button-color);
   display: inline-block;
   box-sizing: border-box; /* 1 */
   padding: var(--Button-padding);
@@ -83,6 +85,16 @@
   &:matches(:disabled, .is-disabled) {
     opacity: var(--Button-disabled-opacity);
     cursor: default;
+  }
+
+  &:--enter {
+    color: color(var(--Button-color) l(+10%));
+    border-color: color(var(--Button-border-color) l(+10%));
+  }
+
+  &:active {
+    color: color(var(--Button-color) shade(10%));
+    border-color: color(var(--Button-border-color) shade(10%));
   }
 }
 

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -233,7 +233,8 @@
   --Button-negative-color: var(--color-white);
 }
 
-.Button--negative {
+.Button--negative,
+.Button--negative:matches(:--enter) {
   color: var(--Button-negative-color);
   border-color: color(var(--Button-negative-background-color) shade(10%));
   background-color: var(--Button-negative-background-color);


### PR DESCRIPTION
## Overview

This PR allows the `.Button` to have `:--enter`, `:active` states following _existing_ button style setup.

![button](https://cloud.githubusercontent.com/assets/459757/20846848/6a4b7522-b880-11e6-86bc-273efd2e319b.gif)

### Detail

In discussing the [open `Button` PR](https://github.com/cloudfour/cloudfour.com-patterns/pull/380) that has introduced new ideas and a possible refactor of how we style the `Button` pattern, @erikjung and I agreed that at minimum we could make the `.Button` styles have the `:--enter`/`:active` states _without_ needing to add a new modifier. 

The [open `Button` PR](https://github.com/cloudfour/cloudfour.com-patterns/pull/380) will stay open and focus on the possibility of a full `button.css` refactor. 

---

cc: @erikjung @tylersticka @saralohr 