### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,38 @@
-# Cloud Four Patterns
+<p align="center"><img src="https://cloudfour.com/android-chrome-512x512.png" alt="" width="128" height="128"></p>
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/1923e350-3172-409a-9361-b04d54d1c3b4/deploy-status)](https://app.netlify.com/sites/cloudfour-patterns/deploys)
+# Cloud Four Patterns 🚧
 
-🚧 This version of the pattern library is heavily work in progress.
+[![Netlify Status](https://api.netlify.com/api/v1/badges/1923e350-3172-409a-9361-b04d54d1c3b4/deploy-status)](https://app.netlify.com/sites/cloudfour-patterns/deploys?filter=v-next)
+
+You are currently viewing the `v-next` branch. This represents a significant refactor of our environment and coding standards. It is a work in progress and not yet ready for use.
+
+If you’re looking for the most stable version of our pattern library, check out [the `master` branch](https://github.com/cloudfour/cloudfour.com-patterns/tree/master).
+
+[View Netlify Preview →](https://v-next--cloudfour-patterns.netlify.com/)
 
 ## Getting Started
 
 1. `npm ci`
 1. `npm run storybook`
+
+## Project Structure
+
+```
+📦cloudfour.com-patterns
+├── 📁.github               # GitHub workflows and templates
+├── 📁.storybook
+│   ├── 📄main.js           # Settings for Storybook UI
+│   └── 📄preview.js        # Settings for story previews
+├── 📁src
+│   ├── 📄**/*.scss         # Styles (Sass)
+│   ├── 📄**/*.stories.mdx  # Documentation (Storybook Docs)
+│   ├── 📄**/*.twig         # Templates (Twig)
+│   └── 📄**/*.yml          # Design tokens (Theo)
+├── 📄.editorconfig         # Low-level code consistency
+├── 📄.nvmrc                # Node version (used by Netlify)
+├── 📄.svgo.yml             # Inline SVG optimization settings
+├── 📄README.md             # ⬅️ You are here!
+├── 📄gulpfile.js           # Complex build task configuration
+├── 📄netlify.toml          # Netlify build settings
+└── 📄package.json          # Project info and dependencies
+```

--- a/README.md
+++ b/README.md
@@ -18,21 +18,21 @@ If you’re looking for the most stable version of our pattern library, check ou
 ## Project Structure
 
 ```
-📦cloudfour.com-patterns
-├── 📁.github               # GitHub workflows and templates
-├── 📁.storybook
-│   ├── 📄main.js           # Settings for Storybook UI
-│   └── 📄preview.js        # Settings for story previews
-├── 📁src
-│   ├── 📄**/*.scss         # Styles (Sass)
-│   ├── 📄**/*.stories.mdx  # Documentation (Storybook Docs)
-│   ├── 📄**/*.twig         # Templates (Twig)
-│   └── 📄**/*.yml          # Design tokens (Theo)
-├── 📄.editorconfig         # Low-level code consistency
-├── 📄.nvmrc                # Node version (used by Netlify)
-├── 📄.svgo.yml             # Inline SVG optimization settings
-├── 📄README.md             # ⬅️ You are here!
-├── 📄gulpfile.js           # Complex build task configuration
-├── 📄netlify.toml          # Netlify build settings
-└── 📄package.json          # Project info and dependencies
+cloudfour.com-patterns
+├── .github               # GitHub workflows and templates
+├── .storybook
+│   ├── main.js           # Settings for Storybook UI
+│   └── preview.js        # Settings for story previews
+├── src
+│   ├── **/*.scss         # Styles (Sass)
+│   ├── **/*.stories.mdx  # Documentation (Storybook Docs)
+│   ├── **/*.twig         # Templates (Twig)
+│   └── **/*.yml          # Design tokens (Theo)
+├── .editorconfig         # Low-level code consistency
+├── .nvmrc                # Node version (used by Netlify)
+├── .svgo.yml             # Inline SVG optimization settings
+├── README.md             # ⬅️ You are here!
+├── gulpfile.js           # Complex build task configuration
+├── netlify.toml          # Netlify build settings
+└── package.json          # Project info and dependencies
 ```


### PR DESCRIPTION
I would like to update this repository so that `v-next` is our default branch, which I believe will make GitHub features like [closing keywords](https://help.github.com/articles/closing-issues-using-keywords) and pull request templates function as expected. But before I do that, I wanted to add more context to our README so anyone navigating here from our articles or publicity is aware of this branch's purpose relative to `master`.

Along the way I made a few other updates just for fun.