### PR TITLE
Separate gulp tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ cloudfour.com-patterns
 ├── .storybook
 │   ├── main.js           # Settings for Storybook UI
 │   └── preview.js        # Settings for story previews
+├── gulpfile.js
+│   └── tasks/*.js        # Complex build tasks
 ├── src
 │   ├── **/*.scss         # Styles (Sass)
 │   ├── **/*.stories.mdx  # Documentation (Storybook Docs)
@@ -32,7 +34,6 @@ cloudfour.com-patterns
 ├── .nvmrc                # Node version (used by Netlify)
 ├── .svgo.yml             # Inline SVG optimization settings
 ├── README.md             # ⬅️ You are here!
-├── gulpfile.js           # Complex build task configuration
 ├── netlify.toml          # Netlify build settings
 └── package.json          # Project info and dependencies
 ```

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -5,6 +5,8 @@
  *
  * This means running `npx gulp hello-world` will run the task exported by
  * `tasks/hello-world.js` if it exists.
+ *
+ * @see https://gulpjs.com/docs/en/getting-started/javascript-and-gulpfiles#splitting-a-gulpfile
  */
 
 module.exports = require('require-dir')('./tasks');

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -1,0 +1,1 @@
+module.exports = require('require-dir')('./tasks');

--- a/gulpfile.js/index.js
+++ b/gulpfile.js/index.js
@@ -1,1 +1,10 @@
+/**
+ * Every JavaScript file in the `tasks/` directory will be exported with its
+ * basename used as the key. These will then be read by Gulp as individual task
+ * definitions.
+ *
+ * This means running `npx gulp hello-world` will run the task exported by
+ * `tasks/hello-world.js` if it exists.
+ */
+
 module.exports = require('require-dir')('./tasks');

--- a/gulpfile.js/tasks/svg-to-twig.js
+++ b/gulpfile.js/tasks/svg-to-twig.js
@@ -4,10 +4,12 @@ const rename = require('gulp-rename');
 const { obj } = require('through2');
 const ltx = require('ltx');
 const yaml = require('js-yaml');
+const path = require('path');
 const { readFileSync } = require('fs');
 
 // Load SVGO preferences from config file to keep things DRY
-const svgoConfig = yaml.safeLoad(readFileSync('.svgo.yml', 'utf8'));
+const svgoPath = path.join(__dirname, '../../.svgo.yml');
+const svgoConfig = yaml.safeLoad(readFileSync(svgoPath, 'utf8'));
 
 // Properties to make configurable via Twig templates
 const dynamicSvgProps = [
@@ -108,4 +110,4 @@ function svgToTwig() {
 }
 
 // Expose to Gulp
-exports.svgToTwig = svgToTwig;
+module.exports = svgToTwig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8055,8 +8055,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8077,14 +8076,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8099,20 +8096,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8229,8 +8223,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8242,7 +8235,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8257,7 +8249,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8265,14 +8256,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8291,7 +8280,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8381,8 +8369,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8394,7 +8381,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8480,8 +8466,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8517,7 +8502,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8537,7 +8521,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8581,14 +8564,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -15068,6 +15049,12 @@
         "is-absolute": "^1.0.0",
         "remove-trailing-separator": "^1.1.0"
       }
+    },
+    "require-dir": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-1.2.0.tgz",
+      "integrity": "sha512-LY85DTSu+heYgDqq/mK+7zFHWkttVNRXC9NKcKGyuGLdlsfbjEPrIEYdCVrx6hqnJb+xSu3Lzaoo8VnmOhhjNA==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "js-yaml": "^3.13.1",
     "ltx": "^2.9.2",
     "prettier": "^1.19.1",
+    "require-dir": "^1.2.0",
     "sass": "^1.25.0",
     "sass-loader": "^8.0.2",
     "style-loader": "^1.1.3",
@@ -57,7 +58,7 @@
   "scripts": {
     "storybook": "npm run svg-to-twig && start-storybook -p 6006",
     "build-storybook": "npm run svg-to-twig && build-storybook",
-    "svg-to-twig": "gulp svgToTwig",
+    "svg-to-twig": "gulp svg-to-twig",
     "check-lint": "npm run check-lint:css && npm run check-lint:js",
     "check-lint:css": "stylelint '**/*.scss'",
     "check-lint:js": "prettier --list-different '**/*.js' && eslint '**/*.js'",


### PR DESCRIPTION
## Overview

I was experimenting with a tweak that would require another Gulp task, and I realized how quickly a gulpfile can spiral into crazy-ness when lots of unrelated stuff is housed in the same file. It also makes it challenging to tell which dependencies are required for which functionality.

This PR gets ahead of that by moving `gulpfile.js` to `gulpfile.js/index.js`. It then exports everything from `gulpfile.js/tasks/` using [require-dir](https://www.npmjs.com/package/require-dir).

## Testing

1. Confirm deploy checks all pass
