### PR TITLE
Add u-list-none utility

### DIFF
--- a/src/utilities/list/demo/style-type.twig
+++ b/src/utilities/list/demo/style-type.twig
@@ -1,0 +1,5 @@
+<ul class="u-list-{{style_type}}">
+  {% for i in 1..3 %}
+    <li>u-list-{{style_type}} {{i}}</li>
+  {% endfor %}
+</ul>

--- a/src/utilities/list/list.scss
+++ b/src/utilities/list/list.scss
@@ -1,0 +1,3 @@
+.u-list-none {
+  list-style-type: none !important;
+}

--- a/src/utilities/list/list.stories.mdx
+++ b/src/utilities/list/list.stories.mdx
@@ -1,0 +1,18 @@
+import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
+import styleTypeDemo from './demo/style-type.twig';
+
+<Meta title="Utilities/List" />
+
+# List
+
+Utilities for tweaking the appearance and behavior of `<ul>` and `<ol>` elements.
+
+## Style Type
+
+- `u-list-none` removes bullets or numbering from a list.
+
+<Preview>
+  <Story name="None" height="160px">
+    {styleTypeDemo({ style_type: 'none' })}
+  </Story>
+</Preview>


### PR DESCRIPTION
## Overview

Another utility a different pattern would benefit from.

Our current pattern is `u-list-reset`, which sets both `list-style: none` and `padding-left: 0`. What's awkward about this currently is that `padding-left` does not have `!important` set, because if it did, you wouldn't be able to set your own padding while also omitting bullets from a list element.

I decided that felt a bit silly, so in this case I've borrowed another concept [from Tailwind](https://tailwindcss.com/docs/list-style-type) and limited this type of utility to a style type override. This means to truly reset a list via utilities alone you'll need something like `u-list-none u-pad-none`, but I think that may actually be easier to understand and troubleshoot.

## Screenshots

<img width="1082" alt="Screen Shot 2020-04-27 at 4 06 04 PM" src="https://user-images.githubusercontent.com/69633/80429463-04cedf00-88a1-11ea-8a1b-e149ce56c65f.png">

---

- See #492 