### PR TITLE
Add HTML tab to Storybook canvas

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -14,6 +14,7 @@ module.exports = {
     // Community addons
     'storybook-addon-themes',
     'storybook-addon-paddings',
+    '@whitespace/storybook-addon-html/register',
   ],
   webpackFinal: async (config) => {
     const isDev = config.mode === 'development';

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,7 @@ import { addDecorator, addParameters } from '@storybook/html';
 import { withA11y } from '@storybook/addon-a11y';
 import { Parser } from 'html-to-react';
 import { withPaddings } from 'storybook-addon-paddings';
+import { withHTML } from '@whitespace/storybook-addon-html/html';
 import * as colors from '../src/design-tokens/colors.yml';
 import * as breakpoints from '../src/design-tokens/breakpoint.yml';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
@@ -12,6 +13,9 @@ import './preview.scss';
 
 // Accessibility testing via aXe
 addDecorator(withA11y);
+
+// Add HTML tab with output source
+addDecorator(withHTML);
 
 // Theme selection from stories
 const themes = [{ name: 'Dark', class: 't-dark', color: colors.primaryBrand }];

--- a/package-lock.json
+++ b/package-lock.json
@@ -5184,7 +5184,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/background/-/background-5.1.2.tgz",
       "integrity": "sha512-jtwH2C/U6ssuGSvwTN3ri/IyjdHb8W9X/g8Y0JLcrH02G+BW3OS8kZdHphF1/YyRklnrKrBT2ngwGUK6aqqV3A==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5194,7 +5193,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/border/-/border-5.1.5.tgz",
       "integrity": "sha512-JvddhNrnhGigtzWRCVuAHepniyVi6hBlimxWDVAdcTuk7aRn9BYJUwfHslURtwYFsF5FoEs8Zmr1oZq2M1AP0A==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5204,7 +5202,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/color/-/color-5.1.2.tgz",
       "integrity": "sha512-1kCkeKDZkt4GYkuFNKc7vJQMcOmTl3bJY3YBUs7fCNM6mMYJeT1pViQ2LwBSBJytj3AB0o4IdLBoepgSgGl5MA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5214,7 +5211,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/core/-/core-5.1.2.tgz",
       "integrity": "sha512-XclBDdNIy7OPOsN4HBsawG2eiWfCcuFt6gxKn1x4QfMIgeO6TOlA2pZZ5GWZtIhCUqEPTgIBta6JXsGyCkLBYw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "object-assign": "^4.1.1"
       }
@@ -5223,15 +5219,13 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/@styled-system/css/-/css-5.1.5.tgz",
       "integrity": "sha512-XkORZdS5kypzcBotAMPBoeckDs9aSZVkvrAlq5K3xP8IMAUek+x2O4NtwoSgkYkWWzVBu6DGdFZLR790QWGG+A==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@styled-system/flexbox": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/flexbox/-/flexbox-5.1.2.tgz",
       "integrity": "sha512-6hHV52+eUk654Y1J2v77B8iLeBNtc+SA3R4necsu2VVinSD7+XY5PCCEzBFaWs42dtOEDIa2lMrgL0YBC01mDQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5241,7 +5235,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/grid/-/grid-5.1.2.tgz",
       "integrity": "sha512-K3YiV1KyHHzgdNuNlaw8oW2ktMuGga99o1e/NAfTEi5Zsa7JXxzwEnVSDSBdJC+z6R8WYTCYRQC6bkVFcvdTeg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5251,7 +5244,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/layout/-/layout-5.1.2.tgz",
       "integrity": "sha512-wUhkMBqSeacPFhoE9S6UF3fsMEKFv91gF4AdDWp0Aym1yeMPpqz9l9qS/6vjSsDPF7zOb5cOKC3tcKKOMuDCPw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5261,7 +5253,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/position/-/position-5.1.2.tgz",
       "integrity": "sha512-60IZfMXEOOZe3l1mCu6sj/2NAyUmES2kR9Kzp7s2D3P4qKsZWxD1Se1+wJvevb+1TP+ZMkGPEYYXRyU8M1aF5A==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5271,7 +5262,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/shadow/-/shadow-5.1.2.tgz",
       "integrity": "sha512-wqniqYb7XuZM7K7C0d1Euxc4eGtqEe/lvM0WjuAFsQVImiq6KGT7s7is+0bNI8O4Dwg27jyu4Lfqo/oIQXNzAg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5293,7 +5283,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/space/-/space-5.1.2.tgz",
       "integrity": "sha512-+zzYpR8uvfhcAbaPXhH8QgDAV//flxqxSjHiS9cDFQQUSznXMQmxJegbhcdEF7/eNnJgHeIXv1jmny78kipgBA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5303,7 +5292,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/typography/-/typography-5.1.2.tgz",
       "integrity": "sha512-BxbVUnN8N7hJ4aaPOd7wEsudeT7CxarR+2hns8XCX1zp0DFfbWw4xYa/olA0oQaqx7F1hzDg+eRaGzAJbF+jOg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2"
       }
