### PR TITLE
Only update prettier commit hash monthly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "extends": ["group:recommended", "group:monorepos"],
   "assignees": ["cloudfour/dev"],
   "reviewers": ["cloudfour/dev"],
-  "rangeStrategy": "pin"
+  "rangeStrategy": "pin",
+  "packageRules": [
+    {
+      "packageNames": ["prettier"],
+      "extends": ["schedule:monthly"]
+    }
+  ]
 }


### PR DESCRIPTION
Currently we are using prettier versions directly from GitHub, because they haven't released a version yet that includes bugfixes we need. Since there are very frequently commits to the prettier repo, renovate would try to update this all the time, which would become annoying. This PR switches it so that renovate only checks for prettier updates once a month.

When prettier releases a new version, we can switch to that version, and remove this section from the renovate config.