### PR TITLE
Change the style of footnote links to make them less distracting.

### DIFF
--- a/src/assets/toolkit/styles/components/footnote-link.css
+++ b/src/assets/toolkit/styles/components/footnote-link.css
@@ -1,9 +1,9 @@
 /** @define FootnoteLink */
 
 :root {
-  --FootnoteLink-background-color: var(--color-blue);
+  --FootnoteLink-background-color: var(--color-gray);
   --FootnoteLink-border-radius: calc(var(--FootnoteLink-min-width) / 2);
-  --FootnoteLink-color: var(--color-white);
+  --FootnoteLink-color: var(--color-black);
   --FootnoteLink-font-size: var(--font-size-xs);
   --FootnoteLink-line-height: var(--ms2);
   --FootnoteLink-min-width: calc(var(--FootnoteLink-line-height) * 1em);


### PR DESCRIPTION
<img width="895" alt="screen shot 2018-08-03 at 2 29 20 pm" src="https://user-images.githubusercontent.com/24928337/43668555-724b8dce-9732-11e8-83a4-ac45f6137213.png">
The purpose of this pull request is to change the design of the footnote links to make them less distracting and not take away from the actual article at hand. They were blue buttons with with white text and it was pretty bold and took the reader out of the article. I played around with different colors and background and came to the grey and black combination. It still says "Hey! Click me!" without being overly distracting.