### PR TITLE
Only support widely used modern browsers

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,4 +1,7 @@
 # Browsers that we support
 
-last 1 version
-> 3%
+> 2%
+last 1 safari version
+last 1 ios version
+last 1 firefox version
+last 1 chromeandroid version


### PR DESCRIPTION
If a project dependent on this project wants to support more browsers than this, they can add their own build process to compile to their own browser targets.


PR created based on this discussion: https://github.com/cloudfour/cloudfour.com-patterns/pull/652#discussion_r414910782

New browsers list is (from `npx browserslist`):

```
and_chr 79
and_uc 12.12
chrome 79
firefox 72
ios_saf 13.3
ios_saf 13.2
safari 13
samsung 10.1
```

# Testing
🤷 run `npx browserslist` and make sure there are no unexpected browsers?