### PR TITLE
Support more highlighted languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5765,6 +5765,12 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/prismjs": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.16.1.tgz",
+      "integrity": "sha512-RNgcK3FEc1GpeOkamGDq42EYkb6yZW5OWQwTS56NJIB8WL0QGISQglA7En7NUx9RGP8AC52DOe+squqbAckXlA==",
+      "dev": true
+    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@storybook/html": "5.3.19",
     "@svgr/webpack": "5.4.0",
     "@testing-library/cypress": "6.0.0",
+    "@types/prismjs": "1.16.1",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
     "babel-loader": "8.1.0",

--- a/src/vendor/prism/_theme.scss
+++ b/src/vendor/prism/_theme.scss
@@ -10,49 +10,60 @@
  */
 
 .token {
-  &.punctuation,
-  &.comment,
-  &.prolog,
-  &.doctype,
   &.cdata,
-  .language-json &.operator {
+  &.comment,
+  &.doctype,
+  &.prolog,
+  &.punctuation {
     color: colors.$text-light;
     opacity: opacity.$muted;
   }
 
-  &.property,
-  &.keyword,
-  &.interpolation-punctuation {
-    color: colors.$primary-brand-lighter;
-  }
-
-  &.constant,
-  &.attr-value,
-  &.selector,
-  &.class-name,
-  .language-js &.string,
-  .language-javascript &.string {
-    color: colors.$green-lighter;
-  }
-
-  &.rule,
-  &.tag,
-  &.regex,
-  &.number,
-  &.boolean,
-  &.function {
-    color: colors.$fuchsia-lighter;
-  }
-
-  &.variable,
   &.attr-name,
-  &.operator {
+  &.boolean,
+  &.builtin,
+  &.constant,
+  &.number,
+  &.selector,
+  &.variable,
+  .language-liquid &.property,
+  .language-twig &.property {
     color: colors.$orange-lighter;
   }
 
-  &.important,
+  &.attr-value,
+  &.plain-text,
+  &.string,
+  &.url {
+    color: colors.$green-lighter;
+  }
+
+  &.entity,
+  &.function,
+  &.parameter,
+  &.tag,
+  .language-liquid &.operator + &.property,
+  .language-twig &.operator + &.property {
+    color: colors.$fuchsia-lighter;
+  }
+
+  &.class-name,
+  &.rule,
+  &.important {
+    color: colors.$purple-lighter;
+  }
+
+  &.block,
+  &.key,
+  &.keyword,
+  &.operator,
+  &.property,
+  &.regex {
+    color: colors.$primary-brand-lighter;
+  }
+
   &.bold {
-    color: colors.$text-light-emphasis;
+    font-weight: font.$weight-semibold;
   }
 
   &.italic {

--- a/src/vendor/prism/config.js
+++ b/src/vendor/prism/config.js
@@ -3,6 +3,7 @@ import 'prismjs/components/prism-core';
 // Required by other languages
 import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-markup-templating';
+import 'prismjs/components/prism-markup';
 // Supported languages
 import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-css';
@@ -10,7 +11,6 @@ import 'prismjs/components/prism-handlebars';
 import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-jsx';
-import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-php';
 import 'prismjs/components/prism-scss';
 import 'prismjs/components/prism-toml';

--- a/src/vendor/prism/config.js
+++ b/src/vendor/prism/config.js
@@ -4,10 +4,26 @@ import 'prismjs/components/prism-core';
 import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-markup-templating';
 // Supported languages
+import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-css';
 import 'prismjs/components/prism-handlebars';
 import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-php';
 import 'prismjs/components/prism-scss';
+import 'prismjs/components/prism-toml';
+import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-twig';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-yaml';
+
+/**
+ * Custom Liquid source highlighting
+ *
+ * Uses Twig highlighting as a starting point but overrides comment syntax.
+ */
+Prism.languages.liquid = Prism.languages.extend('twig', {
+  comment: /{%\s*comment\s*%}[\S\s]*?{%\s*endcomment\s*%}/,
+});

--- a/src/vendor/prism/demo/samples/bash.txt
+++ b/src/vendor/prism/demo/samples/bash.txt
@@ -1,0 +1,3 @@
+npm i --save @11ty/eleventy
+touch index.md subpage.md
+npx @11ty/eleventy --serve

--- a/src/vendor/prism/demo/samples/bash.txt
+++ b/src/vendor/prism/demo/samples/bash.txt
@@ -1,3 +1,20 @@
-npm i --save @11ty/eleventy
-touch index.md subpage.md
-npx @11ty/eleventy --serve
+#!/bin/bash
+
+# This is a comment
+
+for (( i=0;i<$ELEMENTS;i++)); do
+  echo ${ARRAY[${i}]}
+done
+while read LINE; do
+  ARRAY[$count]=$LINE
+  ((count++))
+done
+if [ -d $directory ]; then
+  echo "Directory exists"
+else
+  echo "Directory does not exists"
+fi
+
+crontab -l -u USER | grep -v 'YOUR JOB COMMAND or PATTERN' | crontab -u USER -
+
+git pull origin master

--- a/src/vendor/prism/demo/samples/css.css
+++ b/src/vendor/prism/demo/samples/css.css
@@ -7,6 +7,10 @@
   padding-bottom: calc(24 / 16em * 1.25);
 }
 
+.Sky--clouds::after {
+  transform: rotate(35deg);
+}
+
 @media (min-width: 1337px) {
   p > b > a {
     content: 'Terrible selector! :(';

--- a/src/vendor/prism/demo/samples/jsx.jsx
+++ b/src/vendor/prism/demo/samples/jsx.jsx
@@ -1,0 +1,19 @@
+function formatName(user) {
+  return user.firstName + ' ' + user.lastName;
+}
+
+const user = {
+  firstName: 'Harper',
+  lastName: 'Perez'
+};
+
+const element = (
+  <h1>
+    Hello, {formatName(user)}!
+  </h1>
+);
+
+ReactDOM.render(
+  element,
+  document.getElementById('root')
+);

--- a/src/vendor/prism/demo/samples/liquid.liquid
+++ b/src/vendor/prism/demo/samples/liquid.liquid
@@ -1,0 +1,25 @@
+Anything you put between {% comment %} and {% endcomment %} tags
+is turned into a comment.
+
+{% assign my_string = "Hello World!" %}
+{% assign my_int = 25 %}
+{% assign my_float = 39.756 %}
+{% assign foo = true %}
+{% assign bar = false %}
+{{ site.users[0] }}
+{{ site.users[1] }}
+{{ site.users[3] }}
+
+{% assign my_array = "zebra, octopus, giraffe, Sally Snake" | split: ", " %}
+{{ my_array | sort_natural | join: ", " }}
+
+{% if true or false and false %}
+  This evaluates to true, since the `and` condition is checked first.
+{% endif %}
+
+{% for product in collection.products %}
+  {{ product.title }}
+{% else %}
+  The collection is empty.
+{% endfor %}
+

--- a/src/vendor/prism/demo/samples/php.txt
+++ b/src/vendor/prism/demo/samples/php.txt
@@ -14,39 +14,4 @@ class InlineSvg {
       $this->svg = simplexml_load_string( '<svg></svg>' );
     }
   }
-
-  public function setAttribute( $name, $value ) {
-    $attributes = $this->svg->attributes();
-
-    if ( empty( $attributes->$name ) ) {
-      $this->svg->addAttribute( $name, $value );
-    } else {
-      $attributes->$name = $value;
-    }
-  }
-
-  public function setAttributes( $attributes = array() ) {
-    foreach ( $attributes as $name => $value ) {
-      $this->setAttribute( $name, $value );
-    }
-  }
-
-  public function prepend( $content = '' ) {
-    if (!empty($content)) {
-      $xml_string = (string) $this;
-      $xml_string = preg_replace( '/<svg(.*)>/U', '<svg$1>' . trim( $content ), $xml_string, 1 );
-      $this->svg = simplexml_load_string($xml_string);
-    }
-  }
-
-  public function __toString() {
-    // Convert to string
-    $xml_string = $this->svg->asXML();
-    // Strip xmlns attributes
-    $xml_string = preg_replace( '/ xmlns[^=]*="[^"]*"/i', '', $xml_string );
-    // Include only the root element
-    $xml_string = preg_replace( '|^.*(<svg.*</svg>).*$|Us', '$1', $xml_string );
-
-    return $xml_string;
-  }
 }

--- a/src/vendor/prism/demo/samples/toml.txt
+++ b/src/vendor/prism/demo/samples/toml.txt
@@ -1,0 +1,33 @@
+# This is a TOML document.
+
+title = "TOML Example"
+
+[owner]
+name = "Tom Preston-Werner"
+dob = 1979-05-27T07:32:00-08:00 # First class dates
+
+[database]
+server = "192.168.1.1"
+ports = [ 8001, 8001, 8002 ]
+connection_max = 5000
+enabled = true
+
+[servers]
+
+  # Indentation (tabs and/or spaces) is allowed but not required
+  [servers.alpha]
+  ip = "10.0.0.1"
+  dc = "eqdc10"
+
+  [servers.beta]
+  ip = "10.0.0.2"
+  dc = "eqdc10"
+
+[clients]
+data = [ ["gamma", "delta"], [1, 2] ]
+
+# Line breaks are OK when inside arrays
+hosts = [
+  "alpha",
+  "omega"
+]

--- a/src/vendor/prism/demo/samples/tsx.tsx
+++ b/src/vendor/prism/demo/samples/tsx.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+interface IState {
+  clicks: number;
+}
+
+export class Clicker extends React.Component<any, IState> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      clicks: 0,
+    };
+  }
+
+  public clickHandler = () => {
+    this.setState({ clicks: this.state.clicks + 1 });
+  }
+
+  public render() {
+    return (
+      <div>
+        <p>You have clicked the button {this.state.clicks} time(s).</p>
+        <p>
+          <button onClick={this.clickHandler}>click me</button>
+        </p>
+      </div>
+    );
+  }
+}

