### PR TITLE
Primary navigation markup

### DIFF
--- a/src/components/sky-nav/sky-nav.stories.mdx
+++ b/src/components/sky-nav/sky-nav.stories.mdx
@@ -1,0 +1,46 @@
+import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
+import template from './sky-nav.twig';
+// https://timber.github.io/docs/guides/menus/
+const menu = {
+  items: [
+    {
+      link: '/does',
+      title: 'What We Do',
+      current: true,
+    },
+    {
+      link: '/believes',
+      title: 'Our Approach',
+    },
+    {
+      link: '/made',
+      title: 'Our Work',
+    },
+    {
+      link: '/thinks',
+      title: 'Articles',
+    },
+    {
+      link: '/presents',
+      title: 'Speaking',
+    },
+    {
+      link: '/contributes',
+      title: 'Labs',
+    },
+    {
+      link: '/is',
+      title: 'Team',
+    },
+  ],
+};
+
+<Meta title="Components/Sky Nav" />
+
+# Sky Nav
+
+This will eventually be our primary navigation component. Right now, we're just critiquing some markup updates in terms of their accessibility.
+
+<Preview>
+  <Story name="Markup (WIP)">{template({ menu })}</Story>
+</Preview>

--- a/src/components/sky-nav/sky-nav.stories.mdx
+++ b/src/components/sky-nav/sky-nav.stories.mdx
@@ -1,6 +1,5 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
 import template from './sky-nav.twig';
-// https://timber.github.io/docs/guides/menus/
 const menu = {
   items: [
     {
@@ -40,6 +39,8 @@ const menu = {
 # Sky Nav
 
 This will eventually be our primary navigation component. Right now, we're just critiquing some markup updates in terms of their accessibility.
+
+We are tentatively using the same template properties as [Timber Menus](https://timber.github.io/docs/guides/menus/).
 
 <Preview>
   <Story name="Markup (WIP)">{template({ menu })}</Story>

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -26,7 +26,10 @@
     <span class="u-hidden-visually">Toggle Main</span>
     Menu
   </button>
-  <nav aria-label="Main Menu">
+  <nav aria-labelledby="nav-label">
+    <h2 id="nav-label" class="u-hidden-visually">
+      Site
+    </h2>
     <ul>
       {% for item in menu.items %}
         <li>

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -7,7 +7,12 @@
   https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Banner_Role
 #}
 <header>
-  <a href="/" title="Return to home">
+  <a href="/"
+    {% if is_home %}
+      aria-current="page"
+    {% else %}
+      title="Return to home"
+    {% endif %}>
     {# https://heydonworks.com/article/aria-label-is-a-xenophobe/ #}
     <span class="u-hidden-visually">Home: Cloud Four</span>
     {# http://simplyaccessible.com/article/7-solutions-svgs/#acc-heading-4 #}

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -2,17 +2,13 @@
 <a href="#main">
   Skip to main content
 </a>
+
 {#
   This may require `role="banner"` if nested in something other than `body`.
   https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Banner_Role
 #}
 <header>
-  <a href="/"
-    {% if is_home %}
-      aria-current="page"
-    {% else %}
-      title="Return to home"
-    {% endif %}>
+  <a href="/"{% if is_home %} aria-current="page"{% endif %}>
     {# https://heydonworks.com/article/aria-label-is-a-xenophobe/ #}
     <span class="u-hidden-visually">Home: Cloud Four</span>
     {# http://simplyaccessible.com/article/7-solutions-svgs/#acc-heading-4 #}
@@ -30,7 +26,12 @@
     <h2 id="menu-label" class="u-hidden-visually">
       Main Menu
     </h2>
-    <ul>
+    {#
+      Preemptively adding `role="list"` since we will be removing list styles
+      via CSS
+      https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
+    #}
+    <ul role="list">
       {% for item in menu.items %}
         <li>
           <a href="{{item.link}}"{% if item.current %} aria-current="page"{% endif %}>
@@ -41,3 +42,8 @@
     </ul>
   </nav>
 </header>
+
+<main id="main">
+  <h1>Main Content</h1>
+  <p>This is where the actual page content would go.</p>
+</main>

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -1,0 +1,35 @@
+{# https://webaim.org/techniques/skipnav/ #}
+<a href="#main">
+  Skip to main content
+</a>
+{#
+  This may require `role="banner"` if nested in something other than `body`.
+  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Banner_Role
+#}
+<header>
+  <a href="/" title="Return to home">
+    {# https://heydonworks.com/article/aria-label-is-a-xenophobe/ #}
+    <span class="u-hidden-visually">Home: Cloud Four</span>
+    {# http://simplyaccessible.com/article/7-solutions-svgs/#acc-heading-4 #}
+    {% include '../../assets/icons/cloud-four.svg.twig' with {
+      width: '80',
+      height: '80',
+      focusable: 'false'
+    } only %}
+  </a>
+  <button type="button">
+    <span class="u-hidden-visually">Toggle Main</span>
+    Menu
+  </button>
+  <nav aria-label="Main Menu">
+    <ul>
+      {% for item in menu.items %}
+        <li>
+          <a href="{{item.link}}"{% if item.current %} aria-current="page"{% endif %}>
+            {{item.title}}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </nav>
+</header>

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -26,9 +26,9 @@
     <span class="u-hidden-visually">Toggle Main</span>
     Menu
   </button>
-  <nav aria-labelledby="nav-label">
-    <h2 id="nav-label" class="u-hidden-visually">
-      Site
+  <nav aria-labelledby="menu-label">
+    <h2 id="menu-label" class="u-hidden-visually">
+      Main Menu
     </h2>
     <ul>
       {% for item in menu.items %}


### PR DESCRIPTION
## Overview

I'm extremely proud of the accessibility knowledge in this team. Although the accessibility challenges of our site pale in comparison to those of our main projects, I see that as an invitation to poke a bit at the underpinnings of what we're doing.

Case-in-point: A primary navigation PR consisting _only_ of markup! Well, markup and a pinch of Twig template tags.

I based this revised markup structure on a recent client project with a couple of small changes. Here's a summary of everything that's changed from our what's on our live site:

- Moved the "skip to main content" link _out_ of the `<header>`, since that's where [Heydon](https://heydonworks.com/latest/) seems to put it on all of his projects.
- Replaced the menu button with an actual `button` element, and updated its fallback text to be more descriptive.
- Added alternate home fallback text depending on whether or not you are currently on the home page.
- Added `focusable="false"` to the logo to avoid competition with surrounding links in old browsers.
- Replaced `role="navigation"` on the `<nav>` element with `aria-label="Main Menu"`.
- Added `aria-current="page"` attribute to current menu link (if any).

## Screenshots

<img width="1279" alt="Screen Shot 2020-05-05 at 2 10 21 PM" src="https://user-images.githubusercontent.com/69633/81116443-37e52400-8eda-11ea-8d5e-2154f5bea274.png">

## Testing

Please kick the tires on this stuff and let me know if you have any feedback! Anything we could be doing better or differently so far to make this as inclusive as possible?

---

- See #479 

/CC @gerardo-rodriguez @Paul-Hebert 
