### PR TITLE
Add a11y contrast variations of blue, fuchsia

### DIFF
--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -39,6 +39,10 @@
 
   /* Other colors */
   --color-red: #bf0000;
+
+  /* a11y variations for light-on-dark text contrast */
+  --color-blue-a11y: color(var(--color-blue) l(-4%));
+  --color-fuchsia-a11y: color(var(--color-fuchsia) l(-14%) s(-5%));
 }
 
 /**
@@ -160,7 +164,7 @@
  */
 
 :root {
-  --link-color: var(--color-blue);
+  --link-color: var(--color-blue-a11y);
   --link-hover-color: color(var(--link-color) l(+10%));
 }
 

--- a/src/assets/toolkit/styles/base/base.css
+++ b/src/assets/toolkit/styles/base/base.css
@@ -64,7 +64,7 @@ pre {
 }
 
 *:not(pre, a) > code {
-  color: var(--color-fuchsia);
+  color: var(--color-fuchsia-a11y);
 }
 
 pre {


### PR DESCRIPTION
Resolves an issue where `<a>` and `<code>` sometimes failed to meet WCAG 2 AA contrast ratio thresholds.

I chose to create variations of our base color palette variables because changing the root colors caused a pretty dramatic change in appearance, most noticeably to elements that _didn't_ have contrast problems. My hope is by limiting the color changes to dark text only, it'll make the difference imperceptible to the average viewer.

It does not address contrast issues in the following scenarios:

- Orange buttons and message containers with white text. These only fail contrast ratio checks at the smallest sizes, and the only solution appears to be to adopt more of a _brown_ color... no small change to the color made a dent in the warnings. I find this _really_ peculiar... why would `18px` text pass without changes, but `16px` fails unless a _dramatic_ color shift occurs?
- Label elements in our `FloatLabel` pattern. Any darker and they could be easily mistaken for actual text, which defeats the purpose entirely. We'd be better off [abandoning the pattern](https://www.nngroup.com/articles/form-design-placeholders/).

I went and compared our contrast warnings to a few competitors I admire (using [aXe](https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US), since tota11y appears to be abandoned), and with this change we'll show far fewer warnings per page at small viewport sizes than any of those I inspected. I feel confident we've gone above and beyond most of our peers in this space.

## Before

![screen shot 2017-03-22 at 1 40 36 pm](https://cloud.githubusercontent.com/assets/69633/24220435/77c5f05a-0f07-11e7-942c-7c49870cb8b4.png)

![screen shot 2017-03-22 at 1 42 38 pm](https://cloud.githubusercontent.com/assets/69633/24220447/7b54944c-0f07-11e7-9823-c6b479cd10e0.png)

## After

![screen shot 2017-03-22 at 1 40 27 pm](https://cloud.githubusercontent.com/assets/69633/24220455/8653deac-0f07-11e7-96d3-3e1efff61069.png)

![screen shot 2017-03-22 at 1 42 46 pm](https://cloud.githubusercontent.com/assets/69633/24220459/8aec4bca-0f07-11e7-8bf0-5e27aaf05295.png)

---

@grigs @erikjung @gerardo-rodriguez @aileenjeffries @saralohr 

See #369