--- a/src/vendor/prism/demo/samples/twig.txt
+++ b/src/vendor/prism/demo/samples/twig.txt
@@ -1,0 +1,20 @@
+{% if users|length > 0 %}
+  <ul>
+    {% for user in users %}
+      <li>{{ user.username|e }}</li>
+    {% endfor %}
+  </ul>
+{% endif %}
+
+{% set foo = 'foo' %}
+{% set foo = [1, 2] %}
+{% set foo = {'foo': 'bar'} %}
+
+{{ name|striptags|title }}
+{{ list|join(', ') }}
+
+<div id="footer">
+  {% block footer %}
+    &copy; Copyright 2011 by <a href="http://domain.invalid/">you</a>.
+  {% endblock %}
+</div>

--- a/src/vendor/prism/demo/samples/typescript.ts
+++ b/src/vendor/prism/demo/samples/typescript.ts
@@ -1,0 +1,19 @@
+class Student {
+  fullName: string;
+  constructor(public firstName: string, public middleInitial: string, public lastName: string) {
+    this.fullName = firstName + " " + middleInitial + " " + lastName;
+  }
+}
+
+interface Person {
+  firstName: string;
+  lastName: string;
+}
+
+function greeter(person: Person) {
+  return "Hello, " + person.firstName + " " + person.lastName;
+}
+
+let student = new Student("Jane", "M.", "User");
+
+document.body.textContent = greeter(student);

