### PR TITLE
Add kbd style

### DIFF
--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -119,46 +119,31 @@ pre {
 }
 
 /**
- * When code elements are not within a preformatted block or a link, we offset
- * their color from surrounding content.
+ * When certain monospace inline elements are not within a preformatted block or
+ * a link, we offset their color from surrounding content.
  */
 
-*:not(pre):not(a) > code {
+*:not(pre):not(a) > code,
+*:not(pre):not(a) > kbd {
   color: colors.$fuchsia;
 }
 
+/**
+ * Some additional styles are added to `kbd` elements because it's fun to
+ * embrace just a little skeuomorphism and make them look like keys. ⌨️
+ *
+ * 1. We use a shadow instead of `border-bottom-width` to apply a bit of depth
+ *    because it won't visually impact the element's rounded corners.
+ * 2. Without a `min-width`, single character keys (which is most of them)
+ *    appear rather skinny and strange.
+ */
+
 *:not(pre):not(a) > kbd {
-  // border: sizes.$edge-small solid colors.$gray-light;
-  // border-radius: sizes.$radius-small;
-  // box-shadow: 0 sizes.$edge-small 0 0 colors.$gray-light;
-  // color: colors.$fuchsia;
-  // display: inline-block;
-  // min-width: ms.step(2);
-  // padding: 0 ms.step(-6);
-  // text-align: center;
-  // background: colors.$gray-lighter;
-  // border: sizes.$edge-small solid colors.$gray-light;
-  // border-radius: sizes.$radius-small;
-  // box-shadow: 0 sizes.$edge-small 0 0 colors.$gray-light;
-  // color: colors.$fuchsia;
-  // display: inline-block;
-  // min-width: ms.step(2);
-  // padding: 0 ms.step(-6);
-  // text-align: center;
-  background: colors.$gray-lighter;
-  border: sizes.$edge-small solid;
-  border-image-slice: 1;
-  border-width: 1px;
-  border-image-source: lienar-gradient(
-    to bottom,
-    transparent,
-    colors.$gray-light
-  );
+  border: sizes.$edge-small solid colors.$gray-light;
   border-radius: sizes.$radius-small;
-  box-shadow: 0 sizes.$edge-small 0 0 colors.$gray-light;
-  color: colors.$fuchsia;
+  box-shadow: 0 sizes.$edge-small 0 0 colors.$gray-light; /* 1 */
   display: inline-block;
-  min-width: ms.step(2);
+  min-width: ms.step(2); /* 2 */
   padding: 0 ms.step(-6);
   text-align: center;
 }

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -127,6 +127,42 @@ pre {
   color: colors.$fuchsia;
 }
 
+*:not(pre):not(a) > kbd {
+  // border: sizes.$edge-small solid colors.$gray-light;
+  // border-radius: sizes.$radius-small;
+  // box-shadow: 0 sizes.$edge-small 0 0 colors.$gray-light;
+  // color: colors.$fuchsia;
+  // display: inline-block;
+  // min-width: ms.step(2);
+  // padding: 0 ms.step(-6);
+  // text-align: center;
+  // background: colors.$gray-lighter;
+  // border: sizes.$edge-small solid colors.$gray-light;
+  // border-radius: sizes.$radius-small;
+  // box-shadow: 0 sizes.$edge-small 0 0 colors.$gray-light;
+  // color: colors.$fuchsia;
+  // display: inline-block;
+  // min-width: ms.step(2);
+  // padding: 0 ms.step(-6);
+  // text-align: center;
+  background: colors.$gray-lighter;
+  border: sizes.$edge-small solid;
+  border-image-slice: 1;
+  border-width: 1px;
+  border-image-source: lienar-gradient(
+    to bottom,
+    transparent,
+    colors.$gray-light
+  );
+  border-radius: sizes.$radius-small;
+  box-shadow: 0 sizes.$edge-small 0 0 colors.$gray-light;
+  color: colors.$fuchsia;
+  display: inline-block;
+  min-width: ms.step(2);
+  padding: 0 ms.step(-6);
+  text-align: center;
+}
+
 /**
  * Diff elements
  */

--- a/src/design-tokens/sizes.yml
+++ b/src/design-tokens/sizes.yml
@@ -11,6 +11,10 @@ props:
     value: 0.25rem
     type: relative
     category: sizing
+  - name: radius_small
+    value: 0.125em
+    type: relative
+    category: radius
   - name: radius_medium
     value: 0.25em
     type: relative

--- a/src/design/typography/demo/inline-elements.twig
+++ b/src/design/typography/demo/inline-elements.twig
@@ -1,1 +1,11 @@
-<p><b>Progressive Web Apps</b> are awesome, <em>especially</em> when they make the <del>best</del> <ins>most</ins> of the web! That means using both tried and true <abbr title="HyperText Markup Language">HTML</abbr> techniques like <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">links</a> alongside new techniques like <code>display: grid</code> or <a href="https://github.com/WICG/focus-visible"><code>focus-visible</code></a>!</p>
+{% embed '../../../objects/rhythm/rhythm.twig' %}
+  {% block content %}
+    <p>
+      <b>Progressive Web Apps</b> are awesome, <em>especially</em> when they make the <del>best</del> <ins>most</ins> of the web! That means using both tried and true <abbr title="HyperText Markup Language">HTML</abbr> techniques like <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">links</a> alongside new techniques like <code>display: grid</code> or <a href="https://github.com/WICG/focus-visible"><code>focus-visible</code></a>!
+    </p>
+
+    <p>
+      You can use <kbd>ctrl</kbd> + <kbd>c</kbd> on Windows and <kbd>⌘</kbd> + <kbd>c</kbd> on Mac.
+    </p>
+  {% endblock %}
+{% endembed %}

--- a/src/themes/_dark.scss
+++ b/src/themes/_dark.scss
@@ -15,14 +15,18 @@
     color: colors.$text-light-emphasis;
   }
 
