### PR TITLE
Add New Spacing Utilities

### DIFF
--- a/src/assets/toolkit/styles/utils/space.css
+++ b/src/assets/toolkit/styles/utils/space.css
@@ -11,11 +11,8 @@
     margin-top: $(value) !important;
   }
 
-  .u-staggerHeadings$(suffix) > * + :--headings {
-    margin-top: $(value) !important;
-  }
-
-  .u-staggerNestedHeadings$(suffix) > * > :--headings {
+  .u-staggerHeadings$(suffix) > * + :--headings,
+  .u-staggerHeadings$(suffix) > * + .HashHeading {
     margin-top: $(value) !important;
   }
 }

--- a/src/assets/toolkit/styles/utils/space.css
+++ b/src/assets/toolkit/styles/utils/space.css
@@ -10,6 +10,10 @@
   .u-staggerItems$(suffix) > * + * {
     margin-top: $(value) !important;
   }
+
+  .u-staggerHeadings$(suffix) > * + :--headings {
+    margin-top: $(value) !important;
+  }
 }
 
 @define-mixin makePullUtils $value, $suffix, $prefix {

--- a/src/assets/toolkit/styles/utils/space.css
+++ b/src/assets/toolkit/styles/utils/space.css
@@ -14,6 +14,10 @@
   .u-staggerHeadings$(suffix) > * + :--headings {
     margin-top: $(value) !important;
   }
+
+  .u-staggerNestedHeadings$(suffix) > * > :--headings {
+    margin-top: $(value) !important;
+  }
 }
 
 @define-mixin makePullUtils $value, $suffix, $prefix {

--- a/src/pages/sandbox/danielle-stagger-headings-a.hbs
+++ b/src/pages/sandbox/danielle-stagger-headings-a.hbs
@@ -3,7 +3,7 @@ title: Stagger Headings A
 layout: toolkit.default
 ---
 
-<div class="u-staggerItems u-staggerHeadings3 u-staggerNestedHeadings3">
+<div class="u-staggerItems u-staggerHeadings3">
   <h1>Heading</h1>
   {{#iterate 2}}
     <p>{{random "paragraph"}}</p>

--- a/src/pages/sandbox/danielle-stagger-headings-a.hbs
+++ b/src/pages/sandbox/danielle-stagger-headings-a.hbs
@@ -1,9 +1,9 @@
 ---
-title: Stagger Headings
+title: Stagger Headings A
 layout: toolkit.default
 ---
 
-<div class="u-staggerItems u-staggerHeadings3">
+<div class="u-staggerItems u-staggerHeadings3 u-staggerNestedHeadings3">
   <h1>Heading</h1>
   {{#iterate 2}}
     <p>{{random "paragraph"}}</p>

--- a/src/pages/sandbox/danielle-stagger-headings-b.hbs
+++ b/src/pages/sandbox/danielle-stagger-headings-b.hbs
@@ -1,0 +1,59 @@
+---
+title: Stagger Headings B
+layout: toolkit.default
+---
+
+<div class="u-staggerItems u-staggerHeadings3 u-staggerNestedHeadings3">
+  <h1>Heading</h1>
+  {{#iterate 2}}
+    <p>{{random "paragraph"}}</p>
+  {{/iterate}}
+  <div class="HashHeading HashHeading--h2">
+    <h2>
+      This Is a Subhead 2
+    </h2>
+    <a href="#HashHeading-demo-2" label="Permalink for This Is a Subhead 2"
+     class="HashHeading-link">
+      {{svg "icons/link" class="Icon" aria-hidden="true"}}
+    </a>
+  </div>
+  {{#iterate 2}}
+    <p>{{random "paragraph"}}</p>
+  {{/iterate}}
+  <div class="HashHeading HashHeading--h3">
+    <h3>
+      This Is a Subhead 3
+    </h3>
+    <a href="#HashHeading-demo-2" label="Permalink for This Is a Subhead 2"
+     class="HashHeading-link">
+      {{svg "icons/link" class="Icon" aria-hidden="true"}}
+    </a>
+  </div>
+  {{#iterate 2}}
+    <p>{{random "paragraph"}}</p>
+  {{/iterate}}
+  <div class="HashHeading HashHeading--h2">
+    <h2>
+      This Is a Subhead 2
+    </h2>
+    <a href="#HashHeading-demo-2" label="Permalink for This Is a Subhead 2"
+     class="HashHeading-link">
+      {{svg "icons/link" class="Icon" aria-hidden="true"}}
+    </a>
+  </div>
+  {{#iterate 2}}
+    <p>{{random "paragraph"}}</p>
+  {{/iterate}}
+  <div class="HashHeading HashHeading--h3">
+    <h3>
+      This Is a Subhead 3
+    </h3>
+    <a href="#HashHeading-demo-2" label="Permalink for This Is a Subhead 2"
+     class="HashHeading-link">
+      {{svg "icons/link" class="Icon" aria-hidden="true"}}
+    </a>
+  </div>
+  {{#iterate 2}}
+    <p>{{random "paragraph"}}</p>
+  {{/iterate}}
+</div>

--- a/src/pages/sandbox/danielle-stagger-headings-b.hbs
+++ b/src/pages/sandbox/danielle-stagger-headings-b.hbs
@@ -3,7 +3,7 @@ title: Stagger Headings B
 layout: toolkit.default
 ---
 
-<div class="u-staggerItems u-staggerHeadings3 u-staggerNestedHeadings3">
+<div class="u-staggerItems u-staggerHeadings3">
   <h1>Heading</h1>
   {{#iterate 2}}
     <p>{{random "paragraph"}}</p>

--- a/src/pages/sandbox/danielle-stagger-headings.hbs
+++ b/src/pages/sandbox/danielle-stagger-headings.hbs
@@ -1,0 +1,15 @@
+---
+title: Stagger Headings
+layout: toolkit.default
+---
+
+<div class="u-staggerItems u-staggerHeadings3">
+  <h1>Heading</h1>
+  {{#iterate 2}}
+    <p>{{random "paragraph"}}</p>
+  {{/iterate}}
+  <h1>Heading</h1>
+  {{#iterate 2}}
+    <p>{{random "paragraph"}}</p>
+  {{/iterate}}
+</div>

--- a/src/patterns/utilities/space.hbs
+++ b/src/patterns/utilities/space.hbs
@@ -14,6 +14,9 @@ notes: |
   + `u-spaceRightX` applies `margin` to right.
   + `u-spaceItemsX` applies vertical `margin` between adjacent items.
   + `u-staggerItemsX` applies vertical `margin` between adjacent items proportional to the item's `font-size`.
+  + `u-staggerHeadingsX` applies vertical `margin` between adjacent items using
+  a larger proportion than `u-staggerItems` to further differentiate headings
+  from preceding content.
   + `u-padX` applies `padding` all around.
   + `u-padEndsX` applies `padding` to top and bottom.
   + `u-padSidesX` applies `padding` to left and right.
@@ -33,8 +36,8 @@ notes: |
   leading zero (`01` through `06`) for whitespace smaller than the ratio with
   any of the above utilities except `u-pull*`.
 
-  With the exception of `u-spaceItems*`, all of these utilities support our
-  standard breakpoint abbreviations of `sm`, `md` and `lg`.
+  With the exception of `u-spaceItems*` and `u-staggerHeadings`, all of these
+  utilities support our standard breakpoint abbreviations of `sm`, `md` and `lg`.
 ---
 
 <div class="u-borderLeftMd u-padLeftNone">

--- a/src/patterns/utilities/space.hbs
+++ b/src/patterns/utilities/space.hbs
@@ -16,9 +16,6 @@ notes: |
   + `u-staggerItemsX` applies vertical `margin` between adjacent items proportional to the item's `font-size`.
   + `u-staggerHeadingsX` can be used to apply increased vertical `margin` to
   headings. Useful for increasing contrast between headings and their preceding content.
-  + `u-staggerNestedHeadingsX` can be used to apply increased vertical `margin`
-  to nested headings. Useful for increasing contrast between elements like
-  `HashHeading` and their preceding content.
   + `u-padX` applies `padding` all around.
   + `u-padEndsX` applies `padding` to top and bottom.
   + `u-padSidesX` applies `padding` to left and right.

--- a/src/patterns/utilities/space.hbs
+++ b/src/patterns/utilities/space.hbs
@@ -14,9 +14,11 @@ notes: |
   + `u-spaceRightX` applies `margin` to right.
   + `u-spaceItemsX` applies vertical `margin` between adjacent items.
   + `u-staggerItemsX` applies vertical `margin` between adjacent items proportional to the item's `font-size`.
-  + `u-staggerHeadingsX` applies vertical `margin` between adjacent items using
-  a larger proportion than `u-staggerItems` to further differentiate headings
-  from preceding content.
+  + `u-staggerHeadingsX` can be used to apply increased vertical `margin` to
+  headings. Useful for increasing contrast between headings and their preceding content.
+  + `u-staggerNestedHeadingsX` can be used to apply increased vertical `margin`
+  to nested headings. Useful for increasing contrast between elements like
+  `HashHeading` and their preceding content.
   + `u-padX` applies `padding` all around.
   + `u-padEndsX` applies `padding` to top and bottom.
   + `u-padSidesX` applies `padding` to left and right.
@@ -36,7 +38,7 @@ notes: |
   leading zero (`01` through `06`) for whitespace smaller than the ratio with
   any of the above utilities except `u-pull*`.
 
-  With the exception of `u-spaceItems*` and `u-staggerHeadings`, all of these
+  With the exception of `u-spaceItems*` and `u-stagger*`, all of these
   utilities support our standard breakpoint abbreviations of `sm`, `md` and `lg`.
 ---
 


### PR DESCRIPTION
## Summary 

While we have `u-staggerItems` utilities, sometimes they don't provide enough contrast between  elements. This PR add two new spacing utilities that help to adjust the space between headings and their preceding content:

- `u-staggerHeadings`
- `u-staggerNestedHeadings`

## Screenshots

### `u-staggerItems`

![stagger-items](https://user-images.githubusercontent.com/42841342/65788632-5c8d4800-e110-11e9-9425-a3ae53630b34.png)

### `u-staggerHeadings`

![stagger-headings](https://user-images.githubusercontent.com/42841342/65788646-63b45600-e110-11e9-9c9f-5702454f5f95.png)

### `u-staggerNestedHeadings`

![stagger-nested-headings](https://user-images.githubusercontent.com/42841342/65788667-6b73fa80-e110-11e9-9c78-7462441cbf7c.png)

### Space Utilities

<img width="1062" alt="utilities" src="https://user-images.githubusercontent.com/42841342/65788712-86466f00-e110-11e9-89b5-d9312c9539a9.png">
