### PR TITLE
Add HashHeading--h* modifiers, u-staggerItems* utilities

### DIFF
--- a/src/assets/toolkit/styles/base/typography.css
+++ b/src/assets/toolkit/styles/base/typography.css
@@ -31,41 +31,55 @@ body {
 }
 
 /**
- * Largest and smallest default heading sizes
+ * Heading sizes
+ *
+ * Styles stored as mixins to keep things DRY for HashHeading component.
  */
 
-h1 {
+@define-mixin h1 {
   font-size: var(--font-size-lg);
   line-height: var(--line-height-sm);
+
+  @media (--md-viewport) {
+    font-size: var(--font-size-xl);
+  }
+}
+
+@define-mixin h2 {
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-sm);
+
+  @media (--md-viewport) {
+    font-size: var(--font-size-lg);
+  }
+}
+
+@define-mixin h3 {
+  @media (--md-viewport) {
+    font-size: var(--font-size-md);
+    line-height: var(--line-height-sm);
+  }
+}
+
+@define-mixin h5 {
+  font-size: var(--font-size-xs);
+}
+
+h1 {
+  @mixin h1;
 }
 
 h2 {
-  font-size: var(--font-size-md);
-  line-height: var(--line-height-sm);
+  @mixin h2;
+}
+
+h3 {
+  @mixin h3;
 }
 
 h5,
 h6 {
-  font-size: var(--font-size-xs);
-}
-
-/**
- * Responsive heading size increases
- */
-
-@media (--md-viewport) {
-  h1 {
-    font-size: var(--font-size-xl);
-  }
-
-  h2 {
-    font-size: var(--font-size-lg);
-  }
-
-  h3 {
-    font-size: var(--font-size-md);
-    line-height: var(--line-height-sm);
-  }
+  @mixin h5;
 }
 
 /**

--- a/src/assets/toolkit/styles/components/hash-heading.css
+++ b/src/assets/toolkit/styles/components/hash-heading.css
@@ -26,7 +26,7 @@
    */
 
   .HashHeading-heading,
-  .HashHeading > :matches(h1, h2, h3, h4, h5, h6) {
+  .HashHeading > :--headings {
     display: inline; /* 1 */
     margin-right: calc(var(--ms-6) * 1rem); /* 2 */
   }
@@ -61,6 +61,7 @@
 
   color: color(var(--color-gray) l(-20%) s(-10%)); /* 7 */
 
+  font-size: calc(var(--ms0) * 1rem);
   line-height: 1; /* 8 */
 }
 
@@ -85,4 +86,44 @@
 
     transform: translateY(-50%); /* 6 */
   }
+}
+
+/**
+ * Heading Level Modifiers
+ *
+ * These exist for when proportional (em-based) spacing is desired, but the
+ * containing HashHeading doesn't have the inner heading's font-size set.
+ *
+ * Mixins defined in base typography stylesheet.
+ */
+
+.HashHeading--h1,
+.HashHeading--h2,
+.HashHeading--h3,
+.HashHeading--h4,
+.HashHeading--h5,
+.HashHeading--h6 {
+  font: var(--heading-font);
+
+  & > .HashHeading-heading,
+  & > :--headings {
+    font: inherit;
+  }
+}
+
+.HashHeading--h1 {
+  @mixin h1;
+}
+
+.HashHeading--h2 {
+  @mixin h2;
+}
+
+.HashHeading--h3 {
+  @mixin h3;
+}
+
+.HashHeading--h5,
+.HashHeading--h6 {
+  @mixin h5;
 }

--- a/src/assets/toolkit/styles/utils/space.css
+++ b/src/assets/toolkit/styles/utils/space.css
@@ -6,6 +6,12 @@
   }
 }
 
