### PR TITLE
Add css selector bem linting

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -1,0 +1,45 @@
+module.exports = {
+  plugins: ['stylelint-selector-bem-pattern'],
+  extends: ['stylelint-config-cloudfour', 'stylelint-config-prettier'],
+  rules: {
+    'plugin/selector-bem-pattern': {
+      preset: 'bem',
+      /** These files are automatically assumed to have components */
+      implicitComponents: 'src/components/**/*.scss',
+      /** These files are automatically assumed to have utility selectors */
+      implicitUtilities: 'src/utilities/**/*.scss',
+      utilitySelectors: /^\.u-[a-z-]+(?:\\@[a-z]+)?$/,
+      // https://csswizardry.com/2015/03/more-transparent-ui-code-with-namespaces#the-namespaces
+      ignoreSelectors: [
+        /^\.t-/,
+        /^\/.s-/,
+        /\.is-/,
+        /\.has-/,
+        /\.js-/,
+        /\.o-/,
+        /\.qa-/,
+        /_/
+      ],
+      componentSelectors: {
+        initial: bemSelector,
+        combined: () => /.*/
+      }
+    }
+  }
+};
+
+// Copied from https://github.com/postcss/postcss-bem-linter/blob/master/lib/preset-patterns.js
+// Had to copy so that we can pass `initial` and `combined` separately,
+// otherwise `combined` defaults to `initial`
+
+/**
+ * @param {String} block
+ * @returns {RegExp}
+ */
+function bemSelector(block) {
+  const WORD = '[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*';
+  const element = `(?:__${WORD})?`;
+  const modifier = `(?:(?:_|--)${WORD}){0,2}`;
+  const attribute = '(?:\\[.+\\])?';
+  return new RegExp(`^\\.c-${block}${element}${modifier}${attribute}$`);
+}

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["stylelint-config-cloudfour", "stylelint-config-prettier"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15256,6 +15256,17 @@
         }
       }
     },
+    "postcss-bem-linter": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-bem-linter/-/postcss-bem-linter-3.3.0.tgz",
+      "integrity": "sha512-qfgbgf6JmSpJEdglPOsx6GXkQg+dyHRGkflFoACZYL1dVFqoN5O3KhynuCvZFZ1DVfCFCuqEFgnwn8AyN+4qeQ==",
+      "dev": true,
+      "requires": {
+        "minimatch": "^3.0.3",
+        "postcss": "^7.0.14",
+        "postcss-resolve-nested-selector": "^0.1.1"
+      }
+    },
     "postcss-flexbugs-fixes": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.0.tgz",
@@ -19373,6 +19384,18 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "stylelint-selector-bem-pattern": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-selector-bem-pattern/-/stylelint-selector-bem-pattern-2.1.0.tgz",
+      "integrity": "sha512-cVgHxD6itWzrZeOINYlLpKc5hzn6taaEIdakZ+Heo2dq17toDjk7tOybeoyGvBmmepOOzTIYCCSOctOUWDbb8g==",
+      "dev": true,
+      "requires": {
+        "lodash": ">=3.10.0",
+        "postcss": ">=5.0.19",
+        "postcss-bem-linter": "^3.0.0",
+        "stylelint": ">=3.0.2"
       }
     },
     "stylelint-suitcss": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "stylelint": "13.2.1",
     "stylelint-config-cloudfour": "3.1.2",
     "stylelint-config-prettier": "8.0.1",
+    "stylelint-selector-bem-pattern": "2.1.0",
     "theo": "8.1.5",
     "through2": "3.0.1",
     "twig": "1.15.0",


### PR DESCRIPTION
#63  Overview

Closes #517 
I had to pass a lot of options to https://github.com/postcss/postcss-bem-linter in order for it to accept [our class naming convention](https://github.com/cloudfour/cloudfour.com-patterns/issues/466#issuecomment-589361857). There easily could have been things that I missed.

`postcss-bem-linter` does not want to accept non-component classes with prefixes like `.is-open`, `.t-dark`, etc. The only way I could figure out how to make it allow those was to ignore selectors with those entirely.

So it will give you an error if you do this:

```scss
// components/button.scss
.button {}
// ^ should be .u-button, will error
```
but it does not give you an error if you do this:
```scss
// components/button.scss
.button.is-open {}
```

because `.is-` is on the ignore-list for selectors. I could not find a better way to do this without forking `postcss-bem-linter`.

This also only lints selectors that are in `components` or `utilities`

## Testing

1. Create `components` and `utilities` folders
2. Add files to those folders
3. Add incorrect selectors and make sure it flags them
4. Add correct selectors and make sure it doesn't flag them