### PR TITLE
Icon component template

### DIFF
--- a/src/components/heading/heading.twig
+++ b/src/components/heading/heading.twig
@@ -61,8 +61,8 @@
 {% if permalink and permalink_id %}
   <div class="{{_level_class}}">
     <a class="c-heading__permalink" href="#{{permalink_id}}">
-      {% include '@cloudfour/assets/icons/link.svg.twig' with {
-        class: 'c-icon',
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'link',
         aria_hidden: 'true'
       } only %}
       <span class="u-hidden-visually">Permalink to {{_content}}</span>

--- a/src/components/icon/demo/basic.twig
+++ b/src/components/icon/demo/basic.twig
@@ -1,3 +1,0 @@
-{% include '@cloudfour/assets/icons/heart.svg.twig' with {
-  class: 'c-icon'
-} %}

--- a/src/components/icon/demo/inline.twig
+++ b/src/components/icon/demo/inline.twig
@@ -1,12 +1,13 @@
 <p>
   Before:
-  {% include '@cloudfour/assets/icons/heart.svg.twig' with {
-    class: 'c-icon'
+  {% include '@cloudfour/components/icon/icon.twig' with {
+    name: 'heart'
   } %}
 </p>
 <p>
   After:
-  {% include '@cloudfour/assets/icons/heart.svg.twig' with {
-    class: 'c-icon c-icon--inline'
+  {% include '@cloudfour/components/icon/icon.twig' with {
+    name: 'heart',
+    inline: true
   } %}
 </p>

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -1,8 +1,9 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
-import basicDemo from './demo/basic.twig';
+import { withKnobs, text, boolean } from '@storybook/addon-knobs';
+import template from './icon.twig';
 import inlineDemo from './demo/inline.twig';
 
-<Meta title="Components/Icon" />
+<Meta title="Components/Icon" decorators={[withKnobs]} />
 
 # Icon
 
@@ -11,7 +12,14 @@ The `c-icon` class causes an SVG element to inherit its size and default color f
 For a list of available icons, visit [the Icons page](/?path=/docs/design-icons--page).
 
 <Preview>
-  <Story name="Basic">{basicDemo()}</Story>
+  <Story name="Basic">
+    {template({
+      name: text('name', 'heart'),
+      fallback: text('fallback'),
+      inline: boolean('inline'),
+      class: text('class'),
+    })}
+  </Story>
 </Preview>
 
 ## Modifier: Inline
@@ -19,5 +27,25 @@ For a list of available icons, visit [the Icons page](/?path=/docs/design-icons-
 Icons without a flex or grid container may appear [slightly low in comparison to adjacent text](https://cloudfour.com/thinks/some-imaginary-css/#align-to-typeface-median). The `c-icon--inline` modifier applies a slight positioning adjustment to account for this.
 
 <Preview>
-  <Story name="Inline">{inlineDemo()}</Story>
+  <Story name="Inline">{inlineDemo}</Story>
 </Preview>
+
+## Template Properties
+
+The component template supports the following unique properties:
+
+- `name`: The name of the intended icon [in our library](/?path=/docs/design-icons--page).
+- `fallback`: The name of an icon to display if the first doesn't exist. Useful if you are displaying unique icons based on dynamic content. Defaults to `close`.
+- `inline`: When `true`, the inline modifier will be applied.
+- `class`: Will append to `c-icon` and any other modifier classes.
+
+Additional SVG properties will be passed to the Twig template for the asset itself:
+
+```twig
+{% include '@cloudfour/components/icon/icon.twig' with {
+  name: 'heart',
+  inline: true,
+  viewBox: '-12 -12 48 48',
+  aria_hidden: 'true'
+} %}
+```

--- a/src/components/icon/icon.twig
+++ b/src/components/icon/icon.twig
@@ -1,0 +1,20 @@
+{% set fallback = fallback|default('close') %}
+
+{% set _dir = '@cloudfour/assets/icons/' %}
+{% set _ext = '.svg.twig' %}
+{% set _path = _dir ~ name ~ _ext %}
+{% set _fallback_path = _dir ~ fallback ~ _ext %}
+
+{% set _class = 'c-icon' %}
+
+{% if inline %}
+  {% set _class = _class ~ ' c-icon--inline' %}
+{% endif %}
+
+{% if class %}
+  {% set _class = _class ~ ' ' ~ class %}
+{% endif %}
+
+{% include [ _path, _fallback_path ] with {
+  class: _class,
+} %}

--- a/src/components/message/message.twig
+++ b/src/components/message/message.twig
@@ -10,10 +10,11 @@
   </div>
   {% if include_close %}
     <button class="c-message__close" type="button">
-      {% include '@cloudfour/assets/icons/close.svg.twig' with {
-          class: 'c-icon c-message__close-icon',
-          aria_hidden: true
-        } %}
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'close',
+        class: 'c-message__close-icon',
+        aria_hidden: true
+      } %}
       <span class="u-hidden-visually">Close the notification</span>
     </button>
   {% endif %}

--- a/src/design/icons/icons.stories.mdx
+++ b/src/design/icons/icons.stories.mdx
@@ -41,8 +41,8 @@ For icon usage examples, see [the icon object](/?path=/docs/components-icon--bas
 
 <IconGallery>{iconElements}</IconGallery>
 
-# Vendor Icons
+## Third-Party Brands
 
-This icon set encompasses third-party brand and service icons.
+Intended for outbound links to publications and social media profiles.
 
 <IconGallery>{brandIconElements}</IconGallery>

--- a/src/design/icons/icons.stories.mdx
+++ b/src/design/icons/icons.stories.mdx
@@ -25,7 +25,7 @@ const brandIconElements = brandIconDir.keys().map((key) => {
   // Retains subdirectory if we want to organize with those in the future
   const name = relative('.', key).replace(extname(key), '');
   return (
-    <IconItem name={name}>
+    <IconItem name={`brands/${name}`}>
       <BrandIcon class="c-icon" />
     </IconItem>
   );

--- a/src/objects/rhythm/demo/article.twig
+++ b/src/objects/rhythm/demo/article.twig
@@ -38,8 +38,9 @@
           } only %}
             {% block content %}
               Full article
-              {% include '@cloudfour/assets/icons/arrow-right.svg.twig' with {
-                class: 'c-icon c-icon--inline'
+              {% include '@cloudfour/components/icon/icon.twig' with {
+                name: 'arrow-right',
+                inline: true
               } only %}
             {% endblock %}
           {% endembed %}

--- a/src/objects/rhythm/demo/summary.twig
+++ b/src/objects/rhythm/demo/summary.twig
@@ -8,8 +8,9 @@
       } only %}
         {% block content %}
           What sets us apart
-          {% include '@cloudfour/assets/icons/arrow-right.svg.twig' with {
-            class: 'c-icon c-icon--inline'
+          {% include '@cloudfour/components/icon/icon.twig' with {
+            name: 'arrow-right',
+            inline: true
           } only %}
         {% endblock %}
       {% endembed %}

--- a/src/utilities/display/demo/hidden-visually.twig
+++ b/src/utilities/display/demo/hidden-visually.twig
@@ -1,5 +1,8 @@
 <a href="https://github.com/cloudfour/cloudfour.com-patterns">
-  {% include '@cloudfour/assets/icons/brands/github.svg.twig' with { class: 'c-icon c-icon--inline' } %}
+  {% include '@cloudfour/components/icon/icon.twig' with {
+    name: 'brands/github',
+    inline: true
+  } only %}
   <span class="u-hidden-visually">
     View this project on GitHub
   </span>


### PR DESCRIPTION
## Overview

Now that dynamic template paths are supported, we no longer have to avoid a component template for `c-icon`. Hooray!

---

- Resolves #758 