--- a/src/vendor/prism/demo/samples/yaml.txt
+++ b/src/vendor/prism/demo/samples/yaml.txt
@@ -1,0 +1,29 @@
+--- !<tag:clarkevans.com,2002:invoice>
+invoice: 34843
+date: 2001-01-23
+bill-to: &id001
+  given: Chris
+  family: Dumars
+  address:
+    lines: |
+      458 Walkman Dr.
+      Suite #292
+    city: Royal Oak
+    state: MI
+    postal  : 48046
+ship-to: *id001
+product:
+  - sku: BL394D
+    quantity : 4
+    description: Basketball
+    price: 450.00
+  - sku: BL4438H
+    quantity: 1
+    description: Super Hoop
+    price: 2392.00
+tax: 251.42
+total: 4443.52
+comments:
+  Late afternoon is best.
+  Backup contact is Nancy
+  Billsmer @ 338-4338.

--- a/src/vendor/prism/demo/samples/yaml.txt
+++ b/src/vendor/prism/demo/samples/yaml.txt
@@ -10,11 +10,11 @@ bill-to: &id001
       Suite #292
     city: Royal Oak
     state: MI
-    postal  : 48046
+    postal: 48046
 ship-to: *id001
 product:
   - sku: BL394D
-    quantity : 4
+    quantity: 4
     description: Basketball
     price: 450.00
   - sku: BL4438H
