### PR TITLE
Fix message alignment

### DIFF
--- a/src/assets/toolkit/styles/components/icon.css
+++ b/src/assets/toolkit/styles/components/icon.css
@@ -12,11 +12,8 @@
 }
 
 /**
- * 1. Because vertical alignment is funny, icons always appear about a pixel too
- *    low when they're the same height as the current `font-size`. Using `top`
- *    frees up `margin-top` for adjustments we'll be applying to modifiers.
- * 2. Base dimensions on the current `font-size` for leaner adjustments.
- * 3. Fill with the current text color by default. May be overridden by icon
+ * 1. Base dimensions on the current `font-size` for leaner adjustments.
+ * 2. Fill with the current text color by default. May be overridden by icon
  *    asset SVG attributes.
  */
 .Icon {
@@ -25,9 +22,9 @@
   display: inline-block;
   width: 1em;
   height: 1em;
-  font-size: var(--Icon-size); /* 2 */
+  font-size: var(--Icon-size); /* 1 */
   vertical-align: middle;
-  fill: currentColor; /* 3 */
+  fill: currentColor; /* 2 */
 }
 
 /**

--- a/src/assets/toolkit/styles/components/icon.css
+++ b/src/assets/toolkit/styles/components/icon.css
@@ -21,7 +21,6 @@
  */
 .Icon {
   position: relative;
-  top: -1px; /* 1 */
   margin: 0;
   display: inline-block;
   width: 1em;
@@ -32,13 +31,29 @@
 }
 
 /**
- * 1. Negative vertical margins prevent the icon from disrupting the surrounding
- *    content's `line-height`.
- * 2. Actual size adjustment occurs via `font-size`.
+ * Because vertical alignment is funny, icons always appear about a pixel too
+ * low when they're the same height as the current `font-size`. Using `top`
+ * frees up `margin-top` for adjustments we'll be applying to modifiers.
+ */
+
+.Icon:not(.Icon--block) {
+  top: -1px;
+}
+
+/**
+ * Actual size adjustment occurs via `font-size`.
  */
 
 .Icon--large {
-  margin-top: var(--Icon-line-height-offset); /* 1 */
+  font-size: var(--Icon-size-lg);
+}
+
+/**
+ * Negative vertical margins prevent the icon from disrupting the surrounding
+ * content's `line-height`.
+ */
+
+.Icon--large:not(.Icon--block) {
   margin-bottom: var(--Icon-line-height-offset); /* 1 */
-  font-size: var(--Icon-size-lg); /* 2 */
+  margin-top: var(--Icon-line-height-offset); /* 1 */
 }

--- a/src/assets/toolkit/styles/components/message.css
+++ b/src/assets/toolkit/styles/components/message.css
@@ -1,29 +1,51 @@
 /** @define Message */
 
 :root {
-  --Message-padding: var(--space-xs);
   --Message-background: var(--color-gray);
-  --Message-warning-background: var(--color-orange);
-  --Message-warning-color: var(--color-white);
+  --Message-background-warning: var(--color-orange);
+  --Message-color-warning: var(--color-white);
+  --Message-padding: var(--space-xs);
 }
+
+/**
+ * 1. Display message and close button in a centered row.
+ * 2. Push message and close button as far apart as possible.
+ * 3. Condense line height in case it breaks to multiple lines.
+ */
 
 .Message {
-  display: flex;
-  padding: var(--Message-padding);
+  align-items: center; /* 1 */
   background: var(--Message-background);
-  justify-content: space-between;
-}
-
-.Message a {
-  color: inherit;
-}
-
-.Message-close {
-  color: inherit;
-  cursor: pointer;
+  display: flex; /* 1, 2 */
+  justify-content: space-between; /* 2 */
+  line-height: var(--line-height-sm); /* 3 */
+  padding: var(--Message-padding);
 }
 
 .Message--warning {
-  background: var(--Message-warning-background);
-  color: var(--Message-warning-color);
+  background: var(--Message-background-warning);
+  color: var(--Message-color-warning);
+}
+
+/**
+ * Inherit parent text color for links when blue is hideous against background.
+ */
+
+.Message--warning a {
+  color: inherit;
+}
+
+/**
+ * 1. Close icon should be the same color as the parent text color.
+ * 2. Easy way to collapse extra whitespace between button edge and icon.
+ * 3. Make icon a little larger than the parent text size.
+ * 4. Put some space between message and close button.
+ */
+
+.Message-close {
+  color: inherit; /* 1 */
+  cursor: pointer;
+  display: flex; /* 2 */
+  font-size: var(--font-size-md); /* 3 */
+  margin-left: var(--space-sm); /* 4 */
 }

