### PR TITLE
Add 1px overlap to repeating clouds

### DIFF
--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -68,16 +68,19 @@
 /**
  * Pseudo element for actual clouds, allows clouds to overlay other elements.
  *
- * 1. Non-zero horizontal position adds visual interest for nerds like us who
+ * 1. Some high-resolution mobile devices will show a subpixel gap between the
+ *    bottom of the clouds and the parent element. A single pixel of overlap
+ *    helps avoid this issue.
+ * 2. Non-zero horizontal position adds visual interest for nerds like us who
  *    resize their browser. It also makes the compositions feel a little more
  *    organic (though YMMV).
- * 2. Though not a requirement, setting the `background-size` to a proportional
+ * 3. Though not a requirement, setting the `background-size` to a proportional
  *    unit will make the clouds grow and shrink with the base `font-size`.
  */
 
 .Sky--clouds::after {
   position: absolute;
-  bottom: 0;
+  bottom: -1px; /* 1 */
   left: 0;
 
   width: 100%;
@@ -87,8 +90,8 @@
 
   background-image: var(--Sky-clouds-image);
   background-repeat: repeat-x;
-  background-position: var(--Sky-clouds-x-offset) bottom; /* 1 */
-  background-size: var(--Sky-clouds-image-width); /* 2 */
+  background-position: var(--Sky-clouds-x-offset) bottom; /* 2 */
+  background-size: var(--Sky-clouds-image-width); /* 3 */
 }
 
 /**


### PR DESCRIPTION
Helps alleviate visible seam along bottom edge in some browsers.

I haven't tested this on an actual device yet, only via BrowserStack.

## Before

<img width="474" alt="screen shot 2017-03-30 at 10 03 43 am" src="https://cloud.githubusercontent.com/assets/69633/24516680/6242015e-1530-11e7-89b4-4403ba6528a7.png">

## After

<img width="469" alt="screen shot 2017-03-30 at 10 04 14 am" src="https://cloud.githubusercontent.com/assets/69633/24516669/5e3e9e3c-1530-11e7-8685-c10a22e18dd9.png">

---

@grigs @erikjung @gerardo-rodriguez 

See: #417