### PR TITLE
Spacing utilities

### DIFF
--- a/src/utilities/spacing/demo/directions.twig
+++ b/src/utilities/spacing/demo/directions.twig
@@ -1,0 +1,22 @@
+{% if step < 0 %}
+  {% set step = 'n' ~ step|abs %}
+{% endif %}
+
+{% embed '../../../objects/rhythm/rhythm.twig' with {
+  class: 'demo-u-' ~ name ~ '-directions'
+} %}
+  {% block content %}
+    {% for direction in ['', '-block', '-block-start', '-block-end', '-inline', '-inline-start', '-inline-end'] %}
+      {% set class = 'u-' ~ name ~ direction ~ '-' ~ step %}
+      {% if name == 'pad' %}
+        <div class="{{class}}">
+          <div>{{class}}</div>
+        </div>
+      {% else %}
+        <div>
+          <div class="{{class}}">{{class}}</div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  {% endblock %}
+{% endembed %}

--- a/src/utilities/spacing/demo/logical-properties.twig
+++ b/src/utilities/spacing/demo/logical-properties.twig
@@ -1,0 +1,27 @@
+{% set directions = ['ltr', 'rtl'] %}
+{% set writing_modes = ['horizontal-tb', 'vertical-lr', 'vertical-rl'] %}
+{% if step < 0 %}
+  {% set step = 'n' ~ step|abs %}
+{% endif %}
+
+<div class="demo-u-{{name}}-logical-properties">
+  {% for writing_mode in writing_modes %}
+    {% for direction in directions %}
+      {% set class = 'u-' ~ name ~ '-block-start-' ~ step ~ ' u-' ~ name ~ '-inline-start-' ~ step %}
+      {% set style = 'direction: ' ~ direction ~ '; writing-mode: ' ~ writing_mode ~ ';' %}
+      {% if name == 'pad' %}
+        <div class="{{class}}" style="{{style}}">
+          <div>
+            {{direction}}, {{writing_mode}}
+          </div>
+        </div>
+      {% else %}
+        <div style="{{style}}">
+          <div class="{{class}}">
+            {{direction}}, {{writing_mode}}
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+</div>

--- a/src/utilities/spacing/demo/styles.scss
+++ b/src/utilities/spacing/demo/styles.scss
@@ -1,0 +1,33 @@
+@use '../../../design-tokens/colors.yml';
+@use '../../../design-tokens/sizes.yml';
+@use '../../../mixins/ms';
+
+.demo-u-space-directions {
+  div {
+    border-radius: sizes.$radius-medium;
+  }
+
+  & > div {
+    background: colors.$gray-light;
+    overflow: hidden;
+  }
+
+  [class*='u-space'] {
+    background: colors.$text-light-emphasis;
+    border: sizes.$edge-medium solid colors.$gray;
+    padding: ms.step(-1);
+  }
+}
+
+.demo-u-pad-directions {
+  [class*='u-pad'] {
+    background: colors.$gray-light;
+    border: sizes.$edge-medium solid colors.$gray;
+    border-radius: sizes.$radius-medium;
+
+    div {
+      background: colors.$text-light-emphasis;
+      border-radius: inherit;
+    }
+  }
+}

--- a/src/utilities/spacing/demo/styles.scss
+++ b/src/utilities/spacing/demo/styles.scss
@@ -1,7 +1,9 @@
+@use '../../../design-tokens/breakpoint.yml';
 @use '../../../design-tokens/colors.yml';
 @use '../../../design-tokens/sizes.yml';
 @use '../../../mixins/ms';
 
+.demo-u-space-logical-properties,
 .demo-u-space-directions {
   div {
     border-radius: sizes.$radius-medium;
@@ -19,6 +21,7 @@
   }
 }
 
