### PR TITLE
Revised blockquotes

### DIFF
--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -174,6 +174,34 @@ blockquote {
   padding-left: var(--base-margin);
 }
 
+/**
+ * Make sure items are still spaced apart, using `margin-bottom` so inline
+ * elements won't run up against their preceding sibling.
+ */
+
+blockquote > *:not(:last-child) {
+  margin-bottom: var(--base-margin);
+}
+
+/**
+ * Make the last paragraph that's a direct descendent and an adjacent footer
+ * (if any) inline so that they'll run together all fancy-like. 🎩
+ */
+
+blockquote > p:last-of-type,
+blockquote > p:last-of-type + footer {
+  display: inline;
+}
+
+/**
+ * If the last paragraph's adjacent sibling is *not* a footer, give it a margin
+ * top to compensate for the paragraph's inline-edness.
+ */
+
+blockquote > p:last-of-type + *:not(footer) {
+  margin-top: var(--base-margin);
+}
+
 blockquote cite {
   font-style: normal;
 }

--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -170,16 +170,8 @@ hr {
  */
 
 blockquote {
-  padding-left: var(--space-md);
   font-style: italic;
-}
-
-blockquote p {
-  margin-bottom: var(--base-margin);
-}
-
-blockquote :matches(p:last-of-type, footer) {
-  display: inline;
+  padding-left: var(--base-margin);
 }
 
 blockquote cite {

--- a/src/assets/toolkit/styles/components/cms-content.css
+++ b/src/assets/toolkit/styles/components/cms-content.css
@@ -17,7 +17,3 @@
   border-left: var(--CmsContent-blockquote-border-width) solid var(--CmsContent-blockquote-border-color);
   color: var(--CmsContent-blockquote-color);
 }
-
-.CmsContent blockquote > * + * {
-  margin-top: var(--CmsContent-space);
-}

--- a/src/assets/toolkit/styles/components/cms-content.css
+++ b/src/assets/toolkit/styles/components/cms-content.css
@@ -1,5 +1,8 @@
 :root {
   --CmsContent-space: calc(var(--ms1)  * 1rem);
+  --CmsContent-blockquote-color: color(var(--color-black) blend(var(--color-gray) 50%) s(+5%));
+  --CmsContent-blockquote-border-color: var(--color-gray);
+  --CmsContent-blockquote-border-width: var(--border-width-md);
 }
 
 .CmsContent {}
@@ -8,4 +11,13 @@
   padding: var(--CmsContent-space);
   margin-right: calc(-1 * var(--CmsContent-space));
   margin-left: calc(-1 * var(--CmsContent-space));
+}
+
+.CmsContent blockquote {
+  border-left: var(--CmsContent-blockquote-border-width) solid var(--CmsContent-blockquote-border-color);
+  color: var(--CmsContent-blockquote-color);
+}
+
+.CmsContent blockquote > * + * {
+  margin-top: var(--CmsContent-space);
 }

--- a/src/pages/pages/blog-single-article.hbs
+++ b/src/pages/pages/blog-single-article.hbs
@@ -46,6 +46,13 @@ notes: |
       <p>
         I found myself spending little to no time in photoshop or sketch and jumping into the deep end of pattern libraries and prototypes. For the first time I was working on a team, submitting code, using git and creating pull requests.
       </p>
+      <p>
+        And lists were in this quote, too…
+      </p>
+      <ul>
+        <li>Look, a list item</li>
+        <li>Quick, there's another</li>
+      </ul>
     </blockquote>
 
     <p>

--- a/src/patterns/components/cms-content/base.hbs
+++ b/src/patterns/components/cms-content/base.hbs
@@ -2,6 +2,7 @@
 notes: |
   The `.CmsContent` class is used on the parent element of CMS prose fields to style some common child elements:
     + `<pre>`: Adds padding and negative margins
+    + `<blockquote>`: Adds border, lightens color and adds child spacing
 ---
 
 <article class="CmsContent u-spaceItems1">
@@ -12,6 +13,17 @@ notes: |
   display: block;
   padding: 1rem;
 }</code></pre>
+  <p>
+    {{random "paragraph" sentences="2"}}
+  </p>
+  <blockquote>
+    <p>
+      {{random "paragraph" sentences="1"}}
+    </p>
+    <p>
+      {{random "paragraph" sentences="1"}}
+    </p>
+  </blockquote>
   <p>
     {{random "paragraph" sentences="2"}}
   </p>

--- a/src/patterns/components/cms-content/base.hbs
+++ b/src/patterns/components/cms-content/base.hbs
@@ -2,7 +2,7 @@
 notes: |
   The `.CmsContent` class is used on the parent element of CMS prose fields to style some common child elements:
     + `<pre>`: Adds padding and negative margins
-    + `<blockquote>`: Adds border, lightens color and adds child spacing
+    + `<blockquote>`: Adds border and lightens color
 ---
 
 <article class="CmsContent u-spaceItems1">

--- a/src/patterns/typography/blockquote.hbs
+++ b/src/patterns/typography/blockquote.hbs
@@ -10,6 +10,11 @@ sourceless: true
     to the default resolution of images displayed in CSS as defined by
     image-resolution.
   </p>
+  <p>
+    CSS counters are, in essence, variables maintained by CSS whose values may
+    be incremented by CSS rules to track how many times they're used. This lets
+    you adjust the appearance of content based on its placement in the document.
+  </p>
   <footer>
     <cite><a href="//developer.mozilla.org">The Mozilla Developer Network</a></cite>
   </footer>

--- a/src/patterns/typography/blockquote.hbs
+++ b/src/patterns/typography/blockquote.hbs
@@ -10,11 +10,6 @@ sourceless: true
     to the default resolution of images displayed in CSS as defined by
     image-resolution.
   </p>
-  <p>
-    CSS counters are, in essence, variables maintained by CSS whose values may
-    be incremented by CSS rules to track how many times they're used. This lets
-    you adjust the appearance of content based on its placement in the document.
-  </p>
   <footer>
     <cite><a href="//developer.mozilla.org">The Mozilla Developer Network</a></cite>
   </footer>


### PR DESCRIPTION
This PR revises our `<blockquote>` pattern in a few ways:

- We retain our fancy citation treatment but now we don't have things like paragraphs running against unordered lists and stuff like that.
- In the `CmsContent` class, the `<blockquote>` element is styled to be more visually offset from adjacent content. This is particularly helpful when it contains elements like `<ul>` that have a similar left padding treatment.

## Before

<img width="496" alt="screen shot 2017-03-23 at 10 51 41 am" src="https://cloud.githubusercontent.com/assets/69633/24262252/c4acae68-0fb6-11e7-8ba9-3cb8e4e46f87.png">

## After

<img width="489" alt="screen shot 2017-03-23 at 10 49 56 am" src="https://cloud.githubusercontent.com/assets/69633/24262264/c99b6374-0fb6-11e7-8b9a-ed7adfa95ee6.png">

---

@erikjung @gerardo-rodriguez @aileenjeffries @saralohr 

Fixes #362 