### PR TITLE
Add choosable backgrounds

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,6 +4,7 @@ module.exports = {
   stories: ['../src/**/*.stories.(js|mdx)'],
   addons: [
     '@storybook/addon-a11y/register',
+    '@storybook/addon-backgrounds/register',
     '@storybook/addon-docs',
     '@storybook/addon-knobs/register',
     '@storybook/addon-viewport/register',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,18 @@
-import { addDecorator } from '@storybook/html';
+import { addDecorator, addParameters } from '@storybook/html';
 import { withA11y } from '@storybook/addon-a11y';
 import centered from '@storybook/addon-centered/html';
+import * as colors from '../src/design-tokens/colors.yml';
 import './preview.scss';
 
+// Add decorators to all stories
 addDecorator(centered);
 addDecorator(withA11y);
+
+// Set choosable backgrounds for stories
+const backgrounds = [
+  'primaryBrand',
+  'primaryBrandDarker',
+  'grayLighter'
+].map(name => ({ name, value: colors[name] }));
+
+addParameters({ backgrounds });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1491,6 +1491,168 @@
         "util-deprecate": "^1.0.2"
       }
     },
+    "@storybook/addon-backgrounds": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-5.3.14.tgz",
+      "integrity": "sha512-wrrbVrXV81+iHSf0Ejf9E9vwzVYhvVn0WoqY1ccneEWVWgiPwnptOCS5yYzsCQ2Riye2QutqBvZtaa0k88oKFA==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "5.3.14",
+        "@storybook/api": "5.3.14",
+        "@storybook/client-logger": "5.3.14",
+        "@storybook/components": "5.3.14",
+        "@storybook/core-events": "5.3.14",
+        "@storybook/theming": "5.3.14",
+        "core-js": "^3.0.1",
+        "memoizerific": "^1.11.3",
+        "react": "^16.8.3",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "5.3.14",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.14.tgz",
+          "integrity": "sha512-zoN1MYlArdThp93i+Ogil/pihyx8n7nkrdSO0j9HUh6jUsGeFFEluPQZdRFte9NIoY6ZWSWwuEMDgrv2Pw9r2Q==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "5.3.14",
+            "@storybook/channels": "5.3.14",
+            "@storybook/client-logger": "5.3.14",
+            "@storybook/core-events": "5.3.14",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/api": {
+          "version": "5.3.14",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.14.tgz",
+          "integrity": "sha512-ANWRMTLEoAfu0IsXqbxmbTpxS8xTByZgLj20tH96bxgH1rJo9KAZnJ8A9kGYr+zklU8QnYvVIgmV3HESXII9zg==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/channels": "5.3.14",
+            "@storybook/client-logger": "5.3.14",
+            "@storybook/core-events": "5.3.14",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "5.3.14",
+            "@storybook/theming": "5.3.14",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.3",
+            "semver": "^6.0.0",
+            "shallow-equal": "^1.1.0",
+            "store2": "^2.7.1",
+            "telejson": "^3.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channels": {
+          "version": "5.3.14",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.14.tgz",
+          "integrity": "sha512-k9QBf9Kwe+iGmdEK/kW5xprqem2SPfBVwET6LWvJkWOl9UQ9VoMuCHgV55p0tzjcugaqWWKoF9+FRMWxWRfsQg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.3.14",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.14.tgz",
+          "integrity": "sha512-YCHEsOvo6zPb4udlyAwqr5W0Kv9mAEQmcX73w9IDvAxbjR00T7empW7qmbjvviftKB/5MEgDdiYbj64ccs3aqg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/components": {
+          "version": "5.3.14",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.3.14.tgz",
+          "integrity": "sha512-AsjkIFBrrqcBDLxGdmUHiauZo5gOL65eXx8WA7/yJDF8s45VVZX5Z0buOnjFyEhGVus02gwTov8da2irjL862A==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "5.3.14",
+            "@storybook/theming": "5.3.14",
+            "@types/react-syntax-highlighter": "11.0.2",
+            "@types/react-textarea-autosize": "^4.3.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "markdown-to-jsx": "^6.9.1",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "popper.js": "^1.14.7",
+            "prop-types": "^15.7.2",
+            "react": "^16.8.3",
+            "react-dom": "^16.8.3",
+            "react-focus-lock": "^2.1.0",
+            "react-helmet-async": "^1.0.2",
+            "react-popper-tooltip": "^2.8.3",
+            "react-syntax-highlighter": "^11.0.2",
+            "react-textarea-autosize": "^7.1.0",
+            "simplebar-react": "^1.0.0-alpha.6",
+            "ts-dedent": "^1.1.0"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "5.3.14",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.14.tgz",
+          "integrity": "sha512-VCPLKqRugsOSx/smMJiJOvRgAzTrMpsbRuFw48kBGkQMP9TEV82Qe/341dv+f4GllPyBZyANG0p0m5+w7ZCURQ==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/router": {
+          "version": "5.3.14",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.14.tgz",
+          "integrity": "sha512-O0KwQFncdBeq+O2Aq8UAFBVWjWmP5rtqoacUOFSGkXgObOnyniEraLiPH7rPtq2dAlSpgYI9+srQAZfo52Hz2A==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/csf": "0.0.1",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.3.14",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.14.tgz",
+          "integrity": "sha512-raqXC3yJycEt1CrCAfnBYUA6pyJI80E9M26EeQl3UfytJOL6euprOi+D17QvxqBn7jmmf9ZDw5XRkvJhQ17Y7Q==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "5.3.14",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "@storybook/addon-centered": {
       "version": "5.3.13",
       "resolved": "https://registry.npmjs.org/@storybook/addon-centered/-/addon-centered-5.3.13.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/core": "^7.8.4",
     "@cloudfour/eslint-plugin": "^6.0.0",
     "@storybook/addon-a11y": "^5.3.13",
+    "@storybook/addon-backgrounds": "^5.3.14",
     "@storybook/addon-centered": "^5.3.13",
     "@storybook/addon-docs": "^5.3.13",
     "@storybook/addon-knobs": "^5.3.13",


### PR DESCRIPTION
## Overview

This adds the "Backgrounds" add-on for Storybook. This allows us to swap the preview canvas's background for one of those in our color palette. We can also re-run accessibility tests once a background is applied.

I reached a point where I would find this useful while working on #475.

## Screenshots

![bg-change](https://user-images.githubusercontent.com/69633/75828296-5efb6a00-5d60-11ea-8fb4-00c6d479a127.gif)
