### PR TITLE
Update Colors and Button Styles

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/*
+lts/carbon

--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -48,7 +48,7 @@
   --color-fuchsia: #f14ca3;
 
   /* Other colors */
-  --color-red: #de1d0b;
+  --color-red: #bf0000;
 
   /* a11y variations for light-on-dark text contrast */
   --color-blue-a11y: color-mod(var(--color-blue) l(-4%));

--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -44,11 +44,11 @@
 
   /* Secondary colors */
   --color-orange: #f26941;
-  --color-green: #35c98d;
-  --color-fuchsia: #f14ca3;
+  --color-green: #068362;
+  --color-fuchsia: #dd117d;
 
   /* Other colors */
-  --color-red: #bf0000;
+  --color-red: #de1d0b;
 
   /* a11y variations for light-on-dark text contrast */
   --color-blue-a11y: color-mod(var(--color-blue) l(-4%));

--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -48,7 +48,7 @@
   --color-fuchsia: #f14ca3;
 
   /* Other colors */
-  --color-red: #bf0000;
+  --color-red: #DE2B0B;
 
   /* a11y variations for light-on-dark text contrast */
   --color-blue-a11y: color-mod(var(--color-blue) l(-4%));

--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -43,12 +43,12 @@
   --color-gray: #dbe5ea;
 
   /* Secondary colors */
-  --color-orange: #f26941;
+  --color-orange: #f57b47;
   --color-green: #35c98d;
-  --color-fuchsia: #f14ca3;
+  --color-fuchsia: #dd117d;
 
   /* Other colors */
-  --color-red: #DE2B0B;
+  --color-red: #de1d0b;
 
   /* a11y variations for light-on-dark text contrast */
   --color-blue-a11y: color-mod(var(--color-blue) l(-4%));

--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -43,7 +43,7 @@
   --color-gray: #dbe5ea;
 
   /* Secondary colors */
-  --color-orange: #f57b47;
+  --color-orange: #f26941;
   --color-green: #35c98d;
   --color-fuchsia: #f14ca3;
 

--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -45,7 +45,7 @@
   /* Secondary colors */
   --color-orange: #f57b47;
   --color-green: #35c98d;
-  --color-fuchsia: #dd117d;
+  --color-fuchsia: #f14ca3;
 
   /* Other colors */
   --color-red: #de1d0b;

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -180,7 +180,7 @@
 }
 
 .Button--primary:active {
-  /* background-color: color-mod(var(--Button-primary-background-color) shade(10%)); */
+  background-color: color-mod(var(--Button-primary-background-color) shade(10%));
 }
 
 .Button--primaryDark,
@@ -236,7 +236,7 @@
 .Button--negative,
 .Button--negative:matches(:--enter) {
   color: var(--Button-negative-color);
-  border-color: color-mod(var(--Button-negative-background-color) shade(15%));
+  border-color: color-mod(var(--Button-negative-background-color) shade(10%));
   background-color: var(--Button-negative-background-color);
 }
 

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -162,7 +162,7 @@
  */
 
 :root {
-  --Button-primary-background-color: var(--color-fuchsia);
+  --Button-primary-background-color: #dd117d;
   --Button-primary-color: var(--color-white);
   --Button-primaryDark-background-color: color-mod(var(--color-navy) l(+30%));
 }
@@ -204,7 +204,7 @@
  */
 
 :root {
-  --Button-positive-background-color: #06834f;
+  --Button-positive-background-color: #068362;
   --Button-positive-color: var(--color-white);
 }
 

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -204,7 +204,7 @@
  */
 
 :root {
-  --Button-positive-background-color: #068358;
+  --Button-positive-background-color: #06834f;
   --Button-positive-color: var(--color-white);
 }
 

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -162,7 +162,7 @@
  */
 
 :root {
-  --Button-primary-background-color: var(--color-orange);
+  --Button-primary-background-color: var(--color-fuchsia);
   --Button-primary-color: var(--color-white);
   --Button-primaryDark-background-color: color-mod(var(--color-navy) l(+30%));
 }
@@ -180,7 +180,7 @@
 }
 
 .Button--primary:active {
-  background-color: color-mod(var(--Button-primary-background-color) shade(10%));
+  /* background-color: color-mod(var(--Button-primary-background-color) shade(10%)); */
 }
 
 .Button--primaryDark,
