### PR TITLE
Add u-hidden-visually utility

### DIFF
--- a/src/mixins/_a11y.scss
+++ b/src/mixins/_a11y.scss
@@ -1,0 +1,46 @@
+@use 'sass:map';
+
+/**
+ * Visible only to screen readers.
+ *
+ * @see https://css-tricks.com/inclusively-hidden/
+ */
+
+$_sr-only-props: (
+  border: 0,
+  clip: rect(0 0 0 0),
+  clip-path: polygon(0 0, 0 0, 0 0),
+  height: 1px,
+  margin: -1px,
+  overflow: hidden,
+  padding: 0,
+  position: absolute,
+  white-space: nowrap,
+  width: 1px,
+);
+
+@mixin sr-only($important: false) {
+  @if $important {
+    border: map.get($_sr-only-props, 'border') !important;
+    clip: map.get($_sr-only-props, 'clip') !important;
+    clip-path: map.get($_sr-only-props, 'clip-path') !important;
+    height: map.get($_sr-only-props, 'height') !important;
+    margin: map.get($_sr-only-props, 'margin') !important;
+    overflow: map.get($_sr-only-props, 'overflow') !important;
+    padding: map.get($_sr-only-props, 'padding') !important;
+    position: map.get($_sr-only-props, 'position') !important;
+    white-space: map.get($_sr-only-props, 'white-space') !important;
+    width: map.get($_sr-only-props, 'width') !important;
+  } @else {
+    border: map.get($_sr-only-props, 'border');
+    clip: map.get($_sr-only-props, 'clip');
+    clip-path: map.get($_sr-only-props, 'clip-path');
+    height: map.get($_sr-only-props, 'height');
+    margin: map.get($_sr-only-props, 'margin');
+    overflow: map.get($_sr-only-props, 'overflow');
+    padding: map.get($_sr-only-props, 'padding');
+    position: map.get($_sr-only-props, 'position');
+    white-space: map.get($_sr-only-props, 'white-space');
+    width: map.get($_sr-only-props, 'width');
+  }
+}

--- a/src/utilities/display/demo/hidden-visually.twig
+++ b/src/utilities/display/demo/hidden-visually.twig
@@ -1,0 +1,6 @@
+<a href="https://github.com/cloudfour/cloudfour.com-patterns">
+  {% include '../../../assets/icons/github.svg.twig' with { class: 'c-icon c-icon--inline' } %}
+  <span class="u-hidden-visually">
+    View this project on GitHub
+  </span>
+</a>

--- a/src/utilities/display/display.scss
+++ b/src/utilities/display/display.scss
@@ -1,0 +1,9 @@
+@use '../../mixins/a11y';
+
+/**
+ * Hide from everything but assistive devices.
+ */
+
+.u-hidden-visually {
+  @include a11y.sr-only($important: true);
+}

--- a/src/utilities/display/display.stories.mdx
+++ b/src/utilities/display/display.stories.mdx
@@ -1,0 +1,25 @@
+import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
+import hiddenVisuallyDemo from './demo/hidden-visually.twig';
+
+<Meta title="Utilities/Display" />
+
+# Display
+
+Utilities for specifying the display type of an element.
+
+Contrary to other categories of utilities, there is no shared `display-*` class name prefix. This is for two main reasons:
+
+- It would be confusing for display utilities that do not conform to a known display type (for example, `u-hidden-visually`) to include this segment.
+- Display utilities are more likely to serve as a base for other dependent utility classes. It is more intuitive to have a (currently hypothetical) `u-flex` class and `u-flex-align-items-center` than it would be `u-display-flex` and `u-flex-align-items-center`.
+
+## Hidden Visually
+
+The `u-hidden-visually` class applies a complex set of CSS rules that obscure an element visually but [not from assistive technology like screen readers](https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/#showing-additional-content-for-screen-readers).
+
+In this example, the link will include text when read aloud:
+
+<Preview>
+  <Story name="Hidden Visually" height="100px">
+    {hiddenVisuallyDemo}
+  </Story>
+</Preview>


### PR DESCRIPTION
## Overview

Adds `u-hidden-visually` utility, which I wanted for a different pattern.

This is mostly the same as [what we have currently](https://cloudfour-patterns.netlify.app/patterns/utilities.html#display). I kept the `hidden` past-tense because I like the consistency with `visibility: hidden`, `aria-hidden`, the `hidden` attribute, etc.

The only differences are:

- New class name based on our latest standards.
- Very slightly updated styles based on @Paul-Hebert's [article on the subject](https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/#showing-additional-content-for-screen-readers).
- Styles are applied via a mixin, in case any of our component elements would benefit from these same styles.

## Screenshots

<img width="1080" alt="Screen Shot 2020-04-27 at 2 55 24 PM" src="https://user-images.githubusercontent.com/69633/80424945-8faadc00-8897-11ea-8fb7-21c2060ac2d5.png">

## Testing

1. View deploy preview.
1. Navigate to the Utilities ▸ Display ▸ Hidden Visually story.
1. Confirm that only the icon (not the text) is visible.
1. In accessibility tab, confirm that the "Ensures links have discernible text" test has passed.