### PR TITLE
Checkbox component

### DIFF
--- a/src/assets/icons/check.svg
+++ b/src/assets/icons/check.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-  <polyline points="4 12 9.08 18 20 6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="4"/>
+  <polyline points="4 12 9.08 18 20 6" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="4"/>
 </svg>

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -9,7 +9,9 @@
  * 2. Modern browsers let us apply wholly custom styles to certain elements,
  *    but only when `appearance` is set to `none`. Because this property is not
  *    a finalized standard, vendor prefixes are still required.
- * 3. Without this, checkboxes appear too small unless hard-pixel sizes are
+ * 3. Some browsers will squish the checkbox in flex containers, which we never,
+ *    ever want.
+ * 4. Without this, checkboxes appear too small unless hard-pixel sizes are
  *    used (ew).
  */
 
@@ -25,7 +27,8 @@
     border-radius: sizes.$radius_medium;
     color: colors.$text-dark;
     cursor: pointer;
-    font: inherit; /* 3 */
+    flex: none; /* 3 */
+    font: inherit; /* 4 */
     height: sizes.$toggle-medium;
     margin: 0;
     padding: 0;
@@ -33,6 +36,7 @@
     transition-duration: motion.$speed-quick;
     transition-property: background-color, border-color, color;
     transition-timing-function: motion.$ease-out;
