### PR TITLE
Fix duplicate CSS output

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,6 +4,7 @@ import { withPaddings } from 'storybook-addon-paddings';
 import * as colors from '../src/design-tokens/colors.yml';
 import { ratio } from '../src/design-tokens/modular-scale.yml';
 import 'focus-visible';
+import '../src/index.scss';
 import './preview.scss';
 
 // Accessibility testing via aXe

--- a/.storybook/preview.scss
+++ b/.storybook/preview.scss
@@ -1,11 +1,6 @@
-// Foundational styles
-
-@use "../src/base";
-
 // Tweaks for story display can start here
 
 // Allows canvas background selection via Storybook Backgrounds
-
 body {
   background-color: inherit;
 }

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -3,8 +3,6 @@ import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
 import elementsDemo from './demo/elements.twig';
 import stylesDemo from './demo/styles.twig';
 import stylesDarkDemo from './demo/styles-dark.twig';
-import '../../themes/_index.scss';
-import './button.scss';
 
 <Meta title="Components/Button" decorators={[withKnobs]} />
 

--- a/src/components/checkbox/checkbox.stories.mdx
+++ b/src/components/checkbox/checkbox.stories.mdx
@@ -1,8 +1,6 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import withLabelDemo from './demo/with-label.twig';
-import '../../themes/_index.scss';
-import './checkbox.scss';
 import './demo/styles.scss';
 
 <Meta title="Components/Checkbox" decorators={[withKnobs]} />

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -1,7 +1,6 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
 import basicDemo from './demo/basic.twig';
 import inlineDemo from './demo/inline.twig';
-import './icon.scss';
 
 <Meta title="Components/Icon" />
 

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -2,8 +2,6 @@ import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
 import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
 import textDemo from './demo/example.twig';
 import selectDemo from './demo/select.twig';
-import '../../themes/_index.scss';
-import './input.scss';
 import './demo/styles.scss';
 
 <Meta title="Components/Input" decorators={[withKnobs]} />

--- a/src/components/table/table.stories.mdx
+++ b/src/components/table/table.stories.mdx
@@ -2,7 +2,6 @@ import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import basicDemo from './demo/basic.twig';
 import data from './demo/data.json';
-import './table.scss';
 
 <Meta title="Components/Table" decorators={[withKnobs]} />
 

--- a/src/design/typography/typography.stories.mdx
+++ b/src/design/typography/typography.stories.mdx
@@ -12,7 +12,6 @@ import inlineElementsDemo from './demo/inline-elements.twig';
 import figureDemo from './demo/figure.twig';
 import figureImage from './demo/tiny-web-stacks.png';
 import '../../vendor/prism/config.js';
-import '../../vendor/prism/_theme.scss';
 
 <Meta title="Design/Typography" decorators={[withKnobs]} />
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,7 @@
 @use "./base";
-// The "as components" is necessary because otherwise
-// Sass tries to generate a namespace from the glob pattern and fails
-@use './components/**/*.scss' as components;
+// The "as" is necessary because otherwise Sass tries to generate a namespace
+// from the glob pattern and fails
+@use './objects/*/*.scss' as objects;
+@use './components/*/*.scss' as components;
+@use './themes/*.scss' as themes;
+@use './vendor/*/*.scss' as vendor;

--- a/src/objects/container/container.stories.mdx
+++ b/src/objects/container/container.stories.mdx
@@ -1,7 +1,6 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import basicDemo from './demo/basic.twig';
-import './container.scss';
 
 <Meta title="Objects/Container" decorators={[withKnobs]} />
 

--- a/src/themes/_index.scss
+++ b/src/themes/_index.scss
@@ -1,1 +1,0 @@
-@import '_dark';

--- a/src/themes/themes.stories.mdx
+++ b/src/themes/themes.stories.mdx
@@ -1,6 +1,5 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
 import demo from './demo/fill-canvas.twig';
-import './_index.scss';
 
 <Meta title="Themes" />
 


### PR DESCRIPTION
## Overview

- Only outputs project styles once.
- Makes sure all relevant project styles are included in consumable CSS.
- Remove demo CSS from consumable CSS.

While attempting to create a Prototypes section (as per this afternoon's design conversation), I ran into some issues related to limiting demo CSS to individual stories. While troubleshooting _that_, I was confused by a whole _pile_ of `<style>` elements in the `<head>`. I then realized that every time we ran `import` on an SCSS file, that would output that CSS to the `<head>` of every single story. This meant there was a lot of duplicate styles in our `<head>`.

This attempts to simplify by instead importing the global CSS _once_ (in `preview.js`). This has the added benefit of no longer requiring `import` of SCSS files in individual stories.

This also required the consumable CSS file to include things other than base and component styles. I also noticed that the glob was overreaching, including demo CSS as well, so I constrained it a bit.

Please note that this does not actually solve the problem of limiting prototype CSS to stories, but that problem was impossible to troubleshoot without fixing this one.

## Testing

1. Inspect patterns on deploy preview for regressions.