--- a/src/patterns/components/icon/block.hbs
+++ b/src/patterns/components/icon/block.hbs
@@ -1,0 +1,26 @@
+---
+name: Block Modifier
+notes: |
+  The `Icon--block` class will omit any `line-height` adjustments and set the
+  icon's `display` to `block`. This is useful if you plan on composing the icon
+  using Flexbox, Grid or absolute positioning.
+previewClass: u-spaceItems1
+sourceless: true
+---
+
+<div class="u-borderMd">
+  {{svg "icons/reply" class="Icon"}}
+  Aligned normally
+</div>
+<div class="u-flex u-flexAlignItemsCenter u-borderMd">
+  {{svg "icons/reply" class="Icon u-spaceRight06"}}
+  <div>
+    Aligned with Flexbox alone
+  </div>
+</div>
+<div class="u-flex u-flexAlignItemsCenter u-borderMd">
+  {{svg "icons/reply" class="Icon Icon--block u-spaceRight06"}}
+  <div>
+    Aligned with <code>Icon--block</code> and Flexbox
+  </div>
+</div>

--- a/src/patterns/components/message/overview.hbs
+++ b/src/patterns/components/message/overview.hbs
@@ -9,8 +9,8 @@ notes: |
     <p>Hi, I'm a message!</p>
   {{/block}}
   {{#if includeClose}}
-    <button class="Message-close">
-      {{#svg "icons/close" aria-labelledby=(defaultTo closeIconTitle "Message-close-title")}}
+    <button class="Message-close" type="button">
+      {{#svg "icons/close" class="Icon Icon--block" aria-labelledby=(defaultTo closeIconTitle "Message-close-title")}}
         <title id="{{defaultTo closeIconTitle "Message-close-title"}}">Close</title>
       {{/svg}}
     </button>


### PR DESCRIPTION
This tweaks the `Message` pattern so that its alignment is consistent as the base `font-size` changes.

There were two reasons this was happening. First, there was whitespace between the `Message-close` element and the SVG within. And second, this problem was worse at some sizes more than others because the icon was being sized as `24px` regardless, but everything around it was changing, which is why some resolutions were more symptomatic than others.

To change this, I borrowed an `Icon--block` modifier technique from our other recent projects so we can piggy-back on the `Icon` class and its built-in sizing logic. Then, I just made `Message-close` use `display: flex;` so its content wouldn't flow as text.

I also fixed some issues I saw with `line-height` and space between the "close" button and the text.

**Note:** To get the new icon sizing on the server, the markup will need to be updated to include the `Icon Icon--block` class on the close button. That said, alignment will still be improved even without that change, and nothing will appear overtly broken with _only_ styles applied, so everything should be A-OK.

## Before

![screen shot 2017-03-22 at 2 56 43 pm](https://cloud.githubusercontent.com/assets/69633/24222603/d72c53a6-0f0f-11e7-9b07-7df2a1322122.png)

![screen shot 2017-03-22 at 2 49 59 pm](https://cloud.githubusercontent.com/assets/69633/24222431/49df098a-0f0f-11e7-8ce7-4d8dbb79c30e.png)

## After

![screen shot 2017-03-22 at 2 56 58 pm](https://cloud.githubusercontent.com/assets/69633/24222606/daac0bca-0f0f-11e7-84c1-580d1703575b.png)

![screen shot 2017-03-22 at 2 49 44 pm](https://cloud.githubusercontent.com/assets/69633/24222435/4e60a3ec-0f0f-11e7-8397-aaa73d5e393e.png)

---

@aileenjeffries @saralohr @erikjung @gerardo-rodriguez 

See: #385 