### PR TITLE
Change how renovate handles node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typography"
   ],
   "engines": {
-    "node": "14.1.0"
+    "node": ">=12.16.3"
   },
   "repository": {
     "type": "git",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
   "extends": ["group:recommended", "group:monorepos"],
   "reviewers": ["team:dev"],
-  "rangeStrategy": "pin"
+  "rangeStrategy": "pin",
+  "node": {
+    "supportPolicy": ["active"],
+    "rangeStrategy": "bump"
+  }
 }


### PR DESCRIPTION
## Overview

This PR is created with the hopes that merging it will prevent renovate from making PR's like this: https://github.com/cloudfour/cloudfour.com-patterns/pull/685 and this: https://github.com/cloudfour/cloudfour.com-patterns/pull/680 (for the node version)

The `engines` field is how we specify which node versions we allow our package consumers to use. If that version is pinned, then that means that we are telling our package consumers that they must use node 14.2.0 only, but node releases new versions really frequently so that would be really annoying.

I don't know if these configuration changes will do what we want, but we can't really test it until we merge this. It was my best-guess of what would work based on these documentation pages:

- https://docs.renovatebot.com/node/#configuring-support-policy
- https://docs.renovatebot.com/configuration-options/#rangestrategy