### PR TITLE
Add modular scale documentation

### DIFF
--- a/src/design-tokens/modular-scale.yml
+++ b/src/design-tokens/modular-scale.yml
@@ -17,7 +17,14 @@ aliases:
   major_twelfth: 3
   double_octave: 4
 props:
-  ratio:
+  - name: ratio
     value: '{!major_third}'
     type: float
-    category: modular_scale
+  - name: minimum_step
+    value: -6
+    type: integer
+  - name: maximum_step
+    value: 10
+    type: integer
+global:
+  category: modular_scale

--- a/src/design/modular-scale.stories.mdx
+++ b/src/design/modular-scale.stories.mdx
@@ -1,0 +1,56 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import * as modularScaleTokens from '../design-tokens/modular-scale.yml';
+const sizeRows = [];
+for (
+  let i = modularScaleTokens.minimumStep;
+  i <= modularScaleTokens.maximumStep;
+  i++
+) {
+  // `toFixed` keeps the values from extending past two decimal points.
+  // The leading `+` keeps values from having decimal points where they don't
+  // need them, so `1.00` becomes `1`.
+  const size = `${Number((modularScaleTokens.ratio**i).toFixed(2))}em`;
+  const row = (
+    <tr>
+      <td>{i}</td>
+      <td>{size}</td>
+      <td style={{ width: '90%' }}>
+        <div
+          style={{
+            background: 'currentColor',
+            height: '1em',
+            opacity: 0.66,
+            width: size,
+          }}
+        ></div>
+      </td>
+    </tr>
+  );
+  sizeRows.push(row);
+}
+
+<Meta title="Design/Modular Scale" />
+
+# Modular Scale
+
+Most typographic and whitespace measurements in our patterns are based on steps of [our modular scale](/?path=/docs/design-tokens-modular-scale--page). This has several benefits for text-heavy projects like ours:
+
+- Encourages designers to think in terms of relative proportion rather than hard-set sizes, which makes patterns more versatile in responsive designs.
+- Minimizes loss of text alignment in complex layouts.
+- Avoids the need to define every step of a scale individually.
+- Ensures the relationship between successive steps is predictable and clear.
+
+To learn more about modular scales, we recommend reading [More Meaningful Typography](https://alistapart.com/article/more-meaningful-typography/) by Tim Brown.
+
+## Sizes
+
+<table>
+  <thead>
+    <tr>
+      <th>Step</th>
+      <th>Size</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>{sizeRows}</tbody>
+</table>

--- a/src/design/modular-scale.stories.mdx
+++ b/src/design/modular-scale.stories.mdx
@@ -7,9 +7,9 @@ for (
   i++
 ) {
   // `toFixed` keeps the values from extending past two decimal points.
-  // The leading `+` keeps values from having decimal points where they don't
-  // need them, so `1.00` becomes `1`.
-  const size = `${Number((modularScaleTokens.ratio**i).toFixed(2))}em`;
+  // The `Number` constructor prevents unnecessary decimals from displaying,
+  // for example `1.00` instead of `1`.
+  const size = `${Number((modularScaleTokens.ratio ** i).toFixed(2))}em`;
   const row = (
     <tr>
       <td>{i}</td>


### PR DESCRIPTION
## Overview

While working on revised whitespace patterns it occurred to me that their documentation could be simplified by introducing a shared page describing our modular scale. This PR introduces that on its own to simplify future PRs.

I also defined the minimum and maximum steps of our scales as design tokens. This will come in handy when it comes time to generate utility classes for these steps.

## Screenshots

![Screen Shot 2020-04-22 at 13 21 59](https://user-images.githubusercontent.com/69633/80030166-b387af80-849c-11ea-9f81-f0b81e31924d.png)

![Screen Shot 2020-04-22 at 13 22 05](https://user-images.githubusercontent.com/69633/80030182-b5ea0980-849c-11ea-947a-1b52a335fdb8.png)