### PR TITLE
Add CORS header to allow SW caching

### DIFF
--- a/src/static/_headers
+++ b/src/static/_headers
@@ -1,0 +1,2 @@
+/assets/
+ Access-Control-Allow-Origin: *


### PR DESCRIPTION
This is required in order for us to (easily) use the toolkit output on
other sites in conjunction with service workers and caching, etc.