### PR TITLE
Update prettier to v2

### DIFF
--- a/.remarkrc.js
+++ b/.remarkrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: ['remark-preset-lint-recommended', 'remark-preset-prettier']
+  plugins: ['remark-preset-lint-recommended', 'remark-preset-prettier'],
 };

--- a/.storybook/cloud-four-theme.js
+++ b/.storybook/cloud-four-theme.js
@@ -5,5 +5,5 @@ export default create({
 
   brandTitle: 'Cloud Four Patterns',
   brandUrl: 'https://cloudfour.com',
-  brandImage: '/logo.svg'
+  brandImage: '/logo.svg',
 });

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,18 +17,18 @@ module.exports = {
           implementation: require('sass'),
           sassOptions: {
             // Import Theo design tokens as SCSS variables
-            importer: [require('./theo-importer')]
-          }
-        }
-      }
+            importer: [require('./theo-importer')],
+          },
+        },
+      },
     },
     // Community addons
-    'storybook-addon-themes'
+    'storybook-addon-themes',
   ],
-  webpackFinal: async config => {
+  webpackFinal: async (config) => {
     // Remove default SVG processing from default config.
     // @see https://github.com/storybookjs/storybook/issues/5708#issuecomment-515384927
-    config.module.rules = config.module.rules.map(data => {
+    config.module.rules = config.module.rules.map((data) => {
       if (/svg\|/.test(String(data.test))) {
         data.test = /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/;
       }
@@ -39,20 +39,20 @@ module.exports = {
     config.module.rules.push(
       {
         test: /\.twig$/,
-        use: 'twigjs-loader'
+        use: 'twigjs-loader',
       },
       {
         // Import Theo design tokens as JS objects
         test: /\.ya?ml$/,
-        use: resolve(__dirname, './theo-loader.js')
+        use: resolve(__dirname, './theo-loader.js'),
       },
       {
         // Optimize and process SVGs as React elements for use in documentation
         test: /\.svg$/,
-        use: '@svgr/webpack'
+        use: '@svgr/webpack',
       }
     );
 
     return config;
-  }
+  },
 };

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -2,5 +2,5 @@ import { addons } from '@storybook/addons';
 import cloudFourTheme from './cloud-four-theme';
 
 addons.setConfig({
-  theme: cloudFourTheme
+  theme: cloudFourTheme,
 });

--- a/.storybook/theo-importer.js
+++ b/.storybook/theo-importer.js
@@ -28,13 +28,13 @@ function theoImporter(url, prev, done) {
     .convert({
       transform: {
         file: tokenPath,
-        type: 'web'
+        type: 'web',
       },
       format: {
-        type: 'default.scss' // Variables will have `!default` appended
-      }
+        type: 'default.scss', // Variables will have `!default` appended
+      },
     })
-    .then(scssString => {
+    .then((scssString) => {
       done({ contents: scssString }); // Pass result to Sass
     })
     .catch(({ message }) => {

--- a/.storybook/theo-loader.js
+++ b/.storybook/theo-loader.js
@@ -18,7 +18,7 @@ function theoLoader(source) {
   // By processing import paths beforehand, we give Webpack the info it needs
   // to refresh files accurately and clear its cache.
   if (def.imports) {
-    def.imports.forEach(importPath => {
+    def.imports.forEach((importPath) => {
       // Import paths are relative to the requesting file.
       this.addDependency(resolve(tokenPath, importPath));
     });
@@ -28,14 +28,14 @@ function theoLoader(source) {
     .convert({
       transform: {
         file: tokenPath,
-        type: 'web'
+        type: 'web',
       },
       format: {
         // Outputs ES modules: `export const propertyName = value;`
-        type: 'module.js'
-      }
+        type: 'module.js',
+      },
     })
-    .then(result => {
+    .then((result) => {
       done(null, result);
     })
     .catch(({ message }) => {

--- a/gulpfile.js/tasks/svg-to-twig.js
+++ b/gulpfile.js/tasks/svg-to-twig.js
@@ -23,7 +23,7 @@ const dynamicSvgProps = [
   'role',
   'style',
   'viewBox',
-  'width'
+  'width',
 ];
 
 /**
@@ -46,13 +46,13 @@ function templatizeSvgString(src) {
   svg.children = [...prepend.children, ...svg.children, ...append.children];
 
   // Identify props already in use in the SVG versus those yet to be used
-  const usedProps = dynamicSvgProps.filter(prop => Boolean(svg.attrs[prop]));
-  const unusedProps = dynamicSvgProps.filter(prop => !svg.attrs[prop]);
+  const usedProps = dynamicSvgProps.filter((prop) => Boolean(svg.attrs[prop]));
+  const unusedProps = dynamicSvgProps.filter((prop) => !svg.attrs[prop]);
 
   // Properties already in use should have their value set to a conditional.
   // The `default` filter would be less code, but things get tricky when it
   // comes to managing quotation marks in XML.
-  usedProps.forEach(prop => {
+  usedProps.forEach((prop) => {
     const current = svg.attrs[prop];
     // Dashes have meaning in Twig expressions, so we replace them with
     // underscores in property names.
@@ -69,7 +69,7 @@ function templatizeSvgString(src) {
     // We build a big string of attribute name/value pairs for any properties
     // yet to be used for this asset.
     const unusedPropHtml = unusedProps
-      .map(prop => {
+      .map((prop) => {
         const twigProp = prop.replace(/-/g, '_');
         return `{% if ${twigProp} %} ${prop}="{{${twigProp}}}"{% endif %}`;
       })

--- a/gulpfile.js/tasks/theo-to-mdx.js
+++ b/gulpfile.js/tasks/theo-to-mdx.js
@@ -13,11 +13,11 @@ function theoToMdx() {
     .pipe(
       gulpTheo({
         transform: {
-          type: 'web'
+          type: 'web',
         },
         format: {
-          type: 'stories.mdx'
-        }
+          type: 'stories.mdx',
+        },
       })
     )
     .pipe(dest('src/design-tokens/generated'));

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -2,7 +2,7 @@ const { watch } = require('gulp');
 const svgToTwig = require('./svg-to-twig');
 const theoToMdx = require('./theo-to-mdx');
 
-module.exports = function() {
+module.exports = function () {
   watch('src/assets/**/*.svg', svgToTwig);
   watch('src/design-tokens/**/*.yml', theoToMdx);
 };

--- a/gulpfile.js/theo-formats/stories.mdx.js
+++ b/gulpfile.js/theo-formats/stories.mdx.js
@@ -102,7 +102,7 @@ function mdxStoriesFormat(result) {
   const title = startCase(slug);
   const props = result.get('props').toJS();
   const categories = groupBy(props, 'category');
-  const mdxCategories = Object.keys(categories).map(category =>
+  const mdxCategories = Object.keys(categories).map((category) =>
     categoryToMdx(category, categories[category])
   );
   return `

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@angular/compiler": {
-      "version": "8.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-8.2.14.tgz",
-      "integrity": "sha512-ABZO4E7eeFA1QyJ2trDezxeQM5ZFa1dXw1Mpl/+1vuXDKNjJgNyWYwKp/NwRkLmrsuV0yv4UDCDe4kJOGbPKnw==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -1520,36 +1511,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
-      "dev": true
-    },
-    "@glimmer/interfaces": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.41.4.tgz",
-      "integrity": "sha512-MzXwMyod3MlwSZezHSaVBsCEIW/giYYfTDYARR46QnYsaFVatMVbydjsI7jkAuBCbnLCyNOIc1TrYIj71i/rpg==",
-      "dev": true
-    },
-    "@glimmer/syntax": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.41.0.tgz",
-      "integrity": "sha512-sYmgUMdK0jX+3ZNX9C2TKvL1YZGsKIcXRicwnzoTC7F56z29CbSCc7o6Zf0CI4L2Q7FSnHDxldlSe48wBAr6vQ==",
-      "dev": true,
-      "requires": {
-        "@glimmer/interfaces": "^0.41.0",
-        "@glimmer/util": "^0.41.0",
-        "handlebars": "^4.0.13",
-        "simple-html-tokenizer": "^0.5.7"
-      }
-    },
-    "@glimmer/util": {
-      "version": "0.41.4",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.41.4.tgz",
-      "integrity": "sha512-DwS94K+M0vtG+cymxH0rslJr09qpdjyOLdCjmpKcG/nNiZQfMA1ybAaFEmwk9UaVlUG9STENFeQwyrLevJB+7g==",
-      "dev": true
-    },
-    "@iarna/toml": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.3.tgz",
-      "integrity": "sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==",
       "dev": true
     },
     "@icons/material": {
@@ -4706,29 +4667,6 @@
       "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
       "dev": true
     },
-    "@typescript-eslint/typescript-estree": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
-      "integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "eslint-visitor-keys": "^1.1.0",
-        "glob": "^7.1.6",
-        "is-glob": "^4.0.1",
-        "lodash.unescape": "4.0.1",
-        "semver": "^6.3.0",
-        "tsutils": "^3.17.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -5055,25 +4993,6 @@
             "is-buffer": "^1.1.5"
           }
         }
-      }
-    },
-    "angular-estree-parser": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/angular-estree-parser/-/angular-estree-parser-1.1.5.tgz",
-      "integrity": "sha512-M82O7HGwgS6mBfQq9ijCwuP4uYgSgycmNWQOHomToWRAdfX/c2pAwpCYdbVG9lc6Go8mr5+A2bRQnykdCVdpuA==",
-      "dev": true,
-      "requires": {
-        "lines-and-columns": "^1.1.6",
-        "tslib": "^1.9.3"
-      }
-    },
-    "angular-html-parser": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-1.3.0.tgz",
-      "integrity": "sha512-FCLuM8ZUt30qwiV5KlW8uWL9cwlS2loOIGq8wUQFypkJ1QZqJk829yxTsvp2DvCMZ7uLwfjIaIrKV5N2+RLiSQ==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.3"
       }
     },
     "ansi-align": {
@@ -7057,27 +6976,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "cjk-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cjk-regex/-/cjk-regex-2.0.0.tgz",
-      "integrity": "sha512-E4gFi2f3jC0zFVHpaAcupW+gv9OejZ2aV3DP/LlSO0dDcZJAXw7W0ivn+vN17edN/PhU4HCgs1bfx7lPK7FpdA==",
-      "dev": true,
-      "requires": {
-        "regexp-util": "^1.2.1",
-        "unicode-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "unicode-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/unicode-regex/-/unicode-regex-2.0.0.tgz",
-          "integrity": "sha512-5nbEG2YU7loyTvPABaKb+8B0u8L7vWCsVmCSsiaO249ZdMKlvrXlxR2ex4TUVAdzv/Cne/TdoXSSaJArGXaleQ==",
-          "dev": true,
-          "requires": {
-            "regexp-util": "^1.2.0"
-          }
-        }
-      }
-    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -7873,12 +7771,6 @@
         "type": "^1.0.1"
       }
     },
-    "dashify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dashify/-/dashify-2.0.0.tgz",
-      "integrity": "sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==",
-      "dev": true
-    },
     "data.either": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/data.either/-/data.either-1.5.1.tgz",
@@ -7954,12 +7846,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
-    },
-    "dedent": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
     "deep-equal": {
@@ -8116,12 +8002,6 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
-    "detect-newline": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
-      "dev": true
-    },
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
@@ -8154,12 +8034,6 @@
           "dev": true
         }
       }
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -8386,32 +8260,6 @@
           "dev": true
         }
       }
-    },
-    "editorconfig": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
-      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.19.0",
-        "lru-cache": "^4.1.5",
-        "semver": "^5.6.0",
-        "sigmund": "^1.0.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        }
-      }
-    },
-    "editorconfig-to-prettier": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/editorconfig-to-prettier/-/editorconfig-to-prettier-0.1.1.tgz",
-      "integrity": "sha512-MMadSSVRDb4uKdxV6bCXXN4cTsxIsXYtV4XdPu6FOCSAw6zsCIDA+QEktEU+u6h+c/mTrul5NR+pwFpPxwetiQ==",
-      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -10053,18 +9901,6 @@
         "pkg-dir": "^3.0.0"
       }
     },
-    "find-parent-dir": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
-      "dev": true
-    },
-    "find-project-root": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/find-project-root/-/find-project-root-1.1.1.tgz",
-      "integrity": "sha1-0kJyei2QRyXfVxTyPf3N7doLbvg=",
-      "dev": true
-    },
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -11405,15 +11241,6 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
-    "graphql": {
-      "version": "14.5.8",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
-      "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
-      "dev": true,
-      "requires": {
-        "iterall": "^1.2.2"
-      }
-    },
     "gud": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
@@ -12166,12 +11993,6 @@
       "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
-    "html-element-attributes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-2.2.0.tgz",
-      "integrity": "sha512-OYsGPti+liRbzedLympKEQuVVnnXrmXc+x9ZDrsk+ts1j1f6VVpQ3jk3WiYHlC5ozcSVacugyu9S+r24FyREvA==",
-      "dev": true
-    },
     "html-entities": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
@@ -12263,12 +12084,6 @@
         "terser": "^4.6.3"
       }
     },
-    "html-styles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/html-styles/-/html-styles-1.0.0.tgz",
-      "integrity": "sha1-oYBh/WUfmca3XEXI4FSaO8PgGnU=",
-      "dev": true
-    },
     "html-tag": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/html-tag/-/html-tag-2.0.0.tgz",
@@ -12278,12 +12093,6 @@
         "is-self-closing": "^1.0.1",
         "kind-of": "^6.0.0"
       }
-    },
-    "html-tag-names": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.4.tgz",
-      "integrity": "sha512-QCOY1/oHmo2BNwsTzuYlW51JLXSxfmMvve+2/9i2cbhxXxT6SuhsUWzcIoMwUi0HZW/NIQBSyJaj7fbcsimoKg==",
-      "dev": true
     },
     "html-tags": {
       "version": "3.1.0",
@@ -13139,12 +12948,6 @@
         }
       }
     },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
-      "dev": true
-    },
     "iterate-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
@@ -13159,15 +12962,6 @@
       "requires": {
         "es-get-iterator": "^1.0.2",
         "iterate-iterator": "^1.0.1"
-      }
-    },
-    "jest-docblock": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
-      "integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
-      "dev": true,
-      "requires": {
-        "detect-newline": "^2.1.0"
       }
     },
     "jest-haste-map": {
@@ -13322,12 +13116,6 @@
         }
       }
     },
-    "js-base64": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
-      "integrity": "sha512-Vg8czh0Q7sFBSUMWWArX/miJeBWYBPpdU/3M/DKSaekLMqrqVPaedp+5mZhie/r0lgrcaYBfwXatEew6gwgiQQ==",
-      "dev": true
-    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -13447,15 +13235,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -13485,12 +13264,6 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
     },
     "jstransformer": {
       "version": "1.0.0",
@@ -13667,12 +13440,6 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
-    "linguist-languages": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.7.0.tgz",
-      "integrity": "sha512-6vR1OgfD/YK1xgqVBT3aUx9zurSVeHUsXpVyTilT1o7LW6MNAcGmWy5wwmQAAhvEXxG2PZmktHbQiGtJ5hpGkg==",
-      "dev": true
-    },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -13809,12 +13576,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
-      "dev": true
-    },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
     },
     "lodash.uniq": {
@@ -14029,15 +13790,6 @@
       "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
       "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
       "dev": true
-    },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
     },
     "map-cache": {
       "version": "0.2.2",
@@ -14268,17 +14020,6 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
-    },
-    "mem": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-5.1.1.tgz",
-      "integrity": "sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==",
-      "dev": true,
-      "requires": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^2.1.0",
-        "p-is-promise": "^2.1.0"
-      }
     },
     "memoize-one": {
       "version": "5.1.1",
@@ -14820,12 +14561,6 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
-    },
-    "n-readlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/n-readlines/-/n-readlines-1.0.0.tgz",
-      "integrity": "sha512-ISDqGcspVu6U3VKqtJZG1uR55SmNNF9uK0EMq1IvNVVZOui6MW6VR0+pIZhqz85ORAGp+4zW+5fJ/SE7bwEibA==",
       "dev": true
     },
     "nan": {
@@ -15378,22 +15113,10 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
-    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
     },
     "p-limit": {
@@ -15526,11 +15249,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
-      "dev": true
-    },
-    "parse-srcset": {
-      "version": "github:ikatyang/parse-srcset#54eb9c1cb21db5c62b4d0e275d7249516df6f0ee",
-      "from": "github:ikatyang/parse-srcset#54eb9c1cb21db5c62b4d0e275d7249516df6f0ee",
       "dev": true
     },
     "parse5": {
@@ -16107,17 +15825,6 @@
       "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
       "dev": true
     },
-    "postcss-values-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
-      "integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
-      "dev": true,
-      "requires": {
-        "flatten": "^1.0.2",
-        "indexes-of": "^1.0.1",
-        "uniq": "^1.0.1"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -16125,315 +15832,10 @@
       "dev": true
     },
     "prettier": {
-      "version": "github:prettier/prettier#94a487f19c0ca47d09c59da6d8b0191d245a5669",
-      "from": "github:prettier/prettier#94a487f",
-      "dev": true,
-      "requires": {
-        "@angular/compiler": "8.2.14",
-        "@babel/code-frame": "7.5.5",
-        "@babel/parser": "7.8.3",
-        "@glimmer/syntax": "0.41.0",
-        "@iarna/toml": "2.2.3",
-        "@typescript-eslint/typescript-estree": "2.11.0",
-        "angular-estree-parser": "1.1.5",
-        "angular-html-parser": "1.3.0",
-        "camelcase": "5.3.1",
-        "chalk": "2.4.2",
-        "cjk-regex": "2.0.0",
-        "cosmiconfig": "5.2.1",
-        "dashify": "2.0.0",
-        "dedent": "0.7.0",
-        "diff": "4.0.2",
-        "editorconfig": "0.15.3",
-        "editorconfig-to-prettier": "0.1.1",
-        "escape-string-regexp": "1.0.5",
-        "esutils": "2.0.3",
-        "find-parent-dir": "0.3.0",
-        "find-project-root": "1.1.1",
-        "flow-parser": "0.116.1",
-        "get-stream": "4.1.0",
-        "globby": "6.1.0",
-        "graphql": "14.5.8",
-        "html-element-attributes": "2.2.0",
-        "html-styles": "1.0.0",
-        "html-tag-names": "1.1.4",
-        "ignore": "4.0.6",
-        "is-ci": "2.0.0",
-        "jest-docblock": "24.9.0",
-        "json-stable-stringify": "1.0.1",
-        "leven": "3.1.0",
-        "lines-and-columns": "1.1.6",
-        "linguist-languages": "7.7.0",
-        "lodash": "4.17.15",
-        "mem": "5.1.1",
-        "minimatch": "3.0.4",
-        "minimist": "1.2.2",
-        "n-readlines": "1.0.0",
-        "normalize-path": "3.0.0",
-        "parse-srcset": "github:ikatyang/parse-srcset#54eb9c1cb21db5c62b4d0e275d7249516df6f0ee",
-        "postcss-less": "2.0.0",
-        "postcss-media-query-parser": "0.2.3",
-        "postcss-scss": "2.0.0",
-        "postcss-selector-parser": "2.2.3",
-        "postcss-values-parser": "2.0.1",
-        "regexp-util": "1.2.2",
-        "remark-math": "1.0.6",
-        "remark-parse": "5.0.0",
-        "resolve": "1.14.2",
-        "semver": "6.3.0",
-        "string-width": "4.1.0",
-        "typescript": "3.7.5",
-        "unicode-regex": "3.0.0",
-        "unified": "8.4.2",
-        "vnopts": "1.0.2",
-        "yaml-unist-parser": "1.1.1"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.3.tgz",
-          "integrity": "sha512-/V72F4Yp/qmHaTALizEm9Gf2eQHV3QyTL3K0cNfijwnMnb1L+LDlAubb/ZnSdGAVzVSWakujHYs1I26x66sMeQ==",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "cosmiconfig": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-          "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-          "dev": true,
-          "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.13.1",
-            "parse-json": "^4.0.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "flow-parser": {
-          "version": "0.116.1",
-          "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.116.1.tgz",
-          "integrity": "sha512-uMbaTjiMhBKa/il1esHyWyVVWfrWdG/eLmG62MQulZ59Yghpa30H1tmukFZLptsBafZ8ddiPyf7I+SiA+euZ6A==",
-          "dev": true
-        },
-        "globby": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-          "dev": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "ignore": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-          "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-          "dev": true
-        },
-        "import-fresh": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-          "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-          "dev": true,
-          "requires": {
-            "caller-path": "^2.0.0",
-            "resolve-from": "^3.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.2.tgz",
-          "integrity": "sha512-rIqbOrKb8GJmx/5bc2M0QchhUouMXSpd1RTclXsB41JdL+VtnojfaJR+h7F9k18/4kHUsBFgk80Uk+q569vjPA==",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "postcss-less": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-2.0.0.tgz",
-          "integrity": "sha512-pPNsVnpCB13nBMOcl5GVh8JGmB0JGFjqkLUDzKdVpptFFKEe9wFdEzvh2j4lD2AD+7qcrUfw9Ta+oi5+Fw7jjQ==",
-          "dev": true,
-          "requires": {
-            "postcss": "^5.2.16"
-          }
-        },
-        "postcss-selector-parser": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-          "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-          "dev": true,
-          "requires": {
-            "flatten": "^1.0.2",
-            "indexes-of": "^1.0.1",
-            "uniq": "^1.0.1"
-          }
-        },
-        "remark-parse": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-          "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
-          "dev": true,
-          "requires": {
-            "collapse-white-space": "^1.0.2",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^1.1.0",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "resolve": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-          "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        },
-        "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
-          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^5.2.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.2.tgz",
+      "integrity": "sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==",
+      "dev": true
     },
     "pretty-error": {
       "version": "2.1.1",
@@ -17627,15 +17029,6 @@
       "integrity": "sha512-kUUXjX4AnqnR8KRTCrayAo9PzYMRKmVoGgaz2tBuz0MF3g1ZbGebmtW0yFHfFK9CmBjQKeYIgoL22pFLBJY7sw==",
       "dev": true
     },
-    "regexp-util": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/regexp-util/-/regexp-util-1.2.2.tgz",
-      "integrity": "sha512-5/rl2UD18oAlLQEIuKBeiSIOp1hb5wCXcakl5yvHxlY1wyWI4D5cUKKzCibBeu741PA9JKvZhMqbkDQqPusX3w==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "regexp.prototype.flags": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
@@ -18173,15 +17566,6 @@
             "unist-util-visit-parents": "^2.0.0"
           }
         }
-      }
-    },
-    "remark-math": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-1.0.6.tgz",
-      "integrity": "sha512-I43wU/QOQpXvVFXKjA4FHp5xptK65+5F6yolm8+69/JV0EqSOB64wURUZ3JK50JtnTL8FvwLiH2PZ+fvsBxviA==",
-      "dev": true,
-      "requires": {
-        "trim-trailing-lines": "^1.1.0"
       }
     },
     "remark-mdx": {
@@ -19016,22 +18400,10 @@
         "object-inspect": "^1.7.0"
       }
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
-    },
-    "simple-html-tokenizer": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.9.tgz",
-      "integrity": "sha512-w/3FEDN94r4JQ9WoYrIr8RqDIPZdyNkdpbK9glFady1CAEyD97XWCv8HFetQO21w81e7h7Nh59iYTyG1mUJftg==",
       "dev": true
     },
     "simplebar": {
@@ -21196,15 +20568,6 @@
       "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
       "dev": true
     },
-    "tsutils": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
-      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.8.1"
-      }
-    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -21300,12 +20663,6 @@
           }
         }
       }
-    },
-    "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
-      "dev": true
     },
     "uglify-js": {
       "version": "3.4.10",
@@ -21410,15 +20767,6 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
       "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
       "dev": true
-    },
-    "unicode-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-regex/-/unicode-regex-3.0.0.tgz",
-      "integrity": "sha512-WiDJdORsqgxkZrjC8WsIP573130HNn7KsB0IDnUccW2BG2b19QQNloNhVe6DKk3Aef0UcoIHhNVj7IkkcYWrNw==",
-      "dev": true,
-      "requires": {
-        "regexp-util": "^1.2.0"
-      }
     },
     "unified": {
       "version": "8.4.2",
@@ -22015,25 +21363,6 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
     },
-    "vnopts": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vnopts/-/vnopts-1.0.2.tgz",
-      "integrity": "sha512-d2rr2EFhAGHnTlURu49G7GWmiJV80HbAnkYdD9IFAtfhmxC+kSWEaZ6ZF064DJFTv9lQZQV1vuLTntyQpoanGQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.1",
-        "leven": "^2.1.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "leven": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-          "dev": true
-        }
-      }
-    },
     "void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
@@ -22529,17 +21858,6 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.6.3"
-      }
-    },
-    "yaml-unist-parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yaml-unist-parser/-/yaml-unist-parser-1.1.1.tgz",
-      "integrity": "sha512-cGtqhHBlcft+rTKiPsVcSyi43Eqm5a1buYokW9VkztroKMErBSdR9ANHx+/XxNppHZTu2KMEn4yY8MdhuGoFuA==",
-      "dev": true,
-      "requires": {
-        "lines-and-columns": "^1.1.6",
-        "tslib": "^1.10.0",
-        "yaml": "^1.7.1"
       }
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lodash": "4.17.15",
     "ltx": "2.9.2",
     "npm-run-all": "4.1.5",
-    "prettier": "prettier/prettier#94a487f",
+    "prettier": "2.0.2",
     "remark-preset-lint-recommended": "3.0.4",
     "remark-preset-prettier": "0.4.0",
     "require-dir": "1.2.0",

--- a/renovate.json
+++ b/renovate.json
@@ -2,11 +2,5 @@
   "extends": ["group:recommended", "group:monorepos"],
   "assignees": ["cloudfour/dev"],
   "reviewers": ["cloudfour/dev"],
-  "rangeStrategy": "pin",
-  "packageRules": [
-    {
-      "packageNames": ["prettier"],
-      "extends": ["schedule:monthly"]
-    }
-  ]
+  "rangeStrategy": "pin"
 }

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -17,7 +17,7 @@ The `c-button` class may be applied to button and link elements. The button appe
     {elementsDemo({
       href: text('href', null),
       type: select('type', ['', 'button', 'submit']),
-      disabled: boolean('disabled', false)
+      disabled: boolean('disabled', false),
     })}
   </Story>
 </Preview>
@@ -31,7 +31,7 @@ Some buttons may not require as much emphasis as others. The `c-button--secondar
     {stylesDemo({
       href: text('href', null),
       type: select('type', ['', 'button', 'submit']),
-      disabled: boolean('disabled', false)
+      disabled: boolean('disabled', false),
     })}
   </Story>
 </Preview>
@@ -47,7 +47,7 @@ All the above visual styles will appear slightly different within [our dark them
     {stylesDarkDemo({
       href: text('href', null),
       type: select('type', ['', 'button', 'submit']),
-      disabled: boolean('disabled', false)
+      disabled: boolean('disabled', false),
     })}
   </Story>
 </Preview>

--- a/src/components/table/table.stories.mdx
+++ b/src/components/table/table.stories.mdx
@@ -20,7 +20,7 @@ A table can optionally have a header, a footer, and a caption.
       isRuled: boolean('Add c-tabled--ruled modifier to the table', false),
       isStriped: boolean('Add c-tabled--striped modifier to the table', false),
       numericData: boolean('Add c-table--numeric modifier to the table', false),
-      tableData: data
+      tableData: data,
     })}
   </Story>
 </Preview>
@@ -38,7 +38,7 @@ The `c-table--ruled` modifier adds horizontal rules in between table rows.
       isRuled: true,
       isStriped: boolean('Add c-tabled--striped modifier to the table', false),
       numericData: boolean('Add c-table--numeric modifier to the table', false),
-      tableData: data
+      tableData: data,
     })}
   </Story>
 </Preview>
@@ -56,7 +56,7 @@ The `c-table--striped` modifier adds alternating background colors to table rows
       isRuled: boolean('Add c-tabled--ruled modifier to the table', false),
       isStriped: true,
       numericData: boolean('Add c-table--numeric modifier to the table', false),
-      tableData: data
+      tableData: data,
     })}
   </Story>
 </Preview>
@@ -80,7 +80,7 @@ These changes can be achieved by adding c-table--numeric to the table.
       isRuled: boolean('Add c-tabled--ruled modifier to the table', false),
       isStriped: boolean('Add c-tabled--striped modifier to the table', false),
       numericData: true,
-      tableData: data
+      tableData: data,
     })}
   </Story>
 </Preview>

--- a/src/design/colors.stories.mdx
+++ b/src/design/colors.stories.mdx
@@ -43,7 +43,7 @@ The extended palette is intended to be ever evolving, it offers an additional ra
       brandTokens.primaryBrandLight,
       brandTokens.primaryBrand,
       brandTokens.primaryBrandDark,
-      brandTokens.primaryBrandDarker
+      brandTokens.primaryBrandDarker,
     ]}
   />
   <ColorItem
@@ -53,7 +53,7 @@ The extended palette is intended to be ever evolving, it offers an additional ra
       brandTokens.greenLight,
       brandTokens.green,
       brandTokens.greenDark,
-      brandTokens.greenDarker
+      brandTokens.greenDarker,
     ]}
   />
   <ColorItem
@@ -63,7 +63,7 @@ The extended palette is intended to be ever evolving, it offers an additional ra
       brandTokens.purpleLight,
       brandTokens.purple,
       brandTokens.purpleDark,
-      brandTokens.purpleDarker
+      brandTokens.purpleDarker,
     ]}
   />
   <ColorItem