+    vertical-align: middle;
     width: sizes.$toggle-medium;
 
     /**

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -8,6 +8,7 @@
     -moz-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
     -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
     appearance: none;
+    background-color: colors.$text-light;
     background-position: center;
     background-repeat: no-repeat;
     background-size: contain;
@@ -17,6 +18,8 @@
     cursor: pointer;
     font: inherit;
     height: sizes.$toggle-medium;
+    margin: 0;
+    padding: 0;
     position: relative;
     transition: color motion.$speed-slow motion.$ease-out,
       transform motion.$speed-quick motion.$ease-out;
@@ -28,8 +31,13 @@
     }
 
     &:hover {
+      // background-color: colors.$text-light-emphasis;
       color: colors.$primary-brand;
       transform: scale(1.05);
+
+      .t-dark & {
+        color: colors.$text-dark;
+      }
     }
 
     &:active {
@@ -38,6 +46,27 @@
 
     @include focus.focus-visible {
       box-shadow: 0 0 0 sizes.$edge-large colors.$primary-brand-lighter;
+    }
+
+    &:disabled {
+      border-style: dashed;
+      color: colors.$gray-dark;
+      cursor:  not-allowed;
+      transform: none;
+
+      .t-dark & {
+        color: colors.$primary-brand-lighter;
+      }
+
+      &:checked {
+        background-color: transparent;
+        background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="none" stroke="rgb(72,89,104)" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M4 12l5.08 6L20 6"/%3E%3C/svg%3E');
+        border-color: transparent;
+
+        .t-dark & {
+          background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="none" stroke="%238abfff" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M4 12l5.08 6L20 6"/%3E%3C/svg%3E');
+        }
+      }
     }
   }
 }

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -10,9 +10,6 @@
     -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
     appearance: none;
     background-color: colors.$text-light;
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: contain;
     border: sizes.$edge-medium solid currentColor;
     border-radius: sizes.$radius_medium;
     color: colors.$text-dark;
@@ -22,30 +19,52 @@
     margin: 0;
     padding: 0;
     position: relative;
-    transition: color motion.$speed-slow motion.$ease-out,
-      transform motion.$speed-quick motion.$ease-out;
+    transition-duration: motion.$speed-quick;
+    transition-property: background-color, border-color, color;
+    transition-timing-function: motion.$ease-out;
     width: sizes.$toggle-medium;
 
-    &:checked {
-      background-color: currentColor;
+    &::after {
       background-image: svg-load(
         'icons/check.svg',
         stroke=colors.$text-light-emphasis
       );
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: contain;
+      bottom: sizes.$edge-medium;
+      content: '';
+      left: sizes.$edge-medium;
+      opacity: 0;
+      position: absolute;
+      right: sizes.$edge-medium;
+      top: sizes.$edge-medium;
+      transform: scale(0);
+      transition-duration: motion.$speed-quick;
+      transition-property: opacity, transform;
+      transition-timing-function: motion.$ease-out;
     }
 
     &:hover {
-      // background-color: colors.$text-light-emphasis;
+      background-color: colors.$text-light-emphasis;
       color: colors.$primary-brand;
-      transform: scale(1.05);
 
       .t-dark & {
         color: colors.$text-dark;
       }
     }
 
-    &:active {
-      transform: scale(0.95);
+    &:checked {
+      background-color: currentColor;
+
+      &::after {
+        opacity: 1;
+        transform: scale(1);
+      }
+
+      .t-dark &:hover {
+        color: colors.$primary-brand-darker;
+      }
     }
 
     @include focus.focus-visible {
@@ -53,26 +72,28 @@
     }
 
     &:disabled {
+      background-color: transparent;
       border-style: dashed;
       color: colors.$gray-dark;
       cursor: not-allowed;
-      transform: none;
 
       .t-dark & {
-        color: colors.$primary-brand-lighter;
+        color: colors.$text-light;
       }
 
-      &:checked {
-        background-color: transparent;
+      &::after {
         background-image: svg-load('icons/check.svg', stroke=colors.$gray-dark);
-        border-color: transparent;
 
         .t-dark & {
           background-image: svg-load(
             'icons/check.svg',
-            stroke=colors.$primary-brand-lighter
+            stroke=colors.$text-light
           );
         }
+      }
+
+      &:checked {
+        border-color: transparent;
       }
     }
   }

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -1,0 +1,43 @@
+@use "../../design-tokens/colors.yml";
+@use "../../design-tokens/motion.yml";
+@use "../../design-tokens/sizes.yml";
+@use "../../mixins/focus";
+
+.c-checkbox {
+  @supports (-moz-appearance: none) or (-webkit-appearance: none) or (appearance: none) {
+    -moz-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
+    -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
+    appearance: none;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    border: sizes.$edge-medium solid currentColor;
+    border-radius: sizes.$radius_medium;
+    color: colors.$text-dark;
+    cursor: pointer;
+    font: inherit;
+    height: sizes.$toggle-medium;
+    position: relative;
+    transition: color motion.$speed-slow motion.$ease-out,
+      transform motion.$speed-quick motion.$ease-out;
+    width: sizes.$toggle-medium;
+
+    &:checked {
+      background-color: currentColor;
+      background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="none" stroke="%23fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M4 12l5.08 6L20 6"/%3E%3C/svg%3E');
+    }
+
+    &:hover {
+      color: colors.$primary-brand;
+      transform: scale(1.05);
+    }
+
+    &:active {
+      transform: scale(0.95);
+    }
+
+    @include focus.focus-visible {
+      box-shadow: 0 0 0 sizes.$edge-large colors.$primary-brand-lighter;
+    }
+  }
+}

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -4,7 +4,8 @@
 @use "../../mixins/focus";
 
 .c-checkbox {
-  @supports (-moz-appearance: none) or (-webkit-appearance: none) or (appearance: none) {
+  @supports (-moz-appearance: none) or (-webkit-appearance: none) or
+    (appearance: none) {
     -moz-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
     -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
     appearance: none;
@@ -27,7 +28,10 @@
 
     &:checked {
       background-color: currentColor;
-      background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="none" stroke="%23fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M4 12l5.08 6L20 6"/%3E%3C/svg%3E');
+      background-image: svg-load(
+        'icons/check.svg',
+        stroke=colors.$text-light-emphasis
+      );
     }
 
     &:hover {
@@ -51,7 +55,7 @@
     &:disabled {
       border-style: dashed;
       color: colors.$gray-dark;
-      cursor:  not-allowed;
+      cursor: not-allowed;
       transform: none;
 
       .t-dark & {
@@ -60,11 +64,14 @@
 
       &:checked {
         background-color: transparent;
-        background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="none" stroke="rgb(72,89,104)" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M4 12l5.08 6L20 6"/%3E%3C/svg%3E');
+        background-image: svg-load('icons/check.svg', stroke=colors.$gray-dark);
         border-color: transparent;
 
         .t-dark & {
-          background-image: url('data:image/svg+xml;charset=utf-8,%3Csvg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="none" stroke="%238abfff" stroke-linecap="round" stroke-linejoin="round" stroke-width="4" d="M4 12l5.08 6L20 6"/%3E%3C/svg%3E');
+          background-image: svg-load(
+            'icons/check.svg',
+            stroke=colors.$primary-brand-lighter
+          );
         }
       }
     }

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -3,18 +3,29 @@
 @use "../../design-tokens/sizes.yml";
 @use "../../mixins/focus";
 
+/**
+ * 1. This `@supports` query prevents IE11 (and older browsers) from applying
+ *    these styles, falling back to the native checkbox appearance.
+ * 2. Modern browsers let us apply wholly custom styles to certain elements,
+ *    but only when `appearance` is set to `none`. Because this property is not
+ *    a finalized standard, vendor prefixes are still required.
+ * 3. Without this, checkboxes appear too small unless hard-pixel sizes are
+ *    used (ew).
+ */
+
 .c-checkbox {
   @supports (-moz-appearance: none) or (-webkit-appearance: none) or
     (appearance: none) {
+    /* 1 */
     -moz-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
     -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
-    appearance: none;
+    appearance: none; /* 2 */
     background-color: colors.$text-light;
     border: sizes.$edge-medium solid currentColor;
     border-radius: sizes.$radius_medium;
     color: colors.$text-dark;
     cursor: pointer;
-    font: inherit;
+    font: inherit; /* 3 */
     height: sizes.$toggle-medium;
     margin: 0;
     padding: 0;
@@ -24,6 +35,16 @@
     transition-timing-function: motion.$ease-out;
     width: sizes.$toggle-medium;
 
+    /**
+     * We add the check mark via a pseudo element so we can easily apply
+     * transitions to it without requiring separate elements.
+     *
+     * 1. The icon looks kind of claustrophobic if it runs right up to the
+     *    element edge, so we re-use the border size as an inset value. This
+     *    appears much more balanced!
+     * 2. Starting state of animation.
+     */
+
     &::after {
       background-image: svg-load(
         'icons/check.svg',
@@ -32,18 +53,22 @@
       background-position: center;
       background-repeat: no-repeat;
       background-size: contain;
-      bottom: sizes.$edge-medium;
+      bottom: sizes.$edge-medium; /* 1 */
       content: '';
-      left: sizes.$edge-medium;
-      opacity: 0;
+      left: sizes.$edge-medium; /* 1 */
+      opacity: 0; /* 2 */
       position: absolute;
-      right: sizes.$edge-medium;
-      top: sizes.$edge-medium;
-      transform: scale(0);
+      right: sizes.$edge-medium; /* 1 */
+      top: sizes.$edge-medium; /* 1 */
+      transform: scale(0); /* 2 */
       transition-duration: motion.$speed-quick;
       transition-property: opacity, transform;
       transition-timing-function: motion.$ease-out;
     }
+
+    /**
+     * State: Hover
+     */
 
     &:hover {
       background-color: colors.$text-light-emphasis;
@@ -54,8 +79,16 @@
       }
     }
 
+    /**
+     * State: Checked
+     */
+
     &:checked {
       background-color: currentColor;
+
+      /**
+       * End state of animation
+       */
 
       &::after {
         opacity: 1;
@@ -67,15 +100,36 @@
       }
     }
 
+    /**
+     * State: Focused
+     *
+     * We use `focus-visible` here because checkboxes do not inherently require
+     * keyboard interactions.
+     */
+
     @include focus.focus-visible {
       box-shadow: 0 0 0 sizes.$edge-large colors.$primary-brand-lighter;
     }
 
+    /**
+     * State: Disabled
+     *
+     * 1. We want the checkbox to appear "read-only." A transparent background
+     *    and dashed line help symbolize a lack of interactivity.
+     * 2. Same color used for disabled `c-input` borders.
+     */
+
     &:disabled {
-      background-color: transparent;
-      border-style: dashed;
-      color: colors.$gray-dark;
+      background-color: transparent; /* 1 */
+      border-style: dashed; /* 1 */
+      color: colors.$gray-dark; /* 2 */
       cursor: not-allowed;
+
+      /**
+       * For purely visual consistency with dark theme disabled inputs we would
+       * use `$primary-brand-lighter`, but that will not have enough contrast
+       * on its own in this context.
+       */
 
       .t-dark & {
         color: colors.$text-light;
@@ -91,6 +145,11 @@
           );
         }
       }
+
+      /**
+       * We can forego the border entirely for a disabled checkmark, as the hit
+       * area is unimportant.
+       */
 
       &:checked {
         border-color: transparent;

--- a/src/components/checkbox/checkbox.stories.mdx
+++ b/src/components/checkbox/checkbox.stories.mdx
@@ -12,7 +12,7 @@ import './demo/styles.scss';
 `c-checkbox` may be applied to any `<input type="checkbox">` element. They are larger than native checkboxes and more visually consistent with our [input](/?path=/docs/components-input--text-elements) and [button](/?path=/docs/components-button--elements) components.
 
 <Preview>
-  <Story name="Enabled" height="110px">
+  <Story name="Enabled" height="120px">
     {withLabelDemo({
       disabled: boolean('disabled', false),
     })}
@@ -22,7 +22,7 @@ import './demo/styles.scss';
 Checkboxes appear more subtle and less actionable when the `disabled` attribute is set.
 
 <Preview>
-  <Story name="Disabled" height="110px">
+  <Story name="Disabled" height="120px">
     {withLabelDemo({
       disabled: boolean('disabled', true),
     })}

--- a/src/components/checkbox/checkbox.stories.mdx
+++ b/src/components/checkbox/checkbox.stories.mdx
@@ -1,15 +1,30 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
-import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
-import template from './checkbox.twig';
+import { withKnobs, boolean } from '@storybook/addon-knobs';
+import withLabelDemo from './demo/with-label.twig';
 import '../../themes/_index.scss';
 import './checkbox.scss';
+import './demo/styles.scss';
 
 <Meta title="Components/Checkbox" decorators={[withKnobs]} />
 
 # Checkbox
 
+`c-checkbox` may be applied to any `<input type="checkbox">` element. They are larger than native checkboxes and more visually consistent with our [input](/?path=/docs/components-input--text-elements) and [button](/?path=/docs/components-button--elements) components.
+
 <Preview>
-  <Story name="Example" height="100px">
-    {template()}
+  <Story name="Enabled" height="110px">
+    {withLabelDemo({
+      disabled: boolean('disabled', false),
+    })}
+  </Story>
+</Preview>
+
+Checkboxes appear more subtle and less actionable when the `disabled` attribute is set.
+
+<Preview>
+  <Story name="Disabled" height="110px">
+    {withLabelDemo({
+      disabled: boolean('disabled', true),
+    })}
   </Story>
 </Preview>

--- a/src/components/checkbox/checkbox.stories.mdx
+++ b/src/components/checkbox/checkbox.stories.mdx
@@ -1,0 +1,15 @@
+import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
+import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
+import template from './checkbox.twig';
+import '../../themes/_index.scss';
+import './checkbox.scss';
+
+<Meta title="Components/Checkbox" decorators={[withKnobs]} />
+
+# Checkbox
+
+<Preview>
+  <Story name="Example" height="100px">
+    {template()}
+  </Story>
+</Preview>

--- a/src/components/checkbox/checkbox.twig
+++ b/src/components/checkbox/checkbox.twig
@@ -1,2 +1,10 @@
-<input class="c-checkbox" type="checkbox">
-<input class="c-checkbox" type="checkbox" checked>
+{% include '../input/input.twig' with { value: 'Example' } %}
+<p>
+  <input class="c-checkbox" type="checkbox">
+  <input class="c-checkbox" type="checkbox" checked>
+</p>
+{% include '../input/input.twig' with { value: 'Example', disabled: true } %}
+<p>
+  <input class="c-checkbox" type="checkbox" disabled>
+  <input class="c-checkbox" type="checkbox" checked disabled>
+</p>

--- a/src/components/checkbox/checkbox.twig
+++ b/src/components/checkbox/checkbox.twig
@@ -1,0 +1,2 @@
+<input class="c-checkbox" type="checkbox">
+<input class="c-checkbox" type="checkbox" checked>

--- a/src/components/checkbox/checkbox.twig
+++ b/src/components/checkbox/checkbox.twig
@@ -1,10 +1,21 @@
-{% include '../input/input.twig' with { value: 'Example' } %}
-<p>
-  <input class="c-checkbox" type="checkbox">
-  <input class="c-checkbox" type="checkbox" checked>
-</p>
-{% include '../input/input.twig' with { value: 'Example', disabled: true } %}
-<p>
-  <input class="c-checkbox" type="checkbox" disabled>
-  <input class="c-checkbox" type="checkbox" checked disabled>
-</p>
+{% set attributes %}
+  type="checkbox"
+  class="c-checkbox{% if class %} {{class}}{% endif %}"
+  {% for attribute_name in [
+    'value',
+    'id',
+    'name',
+    'autocomplete',] %}
+    {% set attribute_value = attribute(_context, attribute_name) %}
+    {% if attribute_value %}{{attribute_name}}="{{attribute_value}}"{% endif %}
+  {% endfor %}
+  {% for attribute_name in [
+    'checked',
+    'required',
+    'disabled'] %}
+    {% set attribute_value = attribute(_context, attribute_name) %}
+    {% if attribute_value %}{{attribute_name}}{% endif %}
+  {% endfor %}
+{% endset %}
+
+<input {{attributes}}>

--- a/src/components/checkbox/demo/styles.scss
+++ b/src/components/checkbox/demo/styles.scss
@@ -1,0 +1,13 @@
+@use "../../../mixins/ms";
+
+.demo-checkbox-labels {
+  display: grid;
+  grid-gap: ms.step(1);
+}
+
+.demo-checkbox-label {
+  display: grid;
+  grid-gap: ms.step(-2);
+  grid-template-columns: auto 1fr;
+  user-select: none;
+}

--- a/src/components/checkbox/demo/with-label.twig
+++ b/src/components/checkbox/demo/with-label.twig
@@ -1,0 +1,10 @@
+<div class="demo-checkbox-labels">
+  <label class="demo-checkbox-label">
+    {% include '../checkbox.twig' %}
+    Unchecked
+  </label>
+  <label class="demo-checkbox-label">
+    {% include '../checkbox.twig' with { checked: true } %}
+    Checked
+  </label>
+</div>

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -9,10 +9,10 @@ import './demo/styles.scss';
 
 # Input
 
-The `c-input` class styles text and text-like form elements in a consistent way. It works great with an adjacent [`c-button` component](/?path=/story/components-button--elements).
+The `c-input` class styles text and text-like form elements in a consistent way. It works great with an adjacent [button component](/?path=/story/components-button--elements).
 
 <Preview>
-  <Story name="Text Elements" height="100px">
+  <Story name="Text Elements" height="200px">
     {basicDemo({
       type: select('type', ['text', 'email', 'search', 'date', 'textarea']),
       value: text('value'),

--- a/src/components/input/input.twig
+++ b/src/components/input/input.twig
@@ -4,6 +4,7 @@
   class="c-input{% if class %} {{class}}{% endif %}"
   {% for attribute_name in [
     'id',
+    'name',
     'placeholder',
     'pattern',
     'autocomplete',

--- a/src/design-tokens/sizes.yml
+++ b/src/design-tokens/sizes.yml
@@ -35,3 +35,7 @@ props:
     value: -1
     type: modular/em
     category: sizing
+  toggle_medium:
+    value: 2
+    type: modular/em
+    category: sizing


### PR DESCRIPTION
## Overview

Adds a `c-checkbox` class intended for `<input type="checkbox">` elements.

Originally I was going to style `radio` inputs as well, but I noticed we have _never_ used those on our current site, and it increased the size of the CSS enough that I thought it seemed off. I've also always struggled with naming a single class for both use cases… if we eventually add `c-radio`, [mixins might be a more performant solution](https://csswizardry.com/2016/02/mixins-better-for-performance/) anyway.

I originally had `checked` as a Storybook knob, but I decided to remove it because manipulating the property via Storybook does not animate. I'd rather devs click the element to see the animation.

## Screenshots

<img width="1112" alt="Screen Shot 2020-04-03 at 1 34 54 PM" src="https://user-images.githubusercontent.com/69633/78403021-7ec8bc80-75b0-11ea-9f9d-6ac07078258e.png">
<img width="166" alt="Screen Shot 2020-04-03 at 1 35 07 PM" src="https://user-images.githubusercontent.com/69633/78403026-80928000-75b0-11ea-9d9d-00152c9bf6d0.png">
<img width="172" alt="Screen Shot 2020-04-03 at 1 35 13 PM" src="https://user-images.githubusercontent.com/69633/78403027-812b1680-75b0-11ea-959b-5d780c8eb848.png">


## Testing

1. Try out Checkbox component in deploy preview.

---

- See #490 
- Resolves #461 