### PR TITLE
Syntax highlighting tweaks

### DIFF
--- a/src/assets/toolkit/styles/vendor/prism.css
+++ b/src/assets/toolkit/styles/vendor/prism.css
@@ -31,7 +31,8 @@
 .token.tag,
 .token.regex,
 .token.number,
-.token.boolean {
+.token.boolean,
+.token.function {
   color: color-mod(var(--color-fuchsia) l(+10%));
 }
 

--- a/src/assets/toolkit/styles/vendor/prism.css
+++ b/src/assets/toolkit/styles/vendor/prism.css
@@ -24,7 +24,7 @@
 .token.attr-value,
 .token.selector,
 .token.class-name {
-  color: color-mod(var(--color-green) l(+15%));
+  color: color-mod(var(--color-green) l(+17%));
 }
 
 .token.rule,

--- a/src/patterns/components/cms-content/base.hbs
+++ b/src/patterns/components/cms-content/base.hbs
@@ -55,8 +55,8 @@ sourceless: true
 // Sort by programming language
 repos = indexedRepos.sort((a, b) => {
   if (a.language === b.language) {
-    return a.index < b.index ? -1 : 1;
+    return a.index &lt; b.index ? -1 : 1;
   }
-  return a.language < b.language ? -1 : 1;
+  return a.language &lt; b.language ? -1 : 1;
 });</code></pre>
 </article>

--- a/src/patterns/components/cms-content/base.hbs
+++ b/src/patterns/components/cms-content/base.hbs
@@ -3,16 +3,19 @@ notes: |
   The `.CmsContent` class is used on the parent element of CMS prose fields to style some common child elements:
     + `<pre>`: Adds padding and negative margins
     + `<blockquote>`: Adds border and lightens color
+sourceless: true
 ---
 
 <article class="CmsContent u-staggerItems1">
   <p>
     {{random "paragraph" sentences="2"}}
   </p>
-  <pre><code class="language-css">.CodeSample {
-  display: block;
-  padding: 1rem;
-}</code></pre>
+  <pre><code class="language-html">&lt;button class="Button"&gt;
+  &lt;span class="Button-inner"&gt;
+    Example
+  &lt;/span&gt;
+  &lt;!-- badge, etc. --&gt;
+&lt;/button&gt;</code></pre>
   <p>
     {{random "paragraph" sentences="2"}}
   </p>
@@ -27,4 +30,33 @@ notes: |
   <p>
     {{random "paragraph" sentences="2"}}
   </p>
+  <pre><code class="language-css">.sr-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: polygon(0px 0px, 0px 0px, 0px 0px);
+  -webkit-clip-path: polygon(0px 0px, 0px 0px, 0px 0px);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
+}</code></pre>
+  <p>
+    {{random "paragraph" sentences="2"}}
+  </p>
+  <pre><code class="language-js">const indexedRepos = repos.map((repo, index) => ({
+  name: repo.name,
+  language: String(repo.language),
+  index,
+}));
+
+// Sort by programming language
+repos = indexedRepos.sort((a, b) => {
+  if (a.language === b.language) {
+    return a.index < b.index ? -1 : 1;
+  }
+  return a.language < b.language ? -1 : 1;
+});</code></pre>
 </article>


### PR DESCRIPTION
## Overview

I noticed on some recent blog post drafts that functions had no syntax highlighting in either CSS or JavaScript. This adds that, plus tweaks the green just a tad (since that hue was changed for buttons recently).

## Screenshot

![Screenshot_2019-10-15 Cms Content - Drizzle](https://user-images.githubusercontent.com/69633/66874983-a9bb4780-ef61-11e9-9f46-4867c1222908.png)