@@ -73,7 +73,7 @@ The extended palette is intended to be ever evolving, it offers an additional ra
       brandTokens.fuchsiaLight,
       brandTokens.fuchsia,
       brandTokens.fuchsiaDark,
-      brandTokens.fuchsiaDarker
+      brandTokens.fuchsiaDarker,
     ]}
   />
   <ColorItem
@@ -83,7 +83,7 @@ The extended palette is intended to be ever evolving, it offers an additional ra
       brandTokens.orangeLight,
       brandTokens.orange,
       brandTokens.orangeDark,
-      brandTokens.orangeDarker
+      brandTokens.orangeDarker,
     ]}
   />
   <ColorItem
@@ -93,7 +93,7 @@ The extended palette is intended to be ever evolving, it offers an additional ra
       brandTokens.grayLight,
       brandTokens.gray,
       brandTokens.grayDark,
-      brandTokens.grayDarker
+      brandTokens.grayDarker,
     ]}
   />
 </ColorPalette>

--- a/src/design/icons.stories.mdx
+++ b/src/design/icons.stories.mdx
@@ -3,7 +3,7 @@ import { extname, relative } from 'path';
 // Import whole directory of icons together
 // @see https://webpack.js.org/guides/dependency-management/#context-module-api
 const iconDir = require.context('../assets/icons', true, /\.svg$/);
-const iconElements = iconDir.keys().map(key => {
+const iconElements = iconDir.keys().map((key) => {
   const Icon = iconDir(key).default;
   // Retains subdirectory if we want to organize with those in the future
   const name = relative('.', key).replace(extname(key), '');

--- a/src/design/typography/typography.stories.mdx
+++ b/src/design/typography/typography.stories.mdx
@@ -68,7 +68,7 @@ Syntax highlighting is done via [Prism](https://prismjs.com/) because it's extre
        */
       useEffect(() => Prism.highlightAll());
       return codeBlockDemo({
-        language: select('language', ['', 'html', 'css', 'javascript'], 'html')
+        language: select('language', ['', 'html', 'css', 'javascript'], 'html'),
       });
     }}
   </Story>


### PR DESCRIPTION
Switches prettier from using the version from `master` on GitHub to the latest `v2`. We were using the version from `master` because it had a MDX fix that we needed that not had been published yet. But now they have published a new version so that is no longer necessary.