### PR TITLE
Fix numeric heading drift

### DIFF
--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -70,12 +70,15 @@ $table-border-thick: sizes.$edge_medium solid $table-border-color;
  * When comparing numeric table cells, it's easier if the ones, tens, hundreds,
  * etc. columns are lines up.
  *
- * 1. Make numbers equal width so the columns line up
- * 2. Right align numeric cells so the "ones" column lines up on the right side
+ * 1. Right align cells so the "ones" column lines up on the right side
+ * 2. Make numbers equal width so the columns line up
  */
+.c-table--numeric {
+  text-align: right; /* 1 */
+}
+
 .c-table--numeric td {
-  font-variant-numeric: tabular-nums; /* 1 */
-  text-align: right; /* 2 */
+  font-variant-numeric: tabular-nums; /* 2 */
 }
 
 /**


### PR DESCRIPTION
## Overview

> After #573 was merged, tables started expanding to fill their available width. When that happened, it became more clear that the current alignment of table headings feels a bit off with numeric data.

I updated the numeric modifier to right-align all the whole table.
This fixes the alignment issue while keeping it easy to override.

## Screenshots

<img width="1209" alt="Screen Shot 2020-04-08 at 3 07 20 PM" src="https://user-images.githubusercontent.com/5798536/78838327-caada400-79aa-11ea-9840-fe434f36c133.png">

## Testing

1. Review tables for regressions

---

- Fixes #577 