-  *:not(pre):not(a) > code {
-    color: inherit;
+  del {
+    opacity: inherit;
+  }
+
+  *:not(pre):not(a) > code,
+  *:not(pre):not(a) > kbd {
+    color: colors.$text-light-emphasis;
   }
 
   *:not(pre):not(a) > kbd {
-    background: colors.$primary-brand-dark;
-    border-color: transparent;
+    background-color: colors.$primary-brand-dark;
+    border-color: colors.$primary-brand-darker;
     box-shadow: 0 sizes.$edge-small 0 0 colors.$primary-brand-darker;
-    color: colors.$text-light-emphasis;
   }
 }

--- a/src/themes/_dark.scss
+++ b/src/themes/_dark.scss
@@ -1,4 +1,5 @@
 @use "../design-tokens/colors.yml";
+@use "../design-tokens/sizes.yml";
 
 .t-dark {
   background-color: colors.$primary-brand;
@@ -16,5 +17,12 @@
 
   *:not(pre):not(a) > code {
     color: inherit;
+  }
+
+  *:not(pre):not(a) > kbd {
+    background: colors.$primary-brand-dark;
+    border-color: transparent;
+    box-shadow: 0 sizes.$edge-small 0 0 colors.$primary-brand-darker;
+    color: colors.$text-light-emphasis;
   }
 }


### PR DESCRIPTION
## Overview

We noticed in an article draft recently that we weren't providing any real styling for the `<kbd>` element, which represents keyboard commands. I started by extending our existing `<code>` styles to that element, but decided it might be fun to add just a _pinch_ of skeuomorphism and make them look like keys. I tried not to _overdo_ it, because I wanted it to be clear that they are not _buttons_.

Note that Storybook's Accessibility tab will raise one "incomplete" test for the "command" (`⌘`) keyboard example since it has no text variation. The usual ways around this did not work for me. I decided to keep it as I couldn't find any accessibility information specific to `kbd`, and I think it's a good example of the pattern's usage, but I'm open to feedback on that.

I also noticed a failing test for `<del>` in our dark theme, so I made a small adjustment to fix that.

## Screenshots

<img width="646" alt="Screen Shot 2020-05-05 at 1 14 00 PM" src="https://user-images.githubusercontent.com/69633/81111793-78d93a80-8ed2-11ea-8251-f59a7a3828e8.png">

<img width="652" alt="Screen Shot 2020-05-05 at 1 14 09 PM" src="https://user-images.githubusercontent.com/69633/81111796-7a0a6780-8ed2-11ea-886c-0b6f11e575b1.png">

---

- Resolves #669 

/CC @derekshirk 
