### PR TITLE
Update the Color Gray

### DIFF
--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -40,7 +40,7 @@
   /* Primary colors */
   --color-navy: #0f1c3f;
   --color-blue: #456bd9;
-  --color-gray: #dbe5ea;
+  --color-gray: #dee7ec;
 
   /* Secondary colors */
   --color-orange: #f26941;

--- a/src/data/colors.yml
+++ b/src/data/colors.yml
@@ -3,7 +3,7 @@ primary:
     property: "--color-navy"
   - color: "#456BD9"
     property: "--color-blue"
-  - color: "#DBE5EA"
+  - color: "#DEE7EC"
     property: "--color-gray"
 
 accents:

--- a/src/static/images/portland.svg
+++ b/src/static/images/portland.svg
@@ -6,14 +6,14 @@
     <polygon id="tree" points="0,70 30,0 60,70"/>
     <use id="tree-bg" xlink:href="#tree" fill="#249579"/>
     <use id="tree-fg" xlink:href="#tree" fill="#35C98D"/>
-    <g id="limbs" stroke="#DBE5EA">
+    <g id="limbs" stroke="#dee7ec">
       <line x1="30" y1="30" x2="30" y2="70"/>
       <line x1="30" y1="45" x2="40" y2="37"/>
       <line x1="21" y1="44" x2="30" y2="50"/>
       <line x1="30" y1="55" x2="40" y2="47"/>
     </g>
     <g id="building">
-      <rect x="0" y="0" width="38" height="48" fill="#D8E5EA"/>
+      <rect x="0" y="0" width="38" height="48" fill="#dee7ec"/>
       <rect id="building-detail" x="0" y="3" width="38" height="3" fill="#9FB3BE"/>
       <use xlink:href="#building-detail" y="6"/>
     </g>


### PR DESCRIPTION
## Summary

The links in the site footer are not currently accessible. This PR updates `--color-gray` so that the site footer links meet WCAG color contrast standards.

## Screenshots

### Before

![footer-before](https://user-images.githubusercontent.com/42841342/65645119-297d7400-dfab-11e9-9ff1-427a0c50442f.png)

### After

![footer-after](https://user-images.githubusercontent.com/42841342/65645144-339f7280-dfab-11e9-9e16-2dd49b84d584.png)
