### PR TITLE
Color token and doc tweaks

### DIFF
--- a/src/design-tokens/colors.yml
+++ b/src/design-tokens/colors.yml
@@ -40,77 +40,102 @@ props:
   - name: text_light
     value: "{!white_transparent_85}"
     category: text-color
+    comment: Accessible on primary brand color.
   - name: text_light_emphasis
     value: "{!white}"
     category: text-color
+    comment: Accessible on primary brand color, useful for buttons and headings.
   - name: text_action
     value: "{!blue}"
     category: text-color
+    comment: Accessible on white and lighter-gray.
   - name: primary_brand_lighter
     value: "{!blue_lighter}"
     category: primary-color
+    comment: Accessible on -darker colors.
   - name: primary_brand_light
     value: "{!blue_light}"
     category: primary-color
   - name: primary_brand
     value: "{!blue}"
     category: primary-color
+    comment: Accessible on white.
   - name: primary_brand_dark
     value: "{!blue_dark}"
     category: primary-color
+    comment: Accessible on white.
   - name: primary_brand_darker
     value: "{!blue_darker}"
     category: primary-color
+    comment: Accessible on white.
   - name: green_lighter
     value: "{!green_lighter}"
+    comment: Accessible on -darker colors.
   - name: green_light
     value: "{!green_light}"
   - name: green
     value: "{!green}"
+    comment: Accessible on white.
   - name: green_dark
     value: "{!green_dark}"
+    comment: Accessible on white.
   - name: green_darker
     value: "{!green_darker}"
+    comment: Accessible on white.
   - name: purple_lighter
     value: "{!purple_lighter}"
+    comment: Accessible on -darker colors.
   - name: purple_light
     value: "{!purple_light}"
   - name: purple
     value: "{!purple}"
+    comment: Accessible on white.
   - name: purple_dark
     value: "{!purple_dark}"
+    comment: Accessible on white.
   - name: purple_darker
     value: "{!purple_darker}"
+    comment: Accessible on white.
   - name: fuchsia_lighter
     value: "{!fuchsia_lighter}"
+    comment: Accessible on -darker colors.
   - name: fuchsia_light
     value: "{!fuchsia_light}"
   - name: fuchsia
     value: "{!fuchsia}"
+    comment: Accessible on white.
   - name: fuchsia_dark
     value: "{!fuchsia_dark}"
+    comment: Accessible on white.
   - name: fuchsia_darker
     value: "{!fuchsia_darker}"
+    comment: Accessible on white.
   - name: orange_lighter
     value: "{!orange_lighter}"
+    comment: Accessible on -darker colors.
   - name: orange_light
     value: "{!orange_light}"
   - name: orange
     value: "{!orange}"
   - name: orange_dark
     value: "{!orange_dark}"
+    comment: Accessible on white.
   - name: orange_darker
     value: "{!orange_darker}"
+    comment: Accessible on white.
   - name: gray_lighter
     value: "{!gray_lighter}"
+    comment: Accessible on -darker colors.
   - name: gray_light
     value: "{!gray_light}"
   - name: gray
     value: "{!gray}"
   - name: gray_dark
     value: "{!gray_dark}"
+    comment: Accessible on white.
   - name: gray_darker
     value: "{!gray_darker}"
+    comment: Accessible on white.
 global:
   type: color
-  category: secondary-color
+  category: color

--- a/src/design/colors.stories.mdx
+++ b/src/design/colors.stories.mdx
@@ -51,148 +51,32 @@ Our secondary palette consists of green, purple, fuchsia, and orange. These colo
 
 The extended palette is intended to be ever evolving, it offers an additional range of colors work with. The number of different values was determined by cataloging the current use of color throughout our site to create a sufficient number of variations. Usage of these colors will vary, but they should come in handy for illustrations and components.
 
+[See our Design Token documentation](/?path=/docs/design-tokens-colors--page) for a full list of variable names and accessibility details.
+
 <ColorPalette>
   <ColorItem
-    title="$primary-brand-lighter"
-    subtitle="Accessible on -darker colors."
-    colors={[brandTokens.primaryBrandLighter]}
+    title="$primary-brand-*"
+    colors={[brandTokens.primaryBrandLighter, brandTokens.primaryBrandLight, brandTokens.primaryBrand, brandTokens.primaryBrandDark, brandTokens.primaryBrandDarker]}
   />
   <ColorItem
-    title="$primary-brand-light"
-    colors={[brandTokens.primaryBrandLight]}
+    title="$green-*"
+    colors={[brandTokens.greenLighter, brandTokens.greenLight, brandTokens.green, brandTokens.greenDark, brandTokens.greenDarker]}
   />
   <ColorItem
-    title="$primary-brand"
-    subtitle="Accessible with white."
-    colors={[brandTokens.primaryBrand]}
+    title="$purple-*"
+    colors={[brandTokens.purpleLighter, brandTokens.purpleLight, brandTokens.purple, brandTokens.purpleDark, brandTokens.purpleDarker]}
   />
   <ColorItem
-    title="$primary-brand-dark"
-    subtitle="Accessible with white."
-    colors={[brandTokens.primaryBrandDark]}
+    title="$fuchsia-*"
+    colors={[brandTokens.fuchsiaLighter, brandTokens.fuchsiaLight, brandTokens.fuchsia, brandTokens.fuchsiaDark, brandTokens.fuchsiaDarker]}
   />
   <ColorItem
-    title="$primary-brand-darker"
-    subtitle="Accessible with white."
-    colors={[brandTokens.primaryBrandDarker]}
+    title="$orange-*"
+    colors={[brandTokens.orangeLighter, brandTokens.orangeLight, brandTokens.orange, brandTokens.orangeDark, brandTokens.orangeDarker]}
   />
   <ColorItem
-    title="$green-lighter"
-    subtitle="Accessible on -darker colors."
-    colors={[brandTokens.greenLighter]}
-  />
-  <ColorItem
-    title="$green-light"
-    colors={[brandTokens.greenLight]}
-  />
-  <ColorItem
-    title="$green"
-    subtitle="Accessible with white."
-    colors={[brandTokens.green]}
-  />
-  <ColorItem
-    title="$green-dark"
-    subtitle="Accessible with white."
-    colors={[brandTokens.greenDark]}
-  />
-  <ColorItem
-    title="$green-darker"
-    subtitle="Accessible with white."
-    colors={[brandTokens.greenDarker]}
-  />
-  <ColorItem
-    title="$purple-lighter"
-    subtitle="Accessible on -darker colors."
-    colors={[brandTokens.purpleLighter]}
-  />
-  <ColorItem
-    title="$purple-light"
-    colors={[brandTokens.purpleLight]}
-  />
-  <ColorItem
-    title="$purple"
-    subtitle="Accessible with white."
-    colors={[brandTokens.purple]}
-  />
-  <ColorItem
-    title="$purple-dark"
-    subtitle="Accessible with white."
-    colors={[brandTokens.purpleDark]}
-  />
-  <ColorItem
-    title="$purple-darker"
-    subtitle="Accessible with white."
-    colors={[brandTokens.purpleDarker]}
-  />
-  <ColorItem
-    title="$fuchsia-lighter"
-    subtitle="Accessible on -darker colors."
-    colors={[brandTokens.fuchsiaLighter]}
-  />
-  <ColorItem
-    title="$fuchsia-light"
-    colors={[brandTokens.fuchsiaLight]}
-  />
-  <ColorItem
-    title="$fuchsia"
-    subtitle="Accessible with white."
-    colors={[brandTokens.fuchsia]}
-  />
-  <ColorItem
-    title="$fuchsia-dark"
-    subtitle="Accessible with white."
-    colors={[brandTokens.fuchsiaDark]}
-  />
-  <ColorItem
-    title="$fuchsia-darker"
-    subtitle="Accessible with white."
-    colors={[brandTokens.fuchsiaDarker]}
-  />
-  <ColorItem
-    title="$orange-lighter"
-    subtitle="Accessible on -darker colors."
-    colors={[brandTokens.orangeLighter]}
-  />
-  <ColorItem
-    title="$orange-light"
-    colors={[brandTokens.orangeLight]}
-  />
-  <ColorItem
-    title="$orange"
-    colors={[brandTokens.orange]}
-  />
-  <ColorItem
-    title="$orange-dark"
-    subtitle="Accessible with white."
-    colors={[brandTokens.orangeDark]}
-  />
-  <ColorItem
-    title="$orange-darker"
-    subtitle="Accessible with white."
-    colors={[brandTokens.orangeDarker]}
-  />
-  <ColorItem
-    title="$gray-lighter"
-    subtitle="Accessible on -darker colors."
-    colors={[brandTokens.grayLighter]}
-  />
-  <ColorItem
-    title="$gray-light"
-    colors={[brandTokens.grayLight]}
-  />
-  <ColorItem
-    title="$gray"
-    colors={[brandTokens.gray]}
-  />
-  <ColorItem
-    title="$gray-dark"
-    subtitle="Accessible with white."
-    colors={[brandTokens.grayDark]}
-  />
-  <ColorItem
-    title="$gray-darker"
-    subtitle="Accessible with white."
-    colors={[brandTokens.grayDarker]}
+    title="$gray-*"
+    colors={[brandTokens.grayLighter, brandTokens.grayLight, brandTokens.gray, brandTokens.grayDark, brandTokens.grayDarker]}
   />
 </ColorPalette>
 


### PR DESCRIPTION
## Overview

Now that design token documentation is automated, I've moved some of the accessibility notes into the tokens. This also allowed me to simplify some of the _design_ docs to show the palette gradations together, something @dromo77 and I had discussed but previously avoided because it made it harder to refer to individual variable names (which is no longer a concern since tokens are documented separately).

## Screenshots

Design/Colors docs consolidate palette colors:

<img width="1056" alt="Screen Shot 2020-03-10 at 9 22 10 AM" src="https://user-images.githubusercontent.com/69633/76334890-f6a50f00-62b0-11ea-98a0-b4f0a5010da1.png">

Design Tokens/Colors docs include accessibility info:

<img width="1048" alt="Screen Shot 2020-03-10 at 9 22 45 AM" src="https://user-images.githubusercontent.com/69633/76334940-07ee1b80-62b1-11ea-8de5-37c151b1fd41.png">