### PR TITLE
Set flex-basis for Pagination children

### DIFF
--- a/src/assets/toolkit/styles/components/pagination.css
+++ b/src/assets/toolkit/styles/components/pagination.css
@@ -12,6 +12,7 @@
  * 2. Cap the height to that of an item, and prevent overflowing items from
  *    being visible within the container.
  * 3. Override default list styles.
+ * 4. Center pages if there aren't enough to fill the container.
  */
 
 .Pagination {
@@ -22,6 +23,7 @@
   padding-left: 0; /* 3 */
   list-style: none; /* 3 */
   flex-wrap: wrap; /* 2 */
+  justify-content: center; /* 4 */
 }
 
 /**
@@ -37,11 +39,13 @@
 }
 
 /**
- * Child elements should expand to fill the available space before wrapping.
+ * Child elements should not grow, should shrink as necessary, and it should
+ * default to about ⅛ the available space. This prevents numbers from looking
+ * oddly far apart when there are only a handful visible.
  */
 
 .Pagination > * {
-  flex: 1 1 auto;
+  flex: 0 1 calc(100% / 8);
 }
 
 /**


### PR DESCRIPTION
Prevents odd appearances when there are only a few pages visible.

## Before

<img width="753" alt="screen shot 2017-03-23 at 2 42 53 pm" src="https://cloud.githubusercontent.com/assets/69633/24271621/13f2f7be-0fd7-11e7-8022-68367f60808e.png">

## After

<img width="743" alt="screen shot 2017-03-23 at 2 43 05 pm" src="https://cloud.githubusercontent.com/assets/69633/24271627/176b1f84-0fd7-11e7-9bd2-5db0afb7129c.png">

---

@gerardo-rodriguez @aileenjeffries @saralohr 

Fixes #396