+@define-mixin makeStaggerItemsUtils $value, $suffix {
+  .u-staggerItems$(suffix) > * + * {
+    margin-top: $(value) !important;
+  }
+}
+
 @define-mixin makePullUtils $value, $suffix, $prefix {
   .u-$(prefix)pullSides$(suffix),
   .u-$(prefix)pullLeft$(suffix) {
@@ -83,6 +89,20 @@
 @mixin makeSpaceItemsUtils calc(var(--ms4)  * 1rem),  4;
 @mixin makeSpaceItemsUtils calc(var(--ms5)  * 1rem),  5;
 @mixin makeSpaceItemsUtils calc(var(--ms6)  * 1rem),  6;
+
+@mixin makeStaggerItemsUtils calc(var(--ms-6) * 1em), 06;
+@mixin makeStaggerItemsUtils calc(var(--ms-5) * 1em), 05;
+@mixin makeStaggerItemsUtils calc(var(--ms-4) * 1em), 04;
+@mixin makeStaggerItemsUtils calc(var(--ms-3) * 1em), 03;
+@mixin makeStaggerItemsUtils calc(var(--ms-2) * 1em), 02;
+@mixin makeStaggerItemsUtils calc(var(--ms-1) * 1em), 01;
+@mixin makeStaggerItemsUtils calc(var(--ms0)  * 1em);
+@mixin makeStaggerItemsUtils calc(var(--ms1)  * 1em),  1;
+@mixin makeStaggerItemsUtils calc(var(--ms2)  * 1em),  2;
+@mixin makeStaggerItemsUtils calc(var(--ms3)  * 1em),  3;
+@mixin makeStaggerItemsUtils calc(var(--ms4)  * 1em),  4;
+@mixin makeStaggerItemsUtils calc(var(--ms5)  * 1em),  5;
+@mixin makeStaggerItemsUtils calc(var(--ms6)  * 1em),  6;
 
 @mixin makePullUtils calc(var(--ms1) * 1rem), 1;
 @mixin makePullUtils calc(var(--ms2) * 1rem), 2;

--- a/src/pages/pages/blog-single-article.hbs
+++ b/src/pages/pages/blog-single-article.hbs
@@ -9,7 +9,7 @@ notes: |
 ---
 
 <article class="CmsContent u-spaceEnds1">
-  <div class="u-spaceItems1 u-cf">
+  <div class="u-staggerItems1 u-cf">
     {{{ embed "patterns.combos.blog.post-header" }}}
 
     {{{ embed "patterns.combos.blog.post-intro" }}}
@@ -249,7 +249,7 @@ class Bread {
       I like to look at having technical skills the same way I would look at having presentation skills. Or project management, writing, and concepting skills. We are not just pixel pushers, we are designers. We are complex thinkers, makers and problem solvers. That goes way beyond just the presentation layer of a design. It’s about a breadth of knowledge that informs your creative process. Code informing visual design. And vice versa, visual design informing the code.
     </p>
 
-    <div class="HashHeading">
+    <div class="HashHeading HashHeading--h2">
       <h2 id="natural-unicorns">
         I don’t believe there are natural born unicorns
       </h2>
@@ -264,7 +264,7 @@ class Bread {
       People are not just magically amazing designers and awesome developers. I do believe in the constant and perpetual learner. What being a unicorn is really about is just having a hunger for knowing more. Not stopping at just enough knowledge. Unicorns are just people who are curious. You show me a unicorn, and I see someone who likes to learn not just about their own discipline, but also the ones that overlap theirs.
     </p>
 
-    <div class="HashHeading">
+    <div class="HashHeading HashHeading--h2">
       <h2 id="practical-advice">
         Some practical advice from an Ugly Unicorn
       </h2>

--- a/src/patterns/components/cms-content/base.hbs
+++ b/src/patterns/components/cms-content/base.hbs
@@ -5,7 +5,7 @@ notes: |
     + `<blockquote>`: Adds border and lightens color
 ---
 
-<article class="CmsContent u-spaceItems1">
+<article class="CmsContent u-staggerItems1">
   <p>
     {{random "paragraph" sentences="2"}}
   </p>

--- a/src/patterns/components/hash-heading/heading-modifiers.hbs
+++ b/src/patterns/components/hash-heading/heading-modifiers.hbs
@@ -1,0 +1,25 @@
+---
+name: Heading Modifiers
+previewClass: u-staggerItems1 u-md-padLeft4
+notes: |
+  You may optionally include heading modifiers (`HashHeading--h1` through
+  `HashHeading--h6`) in cases where you'd like to retain proportional
+  `font-size` of the container (for example, when using a `u-staggerItems*`
+  utility).
+---
+
+{{#iterate 3}}
+<div class="HashHeading HashHeading--h{{@count}}">
+  <h{{@count}} id="HashHeading-demo-{{@count}}">
+    This Is a Subhead {{@count}}
+  </h{{@count}}>
+  <a href="#HashHeading-demo-{{@count}}"
+    label="Permalink for This Is a Subhead {{@count}}"
+    class="HashHeading-link">
+    {{svg "icons/link" class="Icon" aria-hidden="true"}}
+  </a>
+</div>
+<p>
+  {{random "paragraph" sentences=2}}
+</p>
+{{/iterate}}

--- a/src/patterns/utilities/space.hbs
+++ b/src/patterns/utilities/space.hbs
@@ -13,6 +13,7 @@ notes: |
   + `u-spaceLeftX` applies `margin` to left.
   + `u-spaceRightX` applies `margin` to right.
   + `u-spaceItemsX` applies vertical `margin` between adjacent items.
+  + `u-staggerItemsX` applies vertical `margin` between adjacent items proportional to the item's `font-size`.
   + `u-padX` applies `padding` all around.
   + `u-padEndsX` applies `padding` to top and bottom.
   + `u-padSidesX` applies `padding` to left and right.


### PR DESCRIPTION
This PR lays the groundwork for addressing #363.

It adds a new compliment to the `u-spaceItems*` utilities, `u-staggerItems*`, which does the same thing except with `em` units, which means larger headings will have more `margin-top` than paragraphs or lists. This will improve readability of blog posts without disrupting the rhythm of other content sections.

Unfortunately, this alone wasn't enough. The `HashHeading` component wraps many of the headings, which means most of the headings had the same `1rem` of `margin-top` as they always had. I couldn't change the structure without impacting accessibility, so instead I added optional modifiers for `HashHeading--h1` through `HashHeading--h6`, which sets the appropriate `font` styles so it can be composed proportionally.

## Before

<img width="840" alt="screen shot 2017-03-23 at 4 10 10 pm" src="https://cloud.githubusercontent.com/assets/69633/24274090/6f022952-0fe3-11e7-8af9-edd32a0d604c.png">

## After

<img width="845" alt="screen shot 2017-03-23 at 4 11 31 pm" src="https://cloud.githubusercontent.com/assets/69633/24274093/7284a000-0fe3-11e7-84b9-f33fe0515244.png">

---

@erikjung @gerardo-rodriguez @aileenjeffries @saralohr 

See: #363 