### PR TITLE
Add hack for making comment footnotes smaller

### DIFF
--- a/src/assets/toolkit/styles/vendor/jetpack-markdown.css
+++ b/src/assets/toolkit/styles/vendor/jetpack-markdown.css
@@ -56,3 +56,11 @@ sup[id^="fnref-"] a {
 .footnotes a[href^="#fnref-"] {
   text-decoration: none;
 }
+
+/**
+ * Footnotes in comments should be smaller in font-size than the parent element.
+ */
+
+[id^="comment-"] .footnotes {
+  font-size: calc(var(--ms-1) * 1em);
+}


### PR DESCRIPTION
Part one of a two-part fix to make this edge case prettier.

## Before

<img width="640" alt="screen shot 2017-03-24 at 4 14 56 pm" src="https://cloud.githubusercontent.com/assets/69633/24316659/31f5cb2a-10ad-11e7-9161-49e183277516.png">

## After

<img width="639" alt="screen shot 2017-03-24 at 4 14 46 pm" src="https://cloud.githubusercontent.com/assets/69633/24316661/377717a2-10ad-11e7-94aa-0b9200804b76.png">

---

@erikjung @gerardo-rodriguez @aileenjeffries 