### PR TITLE
Link to CONTRIBUTING from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ You can add the pattern library package as a dependency to your JavaScript appli
 ```
 npm install @cloudfour/patterns
 ```
+
+## Contributing
+
+Please see the [contribution guidelines for this project](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ npm install @cloudfour/patterns
 
 ## Contributing
 
-Please see the [contribution guidelines for this project](CONTRIBUTING.md).
+To learn how to run this project locally, modify existing patterns, or create new ones, please see the [contribution guidelines for this project](CONTRIBUTING.md).


### PR DESCRIPTION
This commit adds a link to the contributing guide from the readme, which I forgot to add when I relocated those instructions to a new file.

Fixes #702