@@ -204,7 +204,7 @@
  */
 
 :root {
-  --Button-positive-background-color: var(--color-green);
+  --Button-positive-background-color: #068358;
   --Button-positive-color: var(--color-white);
 }
 

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -236,7 +236,7 @@
 .Button--negative,
 .Button--negative:matches(:--enter) {
   color: var(--Button-negative-color);
-  border-color: color-mod(var(--Button-negative-background-color) shade(10%));
+  border-color: color-mod(var(--Button-negative-background-color) shade(15%));
   background-color: var(--Button-negative-background-color);
 }
 

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -162,7 +162,7 @@
  */
 
 :root {
-  --Button-primary-background-color: #dd117d;
+  --Button-primary-background-color: var(--color-fuchsia);
   --Button-primary-color: var(--color-white);
   --Button-primaryDark-background-color: color-mod(var(--color-navy) l(+30%));
 }
@@ -204,7 +204,7 @@
  */
 
 :root {
-  --Button-positive-background-color: #068362;
+  --Button-positive-background-color: var(--color-green);
   --Button-positive-color: var(--color-white);
 }
 

--- a/src/data/colors.yml
+++ b/src/data/colors.yml
@@ -9,7 +9,7 @@ primary:
 accents:
   - color: "#F26941"
     property: "--color-orange"
-  - color: "#35C98D"
+  - color: "#068362"
     property: "--color-green"
-  - color: "#F14CA3"
+  - color: "#DD117D"
     property: "--color-fuchsia"

--- a/src/pages/sandbox/danielle-buttons.hbs
+++ b/src/pages/sandbox/danielle-buttons.hbs
@@ -45,7 +45,6 @@ notes: |
       {{/iterate}}
     </div>
 
-
   </div>
   <div class="u-containSpread">
     <hr class="u-spaceSides1 u-spaceEndsNone">

--- a/src/pages/sandbox/danielle-buttons.hbs
+++ b/src/pages/sandbox/danielle-buttons.hbs
@@ -1,0 +1,57 @@
+---
+title: Button Style Exploration
+layout: toolkit.blank
+notes: |
+  Test page to show buttons in use.
+---
+
+
+{{{embed "patterns.components.sky.base"}}}
+
+<main role="main" id="main">
+  {{#embed "patterns.components.sky.base" class="Sky--clouds"}}
+    {{#content "top"}}
+      {{! Intro }}
+      <div class="u-containProse u-md-spaceSidesNone u-spaceBottom1 u-spaceItems1 u-pad1 u-textWhite">
+        <h1 class="u-textGrow5 u-sm-textGrow6">Page Heading</h1>
+        <p class="TextBlock u-sm-textGrow2">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+        <button class="Button Button--defaultDark" type="button">
+          Default Dark
+        </button>
+      </div>
+    {{/content}}
+  {{/embed}}
+
+  <div class="u-bgWhite">
+    <div class="u-containSpread u-pad1">
+
+    {{! The Work }}
+    <div class="Grid Work u-spaceTop4 u-posRelative u-posRelative">
+      {{#iterate 2}}
+      <div class="Grid-cell u-flex u-flexCol u-md-size1of2 u-spaceEnds2">
+        <h2 class="u-textGrow2 u-sm-textGrow2">Heading</h2>
+        <p class="u-spaceTop02 u-spaceBottom1 u-md-padRight3">
+          {{random "paragraph"}}
+        </p>
+        <p>
+          <button class="Button Button--default">
+            Read more
+            {{svg "icons/arrow-right" class="Icon" role="presentation"}}
+          </button>
+        </p>
+      </div>
+      {{/iterate}}
+    </div>
+
+
+  </div>
+  <div class="u-containSpread">
+    <hr class="u-spaceSides1 u-spaceEndsNone">
+    {{> toolkit.page-segue }}
+  </div>
+</div>
+</main>
+
+{{> toolkit.global-footer }}


### PR DESCRIPTION
## Summary

The existing "primary" and "positive" buttons don't meet WCAG standards for accessibility. To make the “primary” and “positive” buttons accessible, this PR updates several colors including:

- `--color-green`
- `--color-fuchsia`
- `--color-red`

It also adds a new page to the sandbox to test how the new button styles look in use.

## Screenshots

### Before
<img width="514" alt="before" src="https://user-images.githubusercontent.com/42841342/65623142-025b7e00-df7c-11e9-9e8d-7b58e81ccc7f.png">

### After
![after](https://user-images.githubusercontent.com/42841342/65623159-08e9f580-df7c-11e9-9ae3-6dee4892b83c.png)
