### PR TITLE
PWA Stats R2

### DIFF
--- a/src/assets/toolkit/styles/components/icon.css
+++ b/src/assets/toolkit/styles/components/icon.css
@@ -8,7 +8,8 @@
 :root {
   --Icon-line-height-offset: calc((var(--line-height-md) - 1) / -2em);
   --Icon-size: 1em;
-  --Icon-size-lg: calc(var(--Icon-size) * var(--ms-ratio));
+  --Icon-size-1: calc(var(--Icon-size) * var(--ms-ratio));
+  --Icon-size-2: calc(var(--Icon-size-1) * var(--ms-ratio));
 }
 
 /**
@@ -42,7 +43,11 @@
  */
 
 .Icon--large {
-  font-size: var(--Icon-size-lg);
+  font-size: var(--Icon-size-1);
+}
+
+.Icon--larger {
+  font-size: var(--Icon-size-2);
 }
 
 /**
@@ -50,7 +55,8 @@
  * content's `line-height`.
  */
 
-.Icon--large:not(.Icon--block) {
+.Icon--large:not(.Icon--block),
+.Icon--larger:not(.Icon--block) {
   margin-bottom: var(--Icon-line-height-offset); /* 1 */
   margin-top: var(--Icon-line-height-offset); /* 1 */
 }

--- a/src/assets/toolkit/styles/components/pagination.css
+++ b/src/assets/toolkit/styles/components/pagination.css
@@ -99,3 +99,11 @@
 .Pagination-item--next {
   right: 0;
 }
+
+/**
+ * Optional: Inactive controls may appear semi-opaque.
+ */
+
+.Pagination-item--muted {
+  opacity: var(--opacity-mid);
+}

--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -98,7 +98,7 @@
 .Sky a,
 .Sky a:matches(:--enter, :active),
 .Sky :--headings {
-  color: var(--Sky-color);
+  color: inherit;
 }
 
 /**

--- a/src/assets/toolkit/styles/sandbox/sil-pwa.css
+++ b/src/assets/toolkit/styles/sandbox/sil-pwa.css
@@ -1,74 +1,88 @@
 @import "../base/_config.css";
 
-/* Overrides Sky > a { color: white} */
-.u-linkBlue {
-  color: var(--color-blue) !important;
-}
+.Masonry {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 30em;
 
-.u-linkBlue:--enter {
-  color: var(--color-blue) !important;
-  opacity: 0.75 !important;
-}
-
-/* Permalink color */
-.u-linkGrayDark {
-  color: color(var(--color-gray) l(-35%) s(+5%)) !important;
-}
-
-.u-linkGrayDark:--enter {
-  color: color(var(--color-gray) l(-35%) s(+5%)) !important;
-  opacity: 0.75 !important;
-}
-
-/* Permalink bg */
-.u-bgGrayLight {
-  background-color: color(var(--color-gray) l(+5%)) !important;
-}
-
-/* Used for the date on the post page */
-.u-textGrayDark {
-  color: color(var(--color-gray) l(-45%) s(+5%)) !important;
-}
-
-/* Setting columns with min-width
- * Probably break gap size into another utility
- */
-.u-columns {
-  columns: 14.5rem 5;
-  column-gap: calc(1em * var(--ms1));
-}
-
-.u-breakInsideAvoid {
-  break-inside: avoid;
-}
-
-/* Tag style */
-.Button--muted {
-  border-color: var(--color-gray);
-  color: var(--color-blue);
-}
-
-.Button--muted:--enter {
-  border-color: color(var(--color-gray) l(-10%));
-  color: var(--color-blue);
-}
-
-/* Currently we don't have a way (that I'm aware of) to reset text to --ms0;
- * Shrink and grow utilities apply --ms1+ and --ms-1-
- * Used to reduce post headline <h2> to base font size
- */
-@media (--lg-viewport) {
-  .u-lg-textBase {
-    font-size: 1rem !important;
+  @supports (display: grid) {
+    display: grid;
+    grid-gap: var(--space-md);
+    grid-template-columns: repeat(auto-fill, minmax(18em, 1fr));
+    justify-content: center;
+    max-width: none;
   }
 }
 
-/* Applied to "PWA Stats" heading */
-.u-textShadow {
-  text-shadow: .0325em .0325em color(var(--color-navy) s(+25%) l(+10%) a(75%));
+.Masonry > * + * {
+  margin-top: var(--space-md);
+
+  @supports (display: grid) {
+    margin-top: 0;
+  }
 }
 
-/* Applied to current pagination state */
-.u-opacityMid {
-  opacity: var(--opacity-mid);
+.Card {
+  background: var(--color-white);
+  color: var(--link-color);
+  display: flex;
+  flex-direction: column;
+  transform-origin: center;
+  transition: transform 0.2s easeOutQuad;
+  position: relative;
+}
+
+.Card:matches(:--enter) {
+  transform: scale(1.05);
+}
+
+.Card-main {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+  padding: var(--space-md);
+  position: relative;
+  overflow: hidden;
+  text-decoration: none;
+}
+
+.Card-main.Card-main:matches(:--enter, :active) {
+  color: var(--link-hover-color);
+}
+
+.Card-icon {
+  width: calc(var(--ms5) * 1em);
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: var(--space-md);
+}
+
+.Card-summary {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-normal);
+  overflow: hidden;
+}
+
+.Card-summary::before {
+  content: "";
+  float: right;
+  height: calc(var(--ms5) * 1em);
+  margin-left: var(--space-xs);
+  width: calc(var(--ms5) * 1em);
+}
+
+.Card-meta {
+  align-items: center;
+  background-color: color(var(--color-gray) l(+5%));
+  color: #657BAE;
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--font-size-xs);
+  padding: var(--space-sm) var(--space-md);
+}
+
+.Card-metaLink:not(:hover, :focus, :active) {
+  text-decoration: none;
 }

--- a/src/pages/sandbox/pwa-stats-single.hbs
+++ b/src/pages/sandbox/pwa-stats-single.hbs
@@ -9,68 +9,66 @@ stylesheets:
 ---
 
 <div class="Sky Sky--clouds">
-  <div class="u-containSpread u-padSides u-spaceBottom2">
-    <header class="u-textCenter u-padEnds3">
-      <h1 class="u-textNoWrap u-textGrow4 u-sm-textGrow6 u-textShadow">
-        <a href="" class="u-linkWhite u-linkClean">PWA Stats</a>
-      </h1>
-      <p class="u-sm-textGrow1 u-containProse">
-        A community-driven list of stats and news related to Progressive Web Apps, brought to you by
-        <a class="u-textNoWrap" href="https://cloudfour.com/">
-          {{svg "icons/cloud-four" class="Icon Icon--large u-spaceLeft06"}}
-          Cloud Four
-        </a>
+  <div class="u-containSpread u-padSides u-spaceBottom4 u-spaceItems2">
+    <header class="u-textCenter u-padTop3 u-padBottom1">
+      <h1 class="u-textNoWrap u-textGrow4 u-sm-textGrow6">PWA Stats</h1>
+      <p class="u-containProse">
+        <span class="u-md-inlineBlock">
+          A community-driven list of stats and news related to Progressive Web Apps,
+        </span>
+        <span class="u-md-inlineBlock">
+          brought to you by
+          <a class="u-textNoWrap" href="https://cloudfour.com/">
+            {{svg "icons/cloud-four" class="Icon Icon--larger u-spaceLeft06"}}
+            Cloud Four
+          </a>
+        </span>
       </p>
     </header>
     {{#with drizzle.data.pwa-stats.contents.data.[0]}}
-      <article class="u-containProse u-padTop1 u-sm-padTop2 u-padSides1 u-padBottom u-bgWhite u-flex u-flexWrap u-sm-flexNoWrap u-flexAlignItemsStart u-posRelative">
-        {{#if logo}}
-          <img src="{{logo}}" class="u-sm-spaceRight1 u-flexShrink0 u-block u-padTop06" alt="" style="width: 3.5rem;">
-        {{/if}}
-        <div class="u-spaceTop u-sm-spaceTopNone">
-          <header>
-            <h2 class="u-textGrow1 u-lg-textBase u-textNormal u-sm-size3of4 u-md-size5of6">
-              <a href="{{link}}" class="u-linkClean u-linkBlue u-spaceRight05">
-                {{{headline}}}
-              </a>
-            </h2>
-            <p class="u-textShrink1 u-bgGrayLight u-textGrayDark u-posAbsoluteTopRight u-padEnds05 u-padSides03">
-              <time datetime="2015-03-31">
-                March 31, 2015
-              </time>
-            </p>
-          </header>
-          <footer>
-            <h3 class="u-hiddenVisually">Tags:</h3>
-            <ul class="u-listUnstyled u-flex u-flexAlignItemsStart u-flexWrap u-spaceTop">
-              {{#each this.tags}}
-                <li>
-                  <a class="Button Button--muted u-linkBlue u-textShrink2 u-spaceBottom03 u-spaceRight03 u-textNoWrap u-pad05" href="">
-                    #{{this}}
-                  </a>
-                </li>
-              {{/each}}
-            </ul>
-          </footer>
-        </div>
+      <article class="Card u-containProse u-md-textGrow1">
+        <a href="{{link}}" class="Card-main">
+          <h2 class="Card-summary">
+            {{{headline}}}
+          </h2>
+          <img class="Card-icon" src="{{logo}}" alt="">
+        </a>
+        <footer class="Card-meta">
+          <h3 class="u-hiddenVisually">
+            Tags
+          </h3>
+          <ul class="u-listInline">
+            {{#each tags}}
+              <li>
+                <a class="Card-metaLink" href="">
+                  #{{this}}
+                </a>
+              </li>
+            {{/each}}
+          </ul>
+          <p class="u-spaceLeft1">
+            <time datetime="2015-03-31">
+              March 31, 2015
+            </time>
+          </p>
+        </footer>
       </article>
     {{/with}}
   </div>
 </div>
-
-<div class="u-bgWhite">
+<div class="u-bgWhite u-padTop1">
   <div class="u-containSpread u-posRelative">
     <p class="u-pad1 u-size2of3">
-      <span class="u-inlineBlock u-textGrow1 u-spaceRight u-textNoWrap">
-        Help us build this resource!
+      <span class="u-inlineBlock u-spaceRight u-textNoWrap">
+        Make PWA Stats even better:
       </span>
-      <a class="Button Button--primary u-spaceEnds01 u-textNoWrap" href="mailto:info@cloudfour.com">
-        Contribute a Story
+      <a class="Button Button--primary u-spaceEnds01 u-textNoWrap" href="https://github.com/cloudfour/pwastats">
+        {{svg "icons/github" class="Icon Icon--large u-spaceLeft06"}}
+        Contribute
       </a>
     </p>
     <img class="u-posAbsoluteBottomRight u-size2of5 u-sm-size1of3 u-sm-spaceRight1 u-md-size1of4"
       src="/images/portland.svg" alt="">
   </div>
 </div>
-
 {{{embed "toolkit.global-footer"}}}

--- a/src/pages/sandbox/pwa-stats.hbs
+++ b/src/pages/sandbox/pwa-stats.hbs
@@ -10,102 +10,71 @@ stylesheets:
 
 
 <div class="Sky Sky--clouds">
-  <div class="u-containSpread u-padSides u-spaceBottom2">
-    <header class="u-textCenter u-padEnds3">
-      <h1 class="u-textNoWrap u-textGrow4 u-sm-textGrow6 u-textShadow">PWA Stats</h1>
-      <p class="u-sm-textGrow1 u-containProse">
-        A community-driven list of stats and news related to Progressive Web Apps, brought to you by
-        <a class="u-textNoWrap" href="https://cloudfour.com/">
-          {{svg "icons/cloud-four" class="Icon Icon--large u-spaceLeft06"}}
-          Cloud Four
-        </a>
+  <div class="u-containSpread u-padSides u-spaceBottom2 u-spaceItems2">
+    <header class="u-textCenter u-padTop3 u-padBottom1">
+      <h1 class="u-textNoWrap u-textGrow4 u-sm-textGrow6">PWA Stats</h1>
+      <p class="u-containProse">
+        <span class="u-md-inlineBlock">
+          A community-driven list of stats and news related to Progressive Web Apps,
+        </span>
+        <span class="u-md-inlineBlock">
+          brought to you by
+          <a class="u-textNoWrap" href="https://cloudfour.com/">
+            {{svg "icons/cloud-four" class="Icon Icon--larger u-spaceLeft06"}}
+            Cloud Four
+          </a>
+        </span>
       </p>
     </header>
-    <div class="u-columns">
+    <div class="Masonry">
       {{#each drizzle.data.pwa-stats.contents.data}}
-        <article class="u-breakInsideAvoid u-padBottom2">
-          <div class="u-padTop1 u-padSides1 u-padBottom01 u-bgWhite u-posRelative">
-            <header>
-              {{#if logo}}
-                <img src="{{logo}}" class="u-block" style="width: 3rem" alt="">
-              {{/if}}
-              <h2 class="u-textGrow1 u-lg-textBase u-textNormal u-spaceTop">
-                <a href="{{link}}" class="u-linkClean u-linkBlue u-spaceRight05">
-                  {{{headline}}}
-                </a>
-              </h2>
-              <a class="u-posAbsoluteTopRight u-pad04 u-bgGrayLight u-linkGrayDark" href="" title="Visit Post Permalink">
-                {{svg "icons/link" class="Icon u-block"}}
+        <article class="Card">
+          <a href="{{link}}" class="Card-main">
+            <h2 class="Card-summary">
+              {{{headline}}}
+            </h2>
+            <img class="Card-icon" src="{{logo}}" alt="">
+          </a>
+          <footer class="Card-meta">
+            <h3 class="u-hiddenVisually">
+              Tags
+            </h3>
+            <ul class="u-listInline">
+              {{#each tags}}
+                <li>
+                  <a class="Card-metaLink" href="">
+                    #{{this}}
+                  </a>
+                </li>
+              {{/each}}
+            </ul>
+            <p class="u-spaceLeft1">
+              <a class="Card-metaLink" href="./pwa-stats-single.html" title="Permalink">
+                {{svg "icons/link" class="Icon Icon--large"}}
               </a>
-            </header>
-            <footer class="u-spaceTop">
-              <h3 class="u-hiddenVisually">Tags:</h3>
-              <ul class="u-listUnstyled u-flex u-flexAlignItemsStart u-flexWrap">
-                {{#each this.tags}}
-                  <li>
-                    <a class="Button Button--muted u-linkBlue u-textShrink2 u-spaceBottom03 u-spaceRight03 u-textNoWrap u-pad05" href="">
-                      #{{this}}
-                    </a>
-                  </li>
-                {{/each}}
-              </ul>
-            </footer>
-          </div>
+            </p>
+          </footer>
         </article>
       {{/each}}
     </div>
-    <div class="u-containProse">
-      <nav role="menu" aria-label="Pagination">
-        <ul class="Pagination {{#compare (defaultTo current 1) '>' 1}}Pagination--withPrevious{{/compare}} {{#compare (defaultTo current 1) '<' (defaultTo pages 4)}}Pagination--withNext{{/compare}}">
-          {{#iterate (defaultTo pages 4)}}
-            <li>
-              {{#compare @count "===" (defaultTo ../current 1)}}
-                <span class="Pagination-item u-opacityMid">
-                  <span class="u-hiddenVisually">Currently viewing page</span>
-                  {{@count}}
-                </span>
-              {{else}}
-                <a class="Pagination-item" href="#">
-                  {{#compare @count "===" (math (defaultTo ../current 1) "--")}}
-                    <span class="Pagination-item Pagination-item--previous">
-                      {{#svg "icons/arrow-left" class="Icon" aria-labelledby="pagination-previous-title"}}
-                        <title id="pagination-previous-title">Previous:</title>
-                      {{/svg}}
-                    </span>
-                  {{/compare}}
-                  {{#compare @count "===" (math (defaultTo ../current 1) "++")}}
-                    <span class="Pagination-item Pagination-item--next">
-                      {{#svg "icons/arrow-right" class="Icon" aria-labelledby="pagination-next-title"}}
-                        <title id="pagination-next-title">Next:</title>
-                      {{/svg}}
-                    </span>
-                  {{/compare}}
-                  <span class="u-hiddenVisually">Page</span>
-                  {{@count}}
-                </a>
-              {{/compare}}
-            </li>
-          {{/iterate}}
-        </ul>
-      </nav>
+    <div class="u-containProse u-sm-size2of3 u-md-size1of2">
+      {{{embed "patterns.components.pagination.base" pages=4}}}
     </div>
   </div>
 </div>
-
-<div class="u-bgWhite">
+<div class="u-bgWhite u-padTop1">
   <div class="u-containSpread u-posRelative">
     <p class="u-pad1 u-size2of3">
-      <span class="u-inlineBlock u-textGrow1 u-spaceRight u-textNoWrap">
-        Help us build this resource!
+      <span class="u-inlineBlock u-spaceRight u-textNoWrap">
+        Make PWA Stats even better:
       </span>
-      <a class="Button Button--primary u-spaceEnds01 u-textNoWrap" href="mailto:info@cloudfour.com">
-        Contribute a Story
+      <a class="Button Button--primary u-spaceEnds01 u-textNoWrap" href="https://github.com/cloudfour/pwastats">
+        {{svg "icons/github" class="Icon Icon--large u-spaceLeft06"}}
+        Contribute
       </a>
     </p>
     <img class="u-posAbsoluteBottomRight u-size2of5 u-sm-size1of3 u-sm-spaceRight1 u-md-size1of4"
       src="/images/portland.svg" alt="">
   </div>
 </div>
-
-
 {{{embed "toolkit.global-footer"}}}

--- a/src/patterns/components/icon/sizes.hbs
+++ b/src/patterns/components/icon/sizes.hbs
@@ -2,11 +2,15 @@
 name: Size Modifiers
 order: 3
 notes: |
-  You can make icons larger with the `.Icon--large` modifier.
+  You can make icons larger with the `Icon--large` or `Icon--larger` modifiers.
+  These will also adjust top and bottom `margin` values to minimize impact
+  on the containing element's `line-height` (except when `Icon--block` is also
+  applied).
+
+  Alternatively, icons can be sized using any class or style that changes
+  `font-size`.
 ---
 
+{{svg "icons/cloud-four" class="Icon"}}
 {{svg "icons/cloud-four" class="Icon Icon--large"}}
-
-{{svg "icons/envelope" class="Icon Icon--large"}}
-
-{{svg "icons/link" class="Icon Icon--large"}}
+{{svg "icons/cloud-four" class="Icon Icon--larger"}}

--- a/src/patterns/components/pagination/base.hbs
+++ b/src/patterns/components/pagination/base.hbs
@@ -7,7 +7,7 @@ hidden: true;
     {{#iterate (defaultTo pages 10)}}
       <li>
         {{#compare @count "===" (defaultTo ../current 1)}}
-          <span class="Pagination-item">
+          <span class="Pagination-item Pagination-item--muted">
             <span class="u-hiddenVisually">Currently viewing page</span>
             {{@count}}
           </span>


### PR DESCRIPTION
This PR makes changes to three existing components, and refactors the PWA Stats prototypes to use CSS Grid Layout.

I'm doing a PR for this now because I'm still somewhat skittish about adding the PWA Stats specific components to the pattern library proper. They have some idiosyncratic styles that depend on being a child of `.Sky` (or at least a dark background, which is uncommon for the rest of cloudfour.com).