### PR TITLE
Disable renovating node version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,10 @@
   "extends": ["group:recommended", "group:monorepos"],
   "reviewers": ["team:dev"],
   "rangeStrategy": "pin",
-  "node": {
-    "supportPolicy": ["active"],
-    "rangeStrategy": "bump"
-  }
+  "packageRules": [
+    {
+      "packageNames": ["node"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Tries to disable PR's like this: https://github.com/cloudfour/cloudfour.com-patterns/pull/690

I think this is the config we want: https://github.com/renovatebot/config-help/issues/81#issuecomment-414104278