### PR TITLE
Fix pagination arrows

### DIFF
--- a/src/components/pagination/pagination.scss
+++ b/src/components/pagination/pagination.scss
@@ -154,14 +154,14 @@ $indicator-width-current: $indicator-height-current;
 .c-pagination__action.is-previous::before {
   background-image: svg-load(
     'icons/arrow-left.svg',
-    color=colors.$primary-brand
+    stroke=colors.$primary-brand
   );
   left: 0;
 
   .t-dark & {
     background-image: svg-load(
       'icons/arrow-left.svg',
-      color=colors.$text-light-emphasis
+      stroke=colors.$text-light-emphasis
     );
   }
 }
@@ -169,14 +169,14 @@ $indicator-width-current: $indicator-height-current;
 .c-pagination__action.is-next::after {
   background-image: svg-load(
     'icons/arrow-right.svg',
-    color=colors.$primary-brand
+    stroke=colors.$primary-brand
   );
   right: 0;
 
   .t-dark & {
     background-image: svg-load(
       'icons/arrow-right.svg',
-      color=colors.$text-light-emphasis
+      stroke=colors.$text-light-emphasis
     );
   }
 }


### PR DESCRIPTION
## Overview

Updates the SVG inline color assignment for `c-pagination` to account for `currentColor` being unnecessary now. This renders the arrows visible again.

## Screenshots

<img width="659" alt="Screen Shot 2020-05-18 at 12 58 30 PM" src="https://user-images.githubusercontent.com/69633/82254228-4c2c1680-9907-11ea-8487-3199264c9fa8.png">

## Testing

1. View deploy preview.
1. Confirm arrows are visible when next/back affordances are visible.
1. Confirm the same when dark theme is active.

---

- Fixes #706 
