### PR TITLE
Show token comments and font families in docs

### DIFF
--- a/.theo/formats/stories.mdx.js
+++ b/.theo/formats/stories.mdx.js
@@ -40,10 +40,30 @@ function mdxColors(props) {
  * @returns {String}
  */
 function mdxProp(prop, includeComment) {
-  let content = `
-    <td style={{width:'10%'}}><code>$${kebabCase(prop.name)}</code></td>
-    <td>${prop.value}</td>
-  `;
+  // First cell has small percentage to give values and comments more room.
+  let content = `<td style={{width:'10%'}}><code>$${kebabCase(
+    prop.name
+  )}</code></td>`;
+
+  if (prop.category === 'font-family') {
+    // Create an array for each of the fonts in the family string
+    let fonts = prop.value.split(',');
+    // Start a new array to hold the preview elements we're about to create
+    const fontStrings = [];
+    // For each font string we create, we are going to remove the first font
+    // element using `shift`. This allows each segment to be previewed along
+    // with its remaining fallbacks.
+    while (fonts.length) {
+      fontStrings.push(
+        `<span style={{ fontFamily: \`${fonts.join(
+          ','
+        )}\`}}>${fonts.shift().trim()}</span>`
+      );
+    }
+    content += `<td>${fontStrings.join(', ')}</td>`;
+  } else {
+    content += `<td><code>${prop.value}</code></td>`;
+  }
 
   if (includeComment) {
     content += `<td>${prop.comment || '&nbsp;'}</td>`;

--- a/.theo/formats/stories.mdx.js
+++ b/.theo/formats/stories.mdx.js
@@ -36,15 +36,20 @@ function mdxColors(props) {
  * property table.
  *
  * @param {Object} prop - Theo property
+ * @param {Boolean} includeComment - If `true`, include a comment cell.
  * @returns {String}
  */
-function mdxProp(prop) {
-  return `
-<tr>
-  <th scope="row">$${kebabCase(prop.name)}</th>
-  <td>${prop.value}</td>
-</tr>
-  `.trim();
+function mdxProp(prop, includeComment) {
+  let content = `
+    <td style={{width:'10%'}}><code>$${kebabCase(prop.name)}</code></td>
+    <td>${prop.value}</td>
+  `;
+
+  if (includeComment) {
+    content += `<td>${prop.comment || '&nbsp;'}</td>`;
+  }
+
+  return `<tr>${content.trim()}</tr>`;
 }
 
 /**
@@ -54,12 +59,15 @@ function mdxProp(prop) {
  * @returns {String}
  */
 function mdxProps(props) {
-  const rows = props.map(mdxProp);
+  const commentedProps = props.filter((prop) => !!prop.comment);
+  const includeComments = commentedProps.length > 0;
+  const rows = props.map((prop) => mdxProp(prop, includeComments));
   return `
 <table>
   <thead>
     <th>Name</th>
     <th>Value</th>
+    ${includeComments ? `<th>Comment</th>` : ''}
   </thead>
   <tbody>${rows.join('\n')}</tbody>
 </table>`.trim();


### PR DESCRIPTION
## Overview

Makes several improvements to our Theo design token translation task:

- If any token in a category includes comments, they will be displayed in a new "comment" column.
- If a token is in category `font-family`, the value will have each step of the stack applied for preview purposes.
- All token names and non-font-family token values are wrapped in `<code>` so they are more consistent line to line.

## Screenshots

<img width="1046" alt="Screen Shot 2020-04-14 at 4 33 48 PM" src="https://user-images.githubusercontent.com/69633/79283800-ca5f4e00-7e6d-11ea-8bcb-e9cc3b043fde.png">

<img width="1048" alt="Screen Shot 2020-04-14 at 4 33 59 PM" src="https://user-images.githubusercontent.com/69633/79283801-caf7e480-7e6d-11ea-8309-39e794c26841.png">