### PR TITLE
Only output calendar date note when there is one

### DIFF
--- a/src/components/calendar-date/calendar-date.twig
+++ b/src/components/calendar-date/calendar-date.twig
@@ -1,5 +1,6 @@
 {% set datetime = datetime|default('now') %}
 {% set days = days|default(1) %}
+{% set _note %}{% block note %}{{note}}{% endblock %}{% endset %}
 
 <time class="c-calendar-date c-calendar-date--{{datetime|date('F')|lower}}{% if class %} {{class}}{% endif %}"
   datetime="{{datetime|date('Y-m-d')}}">
@@ -10,11 +11,9 @@
     <span class="c-calendar-date__day">
       {{datetime|date('j')}}
     </span>
-    {% if block('note') or note %}
+    {% if _note %}
       <span class="c-calendar-date__note">
-        {% block note %}
-          {{note}}
-        {% endblock %}
+        {{_note}}
       </span>
     {% endif %}
   </span>


### PR DESCRIPTION
## Overview

I noticed while working on #769 that our Calendar Date component's note container was being output even when the note had no content. This resolves that.

## Testing

1. View the HTML tab of the Basic canvas [in `v-next`](https://v-next--cloudfour-patterns.netlify.app/?path=/story/components-calendar-date--basic) and in [the deploy preview](https://deploy-preview-770--cloudfour-patterns.netlify.app/?path=/story/components-calendar-date--basic). Confirm that the `c-calendar-date__note` element is gone in the deploy preview.
1. Confirm that the note is still visible in [the "With Note" example](https://deploy-preview-770--cloudfour-patterns.netlify.app/?path=/story/components-calendar-date--with-note).