@@ -23,7 +23,3 @@ product:
     price: 2392.00
 tax: 251.42
 total: 4443.52
-comments:
-  Late afternoon is best.
-  Backup contact is Nancy
-  Billsmer @ 338-4338.

--- a/src/vendor/prism/globals.ts
+++ b/src/vendor/prism/globals.ts
@@ -1,0 +1,5 @@
+declare global {
+  const Prism: typeof import('prismjs');
+}
+
+export {};

--- a/src/vendor/prism/prism.stories.mdx
+++ b/src/vendor/prism/prism.stories.mdx
@@ -32,6 +32,8 @@ Our CSS includes a custom [Prism](https://prismjs.com/index.html) theme to suppo
 
 ## Supported Languages
 
+<Story name="Bash, Shell">{sampleDemo(samples.bash)}</Story>
+
 <Story name="CSS">{sampleDemo(samples.css)}</Story>
 
 <Story name="Handlebars">{sampleDemo(samples.handlebars)}</Story>
@@ -40,8 +42,22 @@ Our CSS includes a custom [Prism](https://prismjs.com/index.html) theme to suppo
 
 <Story name="JSON">{sampleDemo(samples.json)}</Story>
 
+<Story name="Liquid">{sampleDemo(samples.liquid)}</Story>
+
 <Story name="Markup, HTML">{sampleDemo(samples.markup)}</Story>
 
 <Story name="PHP">{sampleDemo(samples.php)}</Story>
 
+<Story name="React JSX">{sampleDemo(samples.jsx)}</Story>
+
+<Story name="React TSX">{sampleDemo(samples.tsx)}</Story>
+
 <Story name="Sass (SCSS)">{sampleDemo(samples.scss)}</Story>
+
+<Story name="TOML">{sampleDemo(samples.toml)}</Story>
+
+<Story name="Twig">{sampleDemo(samples.twig)}</Story>
+
+<Story name="TypeScript">{sampleDemo(samples.typescript)}</Story>
+
+<Story name="YAML">{sampleDemo(samples.yaml)}</Story>


### PR DESCRIPTION
## Overview

This PR updates our Prism configuration and our syntax highlighting theme to accommodate the following new languages:

- Bash, Shell
- Liquid
- React JSX
- React TSX
- TOML
- Twig
- TypeScript
- YAML

To keep the theme lean and to maintain a loose consistency between color-logic associations between languages (which I feel is helpful when reading an article involving multiple languages, such as JavaScript and CSS), I chose to comment out my original theme and to pepper the styles back in, making adjustments based on how it impacted _all_ examples unless an override was absolutely necessary. Only 11 more lines of CSS to double our language support!

One side effect is that the theme design _has_ changed a tad, which is why I'm requesting design review in addition to developer review.

## Screenshots

![Screenshot_2020-06-01 Storybook(1)](https://user-images.githubusercontent.com/69633/83464527-f63a9100-a425-11ea-9d39-7713d8e7e292.png)

## Testing

[View the new theme at the deploy preview](https://deploy-preview-764--cloudfour-patterns.netlify.app/).

---

- Resolves #757 
