### PR TITLE
Tweak: small CSS changes

### DIFF
--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -43,7 +43,7 @@ a {
   text-decoration: underline;
 }
 
-a:matches(:active, :focus, :hover) {
+a:matches(:active, :--enter) {
   color: var(--link-hover-color);
 }
 

--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -38,9 +38,9 @@ body {
  */
 
 a {
-  text-decoration: underline;
   color: var(--link-color);
-  -webkit-text-decoration-skip: ink;
+  text-decoration-skip: ink;
+  text-decoration: underline;
 }
 
 a:matches(:active, :focus, :hover) {

--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -91,7 +91,6 @@ abbr {
  */
 
 abbr,
-acronym,
 blockquote,
 code,
 kbd,

--- a/src/assets/toolkit/styles/components/thumbnail.css
+++ b/src/assets/toolkit/styles/components/thumbnail.css
@@ -51,7 +51,7 @@
   transition: border 300ms ease; /* 6 */
 }
 
-.Thumbnail:matches(:focus, :hover)::after {
+.Thumbnail:matches(:--enter)::after {
   border-color: color(var(--Thumbnail-border-color) a(25%));
 }
 

--- a/src/assets/toolkit/styles/sandbox/nm-nav-a.css
+++ b/src/assets/toolkit/styles/sandbox/nm-nav-a.css
@@ -109,11 +109,6 @@ body {
   transition: all 300ms ease;
 }
 
-/*.Masthead-control:matches(:--enter) {
-  color: var(--color-blue);
-  background-color: var(--color-white);
-}*/
-
 .Hero {
   background-color: var(--color-blue);
   background-image: url("/images/sandbox/clouds.svg");

--- a/src/assets/toolkit/styles/sandbox/nm-nav-a.css
+++ b/src/assets/toolkit/styles/sandbox/nm-nav-a.css
@@ -68,7 +68,7 @@ body {
   transition: background-color 300ms ease;
 }
 
-.Masthead-link:matches(:focus, :hover) {
+.Masthead-link:matches(:--enter) {
   background-color: color(var(--color-navy) a(20%));
 }
 
@@ -94,7 +94,7 @@ body {
   transition: transform 300ms easeOutCirc;
 }
 
-.Masthead-logo:matches(:focus, :hover) {
+.Masthead-logo:matches(:--enter) {
   transform: scale(1.1);
 }
 
@@ -109,7 +109,7 @@ body {
   transition: all 300ms ease;
 }
 
-/*.Masthead-control:matches(:focus, :hover) {
+/*.Masthead-control:matches(:--enter) {
   color: var(--color-blue);
   background-color: var(--color-white);
 }*/

--- a/src/assets/toolkit/styles/sandbox/tcs-nav-a.css
+++ b/src/assets/toolkit/styles/sandbox/tcs-nav-a.css
@@ -75,7 +75,7 @@ body {
   transition: background-color 300ms ease;
 }
 
-.Masthead-link:matches(:focus, :hover) {
+.Masthead-link:matches(:--enter) {
   background-color: color(var(--color-navy) a(20%));
 }
 
@@ -100,7 +100,7 @@ body {
   transition: transform 300ms easeOutCirc;
 }
 
-.Masthead-logo:matches(:focus, :hover) {
+.Masthead-logo:matches(:--enter) {
   transform: scale(1.1);
 }
 
@@ -117,7 +117,7 @@ body {
   transition: all 300ms ease;
 }
 
-.Masthead-control:matches(:focus, :hover) {
+.Masthead-control:matches(:--enter) {
   color: var(--color-blue);
   background-color: var(--color-white);
 }

--- a/src/assets/toolkit/styles/utils/link.css
+++ b/src/assets/toolkit/styles/utils/link.css
@@ -4,8 +4,8 @@
   color: var(--color-blue);
 }
 
-.u-linkBlock:matches(:active, :focus, :hover) .u-linkTarget,
-.u-linkClean:matches(:active, :focus, :hover) .u-linkTarget {
+.u-linkBlock:matches(:active, :--enter) .u-linkTarget,
+.u-linkClean:matches(:active, :--enter) .u-linkTarget {
   color: var(--link-hover-color);
 }
 
@@ -13,6 +13,9 @@
   text-decoration: none;
 }
 
-.u-linkEnter:not(:focus, :hover) {
+/**
+ * :--enter when combined with :not() misbehaves, so it is not used here.
+ */
+.u-linkEnter:not(:hover, :focus) {
   color: var(--color-relative);
 }


### PR DESCRIPTION
The purpose of this was to just unprefix `text-decoration-skip`, but a few other tweaks made it in.