### PR TITLE
Add Safari 10 to browserslist

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -4,3 +4,4 @@
 
 > 4%
 Last 1 version
+Safari 10

--- a/browserslist
+++ b/browserslist
@@ -4,4 +4,4 @@
 
 > 4%
 Last 1 version
-Safari 10
+Last 3 Safari version


### PR DESCRIPTION
If we are going to have workarounds to support Safari 10, we should also ensure that autoprefixer generates prefixes compatible with Safari 10 and that postcss-preset-env emits syntax compatible with Safari 10