### PR TITLE
Add generated design tokens to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 /dist
+/src/design-tokens/generated
 /storybook-static
 
 # Ignore all files in the prototypes directory except for stories


### PR DESCRIPTION
Previously, if you ran:

```
npm run preprocess
npm run check-lint
```
It would say that `src/design-tokens/generated/font.stories.mdx` did not match prettier format

Now, prettier ignores those generated files.

# Testing

Checkout this branch, run the above commands, ensure it has exit code 0

Closes #654