### PR TITLE
Add initial base styles

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,7 @@
+import { addDecorator } from '@storybook/html';
+import { withA11y } from '@storybook/addon-a11y';
+import centered from '@storybook/addon-centered/html';
+import './preview.scss';
+
+addDecorator(centered);
+addDecorator(withA11y);

--- a/.storybook/preview.scss
+++ b/.storybook/preview.scss
@@ -1,0 +1,4 @@
+// Foundational styles
+@use "../src/base";
+
+// Tweaks for story display can start here

--- a/package-lock.json
+++ b/package-lock.json
@@ -1434,6 +1434,18 @@
         "util-deprecate": "^1.0.2"
       }
     },
+    "@storybook/addon-centered": {
+      "version": "5.3.13",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-centered/-/addon-centered-5.3.13.tgz",
+      "integrity": "sha512-B+eAy+WeS4GqwZlOag2Ee3cOcF+Ryrhzfylru8U+ZIc0yDwm+qQEcX24LNQ6gHzpiWmutMQH+ZNi+3cw1n36Jg==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "5.3.13",
+        "core-js": "^3.0.1",
+        "global": "^4.3.2",
+        "util-deprecate": "^1.0.2"
+      }
+    },
     "@storybook/addon-docs": {
       "version": "5.3.13",
       "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-5.3.13.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@storybook/addon-a11y": "^5.3.13",
+    "@storybook/addon-centered": "^5.3.13",
     "@storybook/addon-docs": "^5.3.13",
     "@storybook/addon-knobs": "^5.3.13",
     "@storybook/addon-viewport": "^5.3.13",

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -1,0 +1,78 @@
+/**
+ * Sensible box model
+ */
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
+
+/**
+ * 1. Remove white space surrounding page.
+ */
+body {
+  margin: 0; /* 1 */
+}
+
+/**
+ * 1. Block display is usually what we want
+ * 2. Remove strange space-below when inline
+ * 3. Responsive by default
+ *
+ * @see https://github.com/mozdevs/cssremedy
+ */
+audio,
+canvas,
+embed,
+iframe,
+img,
+object,
+svg,
+video {
+  display: block; /* 1 */
+  vertical-align: middle; /* 2 */
+  max-width: 100%; /* 3 */
+}
+
+canvas,
+img,
+svg,
+video {
+  height: auto;
+}
+
+audio {
+  width: 100%;
+}
+
+/**
+ * Don't allow code blocks to overflow willy-nilly.
+ */
+pre {
+  overflow: auto;
+}
+
+/**
+ * Old browser fixes
+ */
+
+img {
+  border-style: none;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+article,
+aside,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+nav,
+section {
+  display: block;
+}

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -8,10 +8,10 @@
 }
 
 /**
- * 1. Remove white space surrounding page.
+ * Remove white space surrounding page.
  */
 body {
-  margin: 0; /* 1 */
+  margin: 0;
 }
 
 /**
@@ -34,6 +34,10 @@ video {
   max-width: 100%; /* 3 */
 }
 
+/**
+ * Embedded elements with consistent aspect ratios require this to maintain
+ * that ratio when resized.
+ */
 canvas,
 img,
 svg,
@@ -41,6 +45,9 @@ video {
   height: auto;
 }
 
+/**
+ * It's pretty arbitrary that audio elements are 300px wide by default.
+ */
 audio {
   width: 100%;
 }
@@ -53,17 +60,25 @@ pre {
 }
 
 /**
- * Old browser fixes
+ * IE10 and earlier still show borders around linked images. While usage of that
+ * browser is low, this is an easy fix to include.
  */
-
 img {
   border-style: none;
 }
 
+/**
+ * IE10 and earlier do not respect the `hidden` attribute.
+ *
+ * @see https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/
+ */
 [hidden] {
   display: none !important;
 }
 
+/**
+ * IE11 and earlier display some HTML5 elements as `inline` by default.
+ */
 article,
 aside,
 figcaption,

--- a/src/base/_index.scss
+++ b/src/base/_index.scss
@@ -1,0 +1,2 @@
+@use "_defaults";
+@use "_typography";

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -1,0 +1,17 @@
+/**
+ * Promote consistent line spacing.
+ *
+ * @see https://drafts.csswg.org/css-inline-3/#line-sizing-property
+ */
+html {
+  line-sizing: normal;
+}
+
+/**
+ * 1. Prevent size adjustments on orientation change.
+ * 2. Allow long words (like URLs) to break at arbitrary points.
+ */
+body {
+  text-size-adjust: none; /* 1 */
+  word-wrap: break-word; /* 2 */
+}

--- a/src/demo/button/button.stories.mdx
+++ b/src/demo/button/button.stories.mdx
@@ -1,12 +1,11 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
 import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
-import { withA11y } from '@storybook/addon-a11y';
 import template from './button.twig';
 import './button.scss';
 
 <Meta
   title="Demo/Button"
-  decorators={[withKnobs, withA11y]}/>
+  decorators={[withKnobs]}/>
 
 # Button
 


### PR DESCRIPTION
## Overview

This PR adds some initial base/reset/normalize styles to the project. It then includes these in every Storybook preview via [a preview configuration file](https://medium.com/storybookjs/declarative-storybook-configuration-49912f77b78). This file also allowed me to simplify configuration of global decorators, specifically the a11y add-on.

After implementing these base styles, I noticed that all of the examples were running up against the edge of their container. I decided to install the extremely popular [centered add-on](https://github.com/storybookjs/storybook/tree/master/addons/centered), but if we dislike it we can use the `preview.scss` file to further customize however we wish.

## Testing

Either locally or at the deploy preview URL:

1. Inspect any of the demo elements and confirm that its `box-sizing` has been set to `border-box`.
1. Observe that story canvas contents are now centered.

## Screenshot

<img width="1016" alt="Screen Shot 2020-02-24 at 4 09 42 PM" src="https://user-images.githubusercontent.com/69633/75202458-26d0a780-5720-11ea-8130-7105a2e51a87.png">

---

Closes #476 