### PR TITLE
Remove Private Flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cloudfour.com-patterns",
+  "name": "@cloudfour/patterns",
   "version": "0.1.0",
   "author": "Cloud Four",
   "description": "Front-end patterns for cloudfour.com",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "cloudfour.com-patterns",
   "version": "0.1.0",
-  "private": true,
   "author": "Cloud Four",
   "description": "Front-end patterns for cloudfour.com",
   "homepage": "https://github.com/cloudfour/cloudfour.com-patterns",


### PR DESCRIPTION
## Overview

Remove the `private` flag from `package.json` so we can publish this package to the npm registry.