+.demo-u-pad-logical-properties,
 .demo-u-pad-directions {
   [class*='u-pad'] {
     background: colors.$gray-light;
@@ -28,6 +31,25 @@
     div {
       background: colors.$text-light-emphasis;
       border-radius: inherit;
+    }
+  }
+}
+
+.demo-u-pad-logical-properties,
+.demo-u-space-logical-properties {
+  display: grid;
+  grid-gap: ms.step(1);
+  grid-template-columns: repeat(2, 1fr);
+
+  @media (min-width: breakpoint.$s) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  > :nth-child(-n + 2) {
+    grid-column: span 2;
+
+    @media (min-width: breakpoint.$s) {
+      grid-column: span 4;
     }
   }
 }

--- a/src/utilities/spacing/demo/styles.scss
+++ b/src/utilities/spacing/demo/styles.scss
@@ -35,6 +35,27 @@
   }
 }
 
+.demo-u-pull-directions {
+  display: flex;
+  flex-direction: column;
+
+  div {
+    border-radius: sizes.$radius-medium;
+  }
+
+  & > div {
+    background: colors.$gray-light;
+    padding: ms.step(-1);
+  }
+
+  [class*='u-pull'] {
+    background: colors.$text-light-emphasis;
+    border: sizes.$edge-medium solid colors.$gray;
+    opacity: 0.66;
+    padding: ms.step(-1);
+  }
+}
+
 .demo-u-pad-logical-properties,
 .demo-u-space-logical-properties {
   display: grid;

--- a/src/utilities/spacing/spacing.scss
+++ b/src/utilities/spacing/spacing.scss
@@ -1,0 +1,108 @@
+@use '../../design-tokens/modular-scale.yml';
+@use '../../mixins/ms';
+@use 'sass:math';
+
+@mixin direction-utilities($property, $name, $value) {
+  $value: $value !important;
+
+  @if $property != margin and $property != padding {
+    @error 'Unknown direction utility property #{$property}.';
+  }
+
+  &-#{$name} {
+    @if $property == margin {
+      margin: $value;
+    } @else {
+      padding: $value;
+    }
+  }
+
+  &-block-#{$name} {
+    @if $property == margin {
+      margin-block: $value;
+    } @else {
+      padding-block: $value;
+    }
+  }
+
+  &-block-start-#{$name} {
+    @if $property == margin {
+      margin-block-start: $value;
+    } @else {
+      padding-block-start: $value;
+    }
+  }
+
+  &-block-end-#{$name} {
+    @if $property == margin {
+      margin-block-end: $value;
+    } @else {
+      padding-block-end: $value;
+    }
+  }
+
+  &-inline-#{$name} {
+    @if $property == margin {
+      margin-inline: $value;
+    } @else {
+      padding-inline: $value;
+    }
+  }
+
+  &-inline-start-#{$name} {
+    @if $property == margin {
+      margin-inline-start: $value;
+    } @else {
+      padding-inline-start: $value;
+    }
+  }
+
+  &-inline-end-#{$name} {
+    @if $property == margin {
+      margin-inline-end: $value;
+    } @else {
+      padding-inline-end: $value;
+    }
+  }
+}
+
+@mixin scale-utilities(
+  $property,
+  $minimum-step: modular-scale.$minimum-step,
+  $maximum-step: modular-scale.$maximum-step
+) {
+  @if $property == margin {
+    @include direction-utilities(
+      $property: $property,
+      $name: auto,
+      $value: auto
+    );
+  }
+
+  @for $step
+    from modular-scale.$minimum-step
+    through modular-scale.$maximum-step
+  {
+    $name: math.abs($step);
+
+    @if $step < 0 {
+      $name: 'n#{$name}';
+    }
+
+    @include direction-utilities(
+      $property: $property,
+      $name: $name,
+      $value: ms.step($step)
+    );
+  }
+
+  @include direction-utilities($property: $property, $name: none, $value: 0);
+}
+
+.u-space {
+  @include scale-utilities($property: margin);
+}
+
+.u-pad {
+  @include scale-utilities($property: padding);
+}

--- a/src/utilities/spacing/spacing.scss
+++ b/src/utilities/spacing/spacing.scss
@@ -69,7 +69,8 @@
 @mixin scale-utilities(
   $property,
   $minimum-step: modular-scale.$minimum-step,
-  $maximum-step: modular-scale.$maximum-step
+  $maximum-step: modular-scale.$maximum-step,
+  $base: 1em
 ) {
   @if $property == margin {
     @include direction-utilities(
@@ -92,17 +93,21 @@
     @include direction-utilities(
       $property: $property,
       $name: $name,
-      $value: ms.step($step)
+      $value: ms.step($step, $base)
     );
   }
 
   @include direction-utilities($property: $property, $name: none, $value: 0);
 }
 
+.u-pad {
+  @include scale-utilities($property: padding);
+}
+
 .u-space {
   @include scale-utilities($property: margin);
 }
 
-.u-pad {
-  @include scale-utilities($property: padding);
+.u-pull {
+  @include scale-utilities($property: margin, $base: -1em);
 }

--- a/src/utilities/spacing/spacing.stories.mdx
+++ b/src/utilities/spacing/spacing.stories.mdx
@@ -1,9 +1,10 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
-import { withKnobs, number } from '@storybook/addon-knobs';
+import { withKnobs, radios, number } from '@storybook/addon-knobs';
 import {
   minimumStep,
   maximumStep,
 } from '../../design-tokens/modular-scale.yml';
+import logicalPropertiesDemo from './demo/logical-properties.twig';
 import directionsDemo from './demo/directions.twig';
 import './demo/styles.scss';
 
@@ -11,17 +12,33 @@ import './demo/styles.scss';
 
 # Spacing
 
-Every effort should be made to rely on the whitespace built in to existing object and component patterns, but there are times where that may not suffice:
+While we do our best to predict whitespace needs within the context of our layout objects and components, certain situations are difficult to account for:
 
-- Adjustments in service of specific content.
-- Layout tweaks that improve visual alignment for [our unreliable eyes](https://en.wikipedia.org/wiki/Optical_illusion).
-- Rapid prototyping.
+- Specific article or page content may require unique spacing.
+- [Our unreliable eyes](https://en.wikipedia.org/wiki/Optical_illusion) may prefer alignment tweaks that defy mathematics: For example, circles may appear more visually balanced when they extend past grid lines.
+- Rapid prototypes.
 
-In those cases, whitespace utilities may be used.
+Spacing utilities exist for these use cases.
 
 ## Logical Properties
 
 All of our utilities use [logical properties](https://www.w3.org/TR/css-logical-1/) instead of specific directions [in supported browsers](https://caniuse.com/#feat=css-logical-props) to simplify potential localization projects.
+
+Observe how the direction of the same utility classes change depending on the page's [direction](https://developer.mozilla.org/en-US/docs/Web/CSS/direction) and [writing mode](https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode):
+
+<Preview>
+  <Story name="Logical Properties" height="420px">
+    {logicalPropertiesDemo({
+      name: radios('Utility', ['space', 'pad'], 'space'),
+      step: number('Step', 1, {
+        range: true,
+        min: minimumStep,
+        max: maximumStep,
+        step: 1,
+      }),
+    })}
+  </Story>
+</Preview>
 
 The following table maps the traditional physical property for `direction: ltr` and `writing-mode: horizontal-tb` to its equivalent logical property:
 

--- a/src/utilities/spacing/spacing.stories.mdx
+++ b/src/utilities/spacing/spacing.stories.mdx
@@ -106,3 +106,26 @@ The following utilities apply space _outside_ the element:
 </Preview>
 
 To add consistent spacing between adjacent block elements, see [the rhythm object](/?path=/docs/objects-rhythm--default-story).
+
+## Negative Margin
+
+The following utilities _pull_ an element one direction or another by applying a _negative_ `margin` value:
+
+- `u-pull-{amount}` subtracts `margin` from all sides.
+- `u-pull-block-{amount}` subtracts `margin` from the top and bottom for horizontal writing modes.
+- `u-pull-block-start-{amount}`
+- `u-pull-block-end-{amount}`
+- `u-pull-inline-{amount}` subtracts `margin` from the left and right for left-to-right directions.
+- `u-pull-inline-start-{amount}`
+- `u-pull-inline-end-{amount}`
+
+`{amount}` may be a step of [our modular scale](/?path=/docs/design-modular-scale--page).
+
+<Preview>
+  <Story name="Negative Margin" height="320px">
+    {directionsDemo({
+      name: 'pull',
+      step: 1,
+    })}
+  </Story>
+</Preview>

--- a/src/utilities/spacing/spacing.stories.mdx
+++ b/src/utilities/spacing/spacing.stories.mdx
@@ -1,0 +1,42 @@
+import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
+import { withKnobs, number } from '@storybook/addon-knobs';
+import {
+  minimumStep,
+  maximumStep,
+} from '../../design-tokens/modular-scale.yml';
+import directionsDemo from './demo/directions.twig';
+import './demo/styles.scss';
+
+<Meta title="Utilities/Spacing" decorators={[withKnobs]} />
+
+# Spacing
+
+TODO
+
+<Preview>
+  <Story name="Margin">
+    {directionsDemo({
+      name: 'space',
+      step: number('Step', 0, {
+        range: true,
+        min: minimumStep,
+        max: maximumStep,
+        step: 1,
+      }),
+    })}
+  </Story>
+</Preview>
+
+<Preview>
+  <Story name="Padding">
+    {directionsDemo({
+      name: 'pad',
+      step: number('Step', 0, {
+        range: true,
+        min: minimumStep,
+        max: maximumStep,
+        step: 1,
+      }),
+    })}
+  </Story>
+</Preview>

--- a/src/utilities/spacing/spacing.stories.mdx
+++ b/src/utilities/spacing/spacing.stories.mdx
@@ -11,13 +11,46 @@ import './demo/styles.scss';
 
 # Spacing
 
-TODO
+Every effort should be made to rely on the whitespace built in to existing object and component patterns, but there are times where that may not suffice:
+
+- Adjustments in service of specific content.
+- Layout tweaks that improve visual alignment for [our unreliable eyes](https://en.wikipedia.org/wiki/Optical_illusion).
+- Rapid prototyping.
+
+In those cases, whitespace utilities may be used.
+
+## Logical Properties
+
+All of our utilities use [logical properties](https://www.w3.org/TR/css-logical-1/) instead of specific directions [in supported browsers](https://caniuse.com/#feat=css-logical-props) to simplify potential localization projects.
+
+The following table maps the traditional physical property for `direction: ltr` and `writing-mode: horizontal-tb` to its equivalent logical property:
+
+| Physical Property | Logical Property |
+| ----------------- | ---------------- |
+| `top`             | `block-start`    |
+| `bottom`          | `block-end`      |
+| `left`            | `inline-start`   |
+| `right`           | `inline-end`     |
+
+## Margin
+
+The following utilities apply space _outside_ the element:
+
+- `u-space-{amount}` adds `margin` to all sides.
+- `u-space-block-{amount}` adds `margin` to the top and bottom for horizontal writing modes.
+- `u-space-block-start-{amount}`
+- `u-space-block-end-{amount}`
+- `u-space-inline-{amount}` adds `margin` to the left and right for left-to-right directions.
+- `u-space-inline-start-{amount}`
+- `u-space-inline-end-{amount}`
+
+`{amount}` may be a step of [our modular scale](/?path=/docs/design-modular-scale--page), `auto` or `none`.
 
 <Preview>
-  <Story name="Margin">
+  <Story name="Margin" height="320px">
     {directionsDemo({
       name: 'space',
-      step: number('Step', 0, {
+      step: number('Step', 1, {
         range: true,
         min: minimumStep,
         max: maximumStep,
@@ -27,11 +60,25 @@ TODO
   </Story>
 </Preview>
 
+## Padding
+
+The following utilities pad the _inside_ of the element:
+
+- `u-pad-{amount}` adds `padding` to all sides.
+- `u-pad-block-{amount}` adds `padding` to the top and bottom for horizontal writing modes.
+- `u-pad-block-start-{amount}`
+- `u-pad-block-end-{amount}`
+- `u-pad-inline-{amount}` adds `padding` to the left and right for left-to-right directions.
+- `u-pad-inline-start-{amount}`
+- `u-pad-inline-end-{amount}`
+
+`{amount}` may be a step of [our modular scale](/?path=/docs/design-modular-scale--page) or `none`.
+
 <Preview>
-  <Story name="Padding">
+  <Story name="Padding" height="320px">
     {directionsDemo({
       name: 'pad',
-      step: number('Step', 0, {
+      step: number('Step', 1, {
         range: true,
         min: minimumStep,
         max: maximumStep,

--- a/src/utilities/spacing/spacing.stories.mdx
+++ b/src/utilities/spacing/spacing.stories.mdx
@@ -49,6 +49,34 @@ The following table maps the traditional physical property for `direction: ltr` 
 | `left`            | `inline-start`   |
 | `right`           | `inline-end`     |
 
+## Padding
+
+The following utilities pad the _inside_ of the element:
+
+- `u-pad-{amount}` adds `padding` to all sides.
+- `u-pad-block-{amount}` adds `padding` to the top and bottom for horizontal writing modes.
+- `u-pad-block-start-{amount}`
+- `u-pad-block-end-{amount}`
+- `u-pad-inline-{amount}` adds `padding` to the left and right for left-to-right directions.
+- `u-pad-inline-start-{amount}`
+- `u-pad-inline-end-{amount}`
+
+`{amount}` may be a step of [our modular scale](/?path=/docs/design-modular-scale--page) or `none`.
+
+<Preview>
+  <Story name="Padding" height="320px">
+    {directionsDemo({
+      name: 'pad',
+      step: number('Step', 1, {
+        range: true,
+        min: minimumStep,
+        max: maximumStep,
+        step: 1,
+      }),
+    })}
+  </Story>
+</Preview>
+
 ## Margin
 
 The following utilities apply space _outside_ the element:
@@ -77,30 +105,4 @@ The following utilities apply space _outside_ the element:
   </Story>
 </Preview>
 
-## Padding
-
-The following utilities pad the _inside_ of the element:
-
-- `u-pad-{amount}` adds `padding` to all sides.
-- `u-pad-block-{amount}` adds `padding` to the top and bottom for horizontal writing modes.
-- `u-pad-block-start-{amount}`
-- `u-pad-block-end-{amount}`
-- `u-pad-inline-{amount}` adds `padding` to the left and right for left-to-right directions.
-- `u-pad-inline-start-{amount}`
-- `u-pad-inline-end-{amount}`
-
-`{amount}` may be a step of [our modular scale](/?path=/docs/design-modular-scale--page) or `none`.
-
-<Preview>
-  <Story name="Padding" height="320px">
-    {directionsDemo({
-      name: 'pad',
-      step: number('Step', 1, {
-        range: true,
-        min: minimumStep,
-        max: maximumStep,
-        step: 1,
-      }),
-    })}
-  </Story>
-</Preview>
+To add consistent spacing between adjacent block elements, see [the rhythm object](/?path=/docs/objects-rhythm--default-story).


### PR DESCRIPTION
## Overview

This reintroduces spacing utilities to the project with the following changes from the production version:

- New class naming convention.
- Retains step `0` instead of omitting it.
- Does not reintroduce `space-items` (see #644).
- Uses logical property names instead of physical ones.
- Uses relative units (`em`).

This PR does not include responsive variations of these utilities because it was getting a little large as-is.

## Screenshots

![Screenshot_2020-04-24 Storybook](https://user-images.githubusercontent.com/69633/80238722-c244a280-8613-11ea-8d37-b215eeffa68e.png)

## Testing

Logical property support varies between browsers. This should be resolved by #646. For now, it's best to test in Firefox.