@@ -5313,7 +5301,6 @@
       "resolved": "https://registry.npmjs.org/@styled-system/variant/-/variant-5.1.5.tgz",
       "integrity": "sha512-Yn8hXAFoWIro8+Q5J8YJd/mP85Teiut3fsGVR9CAxwgNfIAiqlYxsk5iHU7VHJks/0KjL4ATSjmbtCDC/4l1qw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/core": "^5.1.2",
         "@styled-system/css": "^5.1.5"
@@ -6246,6 +6233,60 @@
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "@whitespace/storybook-addon-html": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@whitespace/storybook-addon-html/-/storybook-addon-html-1.2.1.tgz",
+      "integrity": "sha512-q13tIW2NCOZyrzxHLExvbuf95jlFgdGPHK1whSSgVg8OQAh8D3GdJryXGwpUMobywdzgHdjTfzyggRStLul5Nw==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@storybook/addons": "^5.3.4",
+        "@storybook/api": "^5.3.4",
+        "@storybook/components": "^5.3.4",
+        "estraverse": "^4.3.0",
+        "prettier": "^1.19.1",
+        "prismjs": "^1.19.0",
+        "react-syntax-highlighter": "^12.2.1"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "9.15.10",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+          "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==",
+          "dev": true
+        },
+        "lowlight": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
+          "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
+          "dev": true,
+          "requires": {
+            "fault": "^1.0.2",
+            "highlight.js": "~9.15.0"
+          }
+        },
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true
+        },
+        "react-syntax-highlighter": {
+          "version": "12.2.1",
+          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
+          "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "highlight.js": "~9.15.1",
+            "lowlight": "1.12.1",
+            "prismjs": "^1.8.4",
+            "refractor": "^2.4.1"
+          }
+        }
       }
     },
     "@xtuc/ieee754": {
@@ -22747,7 +22788,6 @@
       "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.5.tgz",
       "integrity": "sha512-7VoD0o2R3RKzOzPK0jYrVnS8iJdfkKsQJNiLRDjikOpQVqQHns/DXWaPZOH4tIKkhAT7I6wIsy9FWTWh2X3q+A==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@styled-system/background": "^5.1.2",
         "@styled-system/border": "^5.1.5",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/prismjs": "1.16.1",
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
+    "@whitespace/storybook-addon-html": "^1.2.1",
     "babel-loader": "8.1.0",
     "browserify-transform-tools": "1.7.0",
     "css-loader": "3.5.3",


### PR DESCRIPTION
## Overview

Adds [a Storybook add-on](https://github.com/whitespace-se/storybook-addon-html) that displays the output HTML of the current canvas in its own tab. This is presumably a stop-gap solution until Storybook 6's more versatile storysource add-on is done.

## Screenshots

<img width="579" alt="Screen Shot 2020-06-02 at 4 40 12 PM" src="https://user-images.githubusercontent.com/69633/83580106-05861100-a4f0-11ea-9d87-93e73ea95d96.png">

<img width="674" alt="Screen Shot 2020-06-02 at 4 40 27 PM" src="https://user-images.githubusercontent.com/69633/83580108-06b73e00-a4f0-11ea-8e20-54accd7080ba.png">

<img width="505" alt="Screen Shot 2020-06-02 at 4 40 38 PM" src="https://user-images.githubusercontent.com/69633/83580111-07e86b00-a4f0-11ea-8950-4a8adb6c73db.png">

<img width="638" alt="Screen Shot 2020-06-02 at 4 40 53 PM" src="https://user-images.githubusercontent.com/69633/83580112-08810180-a4f0-11ea-8139-e116525ffee3.png">

