### PR TITLE
Adjust viewport settings

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,7 +3,7 @@ import { withA11y } from '@storybook/addon-a11y';
 import { withPaddings } from 'storybook-addon-paddings';
 import * as colors from '../src/design-tokens/colors.yml';
 import * as breakpoints from '../src/design-tokens/breakpoint.yml';
-import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { ratio } from '../src/design-tokens/modular-scale.yml';
 import 'focus-visible';
 import '../src/index.scss';
@@ -89,10 +89,11 @@ addParameters({ paddings });
 // Create viewports using widths defined in design tokens
 const breakpointViewports = Object.keys(breakpoints).map((name) => {
   return {
-    name: `breakpoints.$${name}`,
+    name: `breakpoint.$${name}`,
     styles: {
       width: breakpoints[name],
-      height: '100%',
+      // Account for padding and border around viewport preview
+      height: 'calc(100% - 20px)',
     },
     type: 'other',
   };
@@ -101,7 +102,7 @@ addParameters({
   viewport: {
     viewports: {
       ...breakpointViewports,
-      ...MINIMAL_VIEWPORTS,
+      ...INITIAL_VIEWPORTS,
     },
   },
 });


### PR DESCRIPTION
## Overview

Makes three changes to our integration of [the viewports addon](https://github.com/storybookjs/storybook/tree/master/addons/viewport):

- Changes our breakpoint heights to account for the UI padding and border. Previously, applying one of these breakpoints would result in an extra scrollbar.
- Fixes a typo in our breakpoint token names (`breakpoints` → `breakpoint`)
- Swaps `MINIMAL_VIEWPORTS` (which contained opinionated approximations of categories we tend to discourage, for example "Tablet") with `INITIAL_VIEWPORTS` (which includes specific devices, which are not as subjective). 

## Screenshots

<img width="801" alt="Screen Shot 2020-04-21 at 2 45 33 PM" src="https://user-images.githubusercontent.com/69633/79917320-1f0b4780-83df-11ea-8ab9-b184ce32313e.png">
