### PR TITLE
Differentiate fuchsia variations

### DIFF
--- a/src/assets/toolkit/styles/base/_config.css
+++ b/src/assets/toolkit/styles/base/_config.css
@@ -45,7 +45,8 @@
   /* Secondary colors */
   --color-orange: #f26941;
   --color-green: #068362;
-  --color-fuchsia: #dd117d;
+  --color-fuchsia: #F14CA3;
+  --color-orchid: #dd117d;
 
   /* Other colors */
   --color-red: #de1d0b;

--- a/src/assets/toolkit/styles/components/button.css
+++ b/src/assets/toolkit/styles/components/button.css
@@ -162,7 +162,7 @@
  */
 
 :root {
-  --Button-primary-background-color: var(--color-fuchsia);
+  --Button-primary-background-color: var(--color-orchid);
   --Button-primary-color: var(--color-white);
   --Button-primaryDark-background-color: color-mod(var(--color-navy) l(+30%));
 }

--- a/src/assets/toolkit/styles/components/calendar-date.css
+++ b/src/assets/toolkit/styles/components/calendar-date.css
@@ -10,7 +10,7 @@
   --CalendarDate-min-height: 4.5em;
   --CalendarDate-min-width: 4.5em;
 
-  --CalendarDate-header-background: var(--color-fuchsia);
+  --CalendarDate-header-background: var(--color-orchid);
   --CalendarDate-header-border-bottom-width: var(--border-width-md);
   --CalendarDate-header-color: var(--color-white);
 

--- a/src/data/colors.yml
+++ b/src/data/colors.yml
@@ -12,4 +12,6 @@ accents:
   - color: "#068362"
     property: "--color-green"
   - color: "#DD117D"
+    property: "--color-orchid"
+  - color: "#F14CA3"
     property: "--color-fuchsia"


### PR DESCRIPTION
## Overview

As part of #444, we updated the shade of `--color-fuchsia` for accessibility. Unfortunately, this introduced regressions to the contrast accessibility of that color on dark backgrounds, for example in code blocks.

This PR restores the previous value of `--color-fuchsia`, moves the new value to `--color-orchid` (based on the most similar color keyword) and applies either value selectively.

## Screenshots

### Before

<img width="978" alt="Screen Shot 2019-10-01 at 12 22 15 PM" src="https://user-images.githubusercontent.com/69633/65993600-68497900-e446-11e9-9f10-129be4d4a565.png">

### After

<img width="980" alt="Screen Shot 2019-10-01 at 12 22 02 PM" src="https://user-images.githubusercontent.com/69633/65993619-70a1b400-e446-11e9-94b2-94b355d3d903.png">
