### PR TITLE
Chore: reorganizes third-party assets into vendors directory

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -47,7 +47,7 @@ const orderedCategories = [
   'Components',
   'Themes',
   'Utilities',
-  'Vendors',
+  'Vendor',
   'Prototypes',
 ];
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -47,7 +47,7 @@ const orderedCategories = [
   'Components',
   'Themes',
   'Utilities',
-  'Third-Party',
+  'Vendors',
   'Prototypes',
 ];
 

--- a/src/design/icons/icons.stories.mdx
+++ b/src/design/icons/icons.stories.mdx
@@ -41,7 +41,7 @@ For icon usage examples, see [the icon object](/?path=/docs/components-icon--bas
 
 <IconGallery>{iconElements}</IconGallery>
 
-# Third-party Icons
+# Vendor Icons
 
 This icon set encompasses third-party brand and service icons.
 

--- a/src/vendor/wordpress/gutenberg.stories.mdx
+++ b/src/vendor/wordpress/gutenberg.stories.mdx
@@ -1,7 +1,7 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
-import codeBlockDemo from '../design/typography/demo/code-block.twig';
+import codeBlockDemo from '../../design/typography/demo/code-block.twig';
 
-<Meta title="Third-Party/Gutenberg" />
+<Meta title="Vendors/WordPress/Gutenberg" />
 
 # WordPress Gutenberg Blocks
 

--- a/src/vendor/wordpress/gutenberg.stories.mdx
+++ b/src/vendor/wordpress/gutenberg.stories.mdx
@@ -1,7 +1,7 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
 import codeBlockDemo from '../../design/typography/demo/code-block.twig';
 
-<Meta title="Vendors/WordPress/Gutenberg" />
+<Meta title="Vendor/WordPress/Gutenberg" />
 
 # WordPress Gutenberg Blocks
 


### PR DESCRIPTION
## Overview

See issue #709

This PR consolidates our vendor specific stories and source files into a commonly named `vendor/` directory. 

## Screenshots

Storybook organization:

![Screen Shot 2020-05-19 at 11 17 13 AM](https://user-images.githubusercontent.com/1427548/82363339-84dcf600-99c2-11ea-8eb8-ddbc13429995.png)

Source file organization:

![Screen Shot 2020-05-19 at 10 54 01 AM](https://user-images.githubusercontent.com/1427548/82362659-86f28500-99c1-11ea-8a25-b7856911ab2e.png)

In #704 I also renamed an icon section "Third-party Icons". It felt appropriate to revisit that with this PR as well. 

![Screen Shot 2020-05-19 at 11 35 57 AM](https://user-images.githubusercontent.com/1427548/82365035-f0c05e00-99c4-11ea-9737-a48c2de1f1c5.png)


## Testing

1. Confirm that this direction/organization is not fubar
1. Review files changed
1. View [theme deploy](https://deploy-preview-719--cloudfour-patterns.netlify.app/) and check Storybook and make sure Gutenberg stories work as expected. 

---

Also related to #710 