### PR TITLE
Fluid responsive type lock

### DIFF
--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -13,7 +13,12 @@
  */
 
 html {
-  @include fluid.font-size(20em, 75em, ms.step(0, 1rem), ms.step(1, 1rem)); /* 1 */
+  @include fluid.font-size(
+    20em,
+    75em,
+    ms.step(0, 1rem),
+    ms.step(1, 1rem)
+  ); /* 1 */
   line-sizing: normal; /* 2 */
 }
 

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -1,15 +1,20 @@
 @use "_fonts";
 @use "../design-tokens/font.yml";
+@use "../mixins/fluid";
 @use "../mixins/ms";
 
 /**
- * Promote consistent line spacing.
+ * 1. Adjust base font size between a min and max value based on viewport width.
+ * 2. Promote consistent line spacing.
  *
+ * @todo Revise font size min and max viewport based on standard breakpoints.
+ * @see https://blog.typekit.com/2016/08/17/flexible-typography-with-css-locks/
  * @see https://drafts.csswg.org/css-inline-3/#line-sizing-property
  */
 
 html {
-  line-sizing: normal;
+  @include fluid.font-size(20em, 75em, ms.step(0, 1rem), ms.step(1, 1rem)); /* 1 */
+  line-sizing: normal; /* 2 */
 }
 
 /**

--- a/src/mixins/_fluid.scss
+++ b/src/mixins/_fluid.scss
@@ -1,0 +1,26 @@
+@use "unit";
+
+/**
+ * Dynamically adjust font size between a minimum and maximum, starting at a
+ * minimum breakpoint width and capping at a maximum.
+ *
+ * @see https://blog.typekit.com/2016/08/17/flexible-typography-with-css-locks/
+ * @see https://betterwebtype.com/articles/2019/05/14/the-state-of-fluid-web-typography/
+ */
+
+@mixin font-size($min-width, $max-width, $min-font-size, $max-font-size) {
+  $delta-font-size: unit.strip($max-font-size - $min-font-size);
+  $delta-width: unit.strip($max-width - $min-width);
+
+  & {
+    font-size: $min-font-size;
+
+    @media (min-width: $min-width) {
+      font-size: calc(#{$min-font-size} + #{$delta-font-size} * ((100vw - #{$min-width}) / #{$delta-width}));
+    }
+
+    @media (min-width: $max-width) {
+      font-size: $max-font-size;
+    }
+  }
+}

--- a/src/mixins/_fluid.scss
+++ b/src/mixins/_fluid.scss
@@ -16,7 +16,10 @@
     font-size: $min-font-size;
 
     @media (min-width: $min-width) {
-      font-size: calc(#{$min-font-size} + #{$delta-font-size} * ((100vw - #{$min-width}) / #{$delta-width}));
+      font-size: calc(
+        #{$min-font-size} + #{$delta-font-size} *
+          ((100vw - #{$min-width}) / #{$delta-width})
+      );
     }
 
     @media (min-width: $max-width) {


### PR DESCRIPTION
## Overview

Our current site adapts the base `font-size` above a certain breakpoint, which is good. Instead of adjusting every single type size, you apply a larger base at the root and then adjust anything else as needed.

But the current version has a hard `2px` increase at a single pre-defined breakpoint. That means there are a lot of sizes where the type feels somewhat unaddressed.

While I personally kind of like responsive font sizes to be "unchained," a lot of readers and designers prefer some sort of cap.

The most popular technique for this is [Bootstrap's RFS engine](https://github.com/twbs/rfs). I decided against this for a few reasons:

- I find its "maximum size first" approach counter-intuitive.
- Its documentation seems to encourage using it in a _lot_ of places, which sort of invalidates a lot of the efficiency gained from setting a _root_ size.
- It includes a lot of extra stuff I don't see us needing.

I found [a similar technique](https://blog.typekit.com/2016/08/17/flexible-typography-with-css-locks/) that made more sense to me, so I went ahead and made a mixin to automate that [based on a helpful article I found](https://betterwebtype.com/articles/2019/05/14/the-state-of-fluid-web-typography/).

I then applied that mixin to the `html` element. Starting at `320px` and moving up to `1200px` (just some placeholders I picked, see `@todo` comment), the base font size increases from step `0` to step `1`.

## Screenshots

![fluid-type](https://user-images.githubusercontent.com/69633/76361232-cb83e500-62db-11ea-9cae-9b13afda26dc.gif)

---

- See #470 