### PR TITLE
Cover subpixel seams between skies

### DIFF
--- a/src/assets/toolkit/styles/components/sky.css
+++ b/src/assets/toolkit/styles/components/sky.css
@@ -55,6 +55,17 @@
 }
 
 /**
+ * On some high-resolution mobile devices, a subpixel seam will show between
+ * two of these elements pancaked together. Because we want to encourage this
+ * item to be split between semantic elements like <header> and <main>, we
+ * use a thin shadow to cover these seams without affecting layout.
+ */
+
+.Sky:not(.Sky--clouds) {
+  box-shadow: 0 1px 0 var(--Sky-background-color);
+}
+
+/**
  * Modifier: clouds ☁️
  *
  * 1. Add bottom padding equal to the cloud height to keep content from


### PR DESCRIPTION
Full explanation in CSS comments.

Only tested in BrowserStack so far.

## Before

<img width="345" alt="screen shot 2017-03-30 at 10 37 37 am" src="https://cloud.githubusercontent.com/assets/69633/24518139/b2c8d350-1535-11e7-902c-5ec55c6442ad.png">

## After

<img width="332" alt="screen shot 2017-03-30 at 10 40 48 am" src="https://cloud.githubusercontent.com/assets/69633/24518145/bb21a414-1535-11e7-84c0-37d8ac02b864.png">

---

@grigs @erikjung @gerardo-rodriguez 

See: #417 #418