### PR TITLE
Tweak Card-main text styles

### DIFF
--- a/src/assets/toolkit/styles/components/card.css
+++ b/src/assets/toolkit/styles/components/card.css
@@ -4,8 +4,8 @@
   --Card-bg: var(--color-white);
   --Card-border-color: var(--color-gray);
   --Card-border-width: var(--border-width-md);
-  --Card-main-color: var(--link-color);
-  --Card-main-color-hover: var(--link-hover-color);
+  --Card-main-color: color(var(--color-navy) l(+10%));
+  --Card-main-color-emphasis: var(--link-color);
   --Card-mainObject-size: calc(var(--ms5) * 1em);
   --Card-meta-bg: color(var(--color-gray) l(+5%));
   --Card-meta-color: #657BAE;
@@ -63,10 +63,15 @@
 
 .Card-main.Card-main {
   color: var(--Card-main-color);
+}
 
-  &:matches(:active, :--enter) {
-    color: var(--Card-main-color-hover);
-  }
+/**
+ * Highlight text on interaction, highlight emphasis elements always
+ */
+
+.Card-main.Card-main:--enter,
+.Card-main.Card-main :matches(b, strong, i, em) {
+  color: var(--Card-main-color-emphasis);
 }
 
 /**

--- a/src/patterns/components/card/base.hbs
+++ b/src/patterns/components/card/base.hbs
@@ -17,7 +17,7 @@ labels:
     {{/if}}
     <h2 class="Card-mainContent">
       {{#block "content"}}
-        Sometimes when you innovate, you make mistakes. It is best to admit them quickly, and get on with improving your other innovations.
+        Sometimes when you <b>innovate</b>, you make mistakes. It is best to admit them quickly, and get on with improving your other innovations.
       {{/block}}
     </h2>
   </a>


### PR DESCRIPTION
Emphasis elements highlighted in advance of interaction.

## Before

<img width="1375" alt="screen shot 2017-04-03 at 2 29 49 pm" src="https://cloud.githubusercontent.com/assets/69633/24633386/1bd1536e-187d-11e7-965e-b5f5d27483c7.png">

## After

<img width="1372" alt="screen shot 2017-04-03 at 2 29 33 pm" src="https://cloud.githubusercontent.com/assets/69633/24633391/1f62f65e-187d-11e7-97d0-6ddc96138eb5.png">
