### PR TITLE
Chore: imports WordPress block-library styles

### DIFF
--- a/.changeset/few-parrots-draw.md
+++ b/.changeset/few-parrots-draw.md
@@ -1,5 +1,0 @@
----
-'@cloudfour/patterns': minor
----
-
-Imports Wordpress Gutenberg block-library CSS into Gutenberg stories

--- a/.changeset/few-parrots-draw.md
+++ b/.changeset/few-parrots-draw.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Imports Wordpress Gutenberg block-library CSS into Gutenberg stories

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@caleby/cloudfour-patterns-tmp",
-  "version": "0.6.1",
+  "name": "@cloudfour/patterns",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3314,6 +3314,24 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "dev": true
     },
+    "@emotion/native": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/native/-/native-10.0.27.tgz",
+      "integrity": "sha512-3qxR2XFizGfABKKbX9kAYc0PHhKuCEuyxshoq3TaMEbi9asWHdQVChg32ULpblm4XAf9oxaitAU7J9SfdwFxtw==",
+      "dev": true,
+      "requires": {
+        "@emotion/primitives-core": "10.0.27"
+      }
+    },
+    "@emotion/primitives-core": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-10.0.27.tgz",
+      "integrity": "sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==",
+      "dev": true,
+      "requires": {
+        "css-to-react-native": "^2.2.1"
+      }
+    },
     "@emotion/serialize": {
       "version": "0.11.16",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
@@ -3882,6 +3900,12 @@
         "@nodelib/fs.scandir": "2.1.3",
         "fastq": "^1.6.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA==",
+      "dev": true
     },
     "@reach/router": {
       "version": "1.3.3",
@@ -6393,6 +6417,37 @@
         }
       }
     },
+    "@tannin/compile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
+      "integrity": "sha512-n8m9eNDfoNZoxdvWiTfW/hSPhehzLJ3zW7f8E7oT6mCROoMNWCB4TYtv041+2FMAxweiE0j7i1jubQU4MEC/Gg==",
+      "dev": true,
+      "requires": {
+        "@tannin/evaluate": "^1.2.0",
+        "@tannin/postfix": "^1.1.0"
+      }
+    },
+    "@tannin/evaluate": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.2.0.tgz",
+      "integrity": "sha512-3ioXvNowbO/wSrxsDG5DKIMxC81P0QrQTYai8zFNY+umuoHWRPbQ/TuuDEOju9E+jQDXmj6yI5GyejNuh8I+eg==",
+      "dev": true
+    },
+    "@tannin/plural-forms": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.1.0.tgz",
+      "integrity": "sha512-xl9R2mDZO/qiHam1AgMnAES6IKIg7OBhcXqy6eDsRCdXuxAFPcjrej9HMjyCLE0DJ/8cHf0i5OQTstuBRhpbHw==",
+      "dev": true,
+      "requires": {
+        "@tannin/compile": "^1.1.0"
+      }
+    },
+    "@tannin/postfix": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
+      "integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw==",
+      "dev": true
+    },
     "@testing-library/cypress": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-6.0.0.tgz",
@@ -7137,6 +7192,1111 @@
         }
       }
     },
+    "@wordpress/a11y": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.10.0.tgz",
+      "integrity": "sha512-atECjCyzQFYMbgYg6BLZrj6VpCo2VFvwibxtsKtAD1mpW060EzOLMerfkdxQuNweS0kGYh85+79o8awT3KxhOg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/dom-ready": "^2.9.0",
+        "@wordpress/i18n": "^3.13.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/api-fetch": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.16.0.tgz",
+      "integrity": "sha512-m/WtgIxydZe7V9KISdaCcgBETpKXWufXrhspxjwWhEDRQKS+U/N5aYVaE5K9amQr33XXZEnKpK2fSPa1QrUvCw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/i18n": "^3.13.0",
+        "@wordpress/url": "^2.15.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/autop": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-2.7.0.tgz",
+      "integrity": "sha512-XLNyxlsdXPQMTHl3NnR1nbsggcf12euBwpp6d6qdVLT3+s2FtU2dg9dMVJg/OHKd3/QgA6W+k7yjcyME2aOAFQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/blob": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.8.0.tgz",
+      "integrity": "sha512-5obAEfhdMaDftitAqMXkc8kWyDim1qS8FvVk7m+fZHnkJXFmxdZHJvCAerjjwI//GMVUvZEbpakdWGoW27TIWg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/block-directory": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-directory/-/block-directory-1.10.0.tgz",
+      "integrity": "sha512-y+6iEE6oDqisq4d6DfUTFGS0WT5q79QhCnV0+6+K37Uo9z5liRykV8LOxcUjFkpN/BvFJpYrNpBTrzNvV7hHsQ==",
+      "dev": true,
+      "requires": {
+        "@wordpress/api-fetch": "^3.16.0",
+        "@wordpress/block-editor": "^4.0.0",
+        "@wordpress/blocks": "^6.17.0",
+        "@wordpress/components": "^9.7.0",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/data": "^4.19.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/i18n": "^3.13.0",
+        "@wordpress/icons": "^2.1.0",
+        "@wordpress/plugins": "^2.17.0",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@wordpress/block-editor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-4.0.0.tgz",
+      "integrity": "sha512-WLi8C4AxxNFZopMVv+2qu2vdZVJ/sIWQwxYvyIqINyjeR3LhCPezyyiS06HmWcFqcajWGBZXSSmrrI6avA0mJQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/a11y": "^2.10.0",
+        "@wordpress/blob": "^2.8.0",
+        "@wordpress/blocks": "^6.17.0",
+        "@wordpress/components": "^9.7.0",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/data": "^4.19.0",
+        "@wordpress/deprecated": "^2.8.0",
+        "@wordpress/dom": "^2.10.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/hooks": "^2.8.0",
+        "@wordpress/html-entities": "^2.7.0",
+        "@wordpress/i18n": "^3.13.0",
+        "@wordpress/icons": "^2.1.0",
+        "@wordpress/is-shallow-equal": "^2.0.0",
+        "@wordpress/keyboard-shortcuts": "^1.6.0",
+        "@wordpress/keycodes": "^2.13.0",
+        "@wordpress/priority-queue": "^1.6.0",
+        "@wordpress/rich-text": "^3.17.0",
+        "@wordpress/shortcode": "^2.7.0",
+        "@wordpress/token-list": "^1.10.0",
+        "@wordpress/url": "^2.15.0",
+        "@wordpress/viewport": "^2.18.0",
+        "@wordpress/wordcount": "^2.8.0",
+        "classnames": "^2.2.5",
+        "css-mediaquery": "^0.1.2",
+        "diff": "^4.0.2",
+        "dom-scroll-into-view": "^1.2.1",
+        "inherits": "^2.0.3",
+        "lodash": "^4.17.15",
+        "memize": "^1.1.0",
+        "react-autosize-textarea": "^3.0.2",
+        "react-spring": "^8.0.19",
+        "redux-multi": "^0.1.12",
+        "refx": "^3.0.0",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.1",
+        "traverse": "^0.6.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/block-library": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.19.0.tgz",
+      "integrity": "sha512-ObQmCm11NjmVplRy7t0CgHcEPltcfyMb4dmLbcjI8ahrgLL/lLYZ1vYVdt6VdGsHdOvHo97iFvR2/yxNPNkGvA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/a11y": "^2.10.0",
+        "@wordpress/api-fetch": "^3.16.0",
+        "@wordpress/autop": "^2.7.0",
+        "@wordpress/blob": "^2.8.0",
+        "@wordpress/block-editor": "^4.0.0",
+        "@wordpress/blocks": "^6.17.0",
+        "@wordpress/components": "^9.7.0",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/core-data": "^2.17.0",
+        "@wordpress/data": "^4.19.0",
+        "@wordpress/date": "^3.9.0",
+        "@wordpress/deprecated": "^2.8.0",
+        "@wordpress/dom": "^2.10.0",
+        "@wordpress/editor": "^9.17.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/escape-html": "^1.8.0",
+        "@wordpress/i18n": "^3.13.0",
+        "@wordpress/icons": "^2.1.0",
+        "@wordpress/is-shallow-equal": "^2.0.0",
+        "@wordpress/keycodes": "^2.13.0",
+        "@wordpress/primitives": "^1.5.0",
+        "@wordpress/rich-text": "^3.17.0",
+        "@wordpress/server-side-render": "^1.13.0",
+        "@wordpress/url": "^2.15.0",
+        "@wordpress/viewport": "^2.18.0",
+        "classnames": "^2.2.5",
+        "fast-average-color": "4.3.0",
+        "lodash": "^4.17.15",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "tinycolor2": "^1.4.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/block-serialization-default-parser": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.6.0.tgz",
+      "integrity": "sha512-4l1zrxaLd36qHSkTSx+2C3jM/fTD2NZG7mGGYPzL0/yevd1ZNkkc++7bxAGQuM7m8yPw+MKkiq9ETzNLoTHnbQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/blocks": {
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.17.0.tgz",
+      "integrity": "sha512-pwVW0QsCiVo6EoERYGlZ7ZeSy8FNs6BqrT6UNXl6cV/0IPgxm4Hc+w7J8Tbi6WOZqWQZeFpSEYNQ61Id0f9EBw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/autop": "^2.7.0",
+        "@wordpress/blob": "^2.8.0",
+        "@wordpress/block-serialization-default-parser": "^3.6.0",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/data": "^4.19.0",
+        "@wordpress/dom": "^2.10.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/hooks": "^2.8.0",
+        "@wordpress/html-entities": "^2.7.0",
+        "@wordpress/i18n": "^3.13.0",
+        "@wordpress/icons": "^2.1.0",
+        "@wordpress/is-shallow-equal": "^2.0.0",
+        "@wordpress/shortcode": "^2.7.0",
+        "hpq": "^1.3.0",
+        "lodash": "^4.17.15",
+        "rememo": "^3.0.0",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "tinycolor2": "^1.4.1",
+        "uuid": "^7.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true
+        }
+      }
+    },
+    "@wordpress/components": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.7.0.tgz",
+      "integrity": "sha512-F5AH6zg2K/WxSjQj2Y/9Ds1oj+3f0vd1dGF2sH/dIXstdtTnQYyJyeTmf/GL1czveuZ2w2R+8OYADtRn5f89/w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@emotion/core": "^10.0.22",
+        "@emotion/css": "^10.0.22",
+        "@emotion/native": "^10.0.22",
+        "@emotion/styled": "^10.0.23",
+        "@wordpress/a11y": "^2.10.0",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/deprecated": "^2.8.0",
+        "@wordpress/dom": "^2.10.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/hooks": "^2.8.0",
+        "@wordpress/i18n": "^3.13.0",
+        "@wordpress/icons": "^2.1.0",
+        "@wordpress/is-shallow-equal": "^2.0.0",
+        "@wordpress/keycodes": "^2.13.0",
+        "@wordpress/primitives": "^1.5.0",
+        "@wordpress/rich-text": "^3.17.0",
+        "@wordpress/warning": "^1.1.0",
+        "classnames": "^2.2.5",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^4.0.5",
+        "gradient-parser": "^0.1.5",
+        "lodash": "^4.17.15",
+        "memize": "^1.1.0",
+        "moment": "^2.22.1",
+        "re-resizable": "^6.0.0",
+        "react-dates": "^17.1.1",
+        "react-spring": "^8.0.20",
+        "react-use-gesture": "^7.0.15",
+        "reakit": "^1.0.2",
+        "rememo": "^3.0.0",
+        "tinycolor2": "^1.4.1",
+        "uuid": "^7.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true
+        }
+      }
+    },
+    "@wordpress/compose": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.16.0.tgz",
+      "integrity": "sha512-441spdHY6fBqDq3/MWFnhY8Q2MJTNTNK74mR06X1PXvVoQxuhW8SHJbb7+uHL9JiHAF5MRpqMTrslHC/iBD81A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/is-shallow-equal": "^2.0.0",
+        "clipboard": "^2.0.1",
+        "lodash": "^4.17.15",
+        "mousetrap": "^1.6.2",
+        "react-resize-aware": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/core-data": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.17.0.tgz",
+      "integrity": "sha512-jmZIid2iS1UMmBzjAfQLjuycIEQzGQeylQGjyiBPf4gOGUMGPwqH4W1eN7NP/CoOkc9IPhIIoAsVj3sthEKZ0w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/api-fetch": "^3.16.0",
+        "@wordpress/blocks": "^6.17.0",
+        "@wordpress/data": "^4.19.0",
+        "@wordpress/data-controls": "^1.13.0",
+        "@wordpress/deprecated": "^2.8.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/i18n": "^3.13.0",
+        "@wordpress/is-shallow-equal": "^2.0.0",
+        "@wordpress/url": "^2.15.0",
+        "equivalent-key-map": "^0.2.2",
+        "lodash": "^4.17.15",
+        "rememo": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/data": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.19.0.tgz",
+      "integrity": "sha512-WdTBlro46qbkGDGx1ORKmL74KGR1ApKc5g1lJk6jtHVZZ/atw4Kler4eqkkYQZORt8lDJWBEDdonTBzSneUkmg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/deprecated": "^2.8.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/is-shallow-equal": "^2.0.0",
+        "@wordpress/priority-queue": "^1.6.0",
+        "@wordpress/redux-routine": "^3.9.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.15",
+        "memize": "^1.1.0",
+        "redux": "^4.0.0",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "is-promise": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+          "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+          "dev": true
+        }
+      }
+    },
+    "@wordpress/data-controls": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.13.0.tgz",
+      "integrity": "sha512-EiQCxdHzp2L/5st9bau7/7iqNbCorCzHVsrAp9n0WJVrAwpXNWvDYJlGIrcT+BtoAEsTnbrrMn3eJJbrMWyePA==",
+      "dev": true,
+      "requires": {
+        "@wordpress/api-fetch": "^3.16.0",
+        "@wordpress/data": "^4.19.0"
+      }
+    },
+    "@wordpress/date": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.9.0.tgz",
+      "integrity": "sha512-V4+k6Ipkm/JX1TzRcwo96v0Lk1m1NGAHwO9JsnUCCXlG1Qxgl+MxRkWpgmUwgdCDjVvevS/4bU+LvndDWQIzVA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "moment": "^2.22.1",
+        "moment-timezone": "^0.5.16"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/deprecated": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.8.0.tgz",
+      "integrity": "sha512-MX8ONW8Mf0w38Zllg3d412JcHuIaxmNoaVw03nCi9S31Dj/V3PHEAF8GDeSP0Sfn5DxSs5K4s9LfpE4C2iLgAw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/hooks": "^2.8.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/dom": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.10.0.tgz",
+      "integrity": "sha512-5Wz5JAj0AhLkLaquixCsUskdbSedIs/OBL7vthhnfVKheIt4bShLupJktNZOw7Y8vbISDNxcSeJDuyxBGPUKxA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/dom-ready": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.9.0.tgz",
+      "integrity": "sha512-2egz1f4LaLeeSPTsWUgvgerNUbV9A++x/YWBGiF8t/bC7KX1n4mqexQRihfuofvpBxlkalIJEXxka3pzrD1XHA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/editor": {
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.17.0.tgz",
+      "integrity": "sha512-X76N8P9eRhExfO0vLmyTwGNNjmB3pRx5cxUf8lfpCRmL3H8JVfKgkCK9LK8HwPoM+Z4c2KJqTUVtLdCjs616TA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/api-fetch": "^3.16.0",
+        "@wordpress/autop": "^2.7.0",
+        "@wordpress/blob": "^2.8.0",
+        "@wordpress/block-directory": "^1.10.0",
+        "@wordpress/block-editor": "^4.0.0",
+        "@wordpress/blocks": "^6.17.0",
+        "@wordpress/components": "^9.7.0",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/core-data": "^2.17.0",
+        "@wordpress/data": "^4.19.0",
+        "@wordpress/data-controls": "^1.13.0",
+        "@wordpress/date": "^3.9.0",
+        "@wordpress/deprecated": "^2.8.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/hooks": "^2.8.0",
+        "@wordpress/html-entities": "^2.7.0",
+        "@wordpress/i18n": "^3.13.0",
+        "@wordpress/icons": "^2.1.0",
+        "@wordpress/is-shallow-equal": "^2.0.0",
+        "@wordpress/keyboard-shortcuts": "^1.6.0",
+        "@wordpress/keycodes": "^2.13.0",
+        "@wordpress/media-utils": "^1.12.0",
+        "@wordpress/notices": "^2.5.0",
+        "@wordpress/rich-text": "^3.17.0",
+        "@wordpress/server-side-render": "^1.13.0",
+        "@wordpress/url": "^2.15.0",
+        "@wordpress/viewport": "^2.18.0",
+        "@wordpress/wordcount": "^2.8.0",
+        "classnames": "^2.2.5",
+        "lodash": "^4.17.15",
+        "memize": "^1.1.0",
+        "react-autosize-textarea": "^3.0.2",
+        "redux-optimist": "^1.0.0",
+        "refx": "^3.0.0",
+        "rememo": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/element": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.14.0.tgz",
+      "integrity": "sha512-msSkGecq2Z8lBoj95D0vxj64lbGx7c7Q8VxsNLA3G813HVybeY5gYeWFokWKfok+tszCwjJI4ZgR4DxRsYNTig==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/escape-html": "^1.8.0",
+        "lodash": "^4.17.15",
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/escape-html": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.8.0.tgz",
+      "integrity": "sha512-z7z+57nm9Dv3Hau0u3+17dJCbpWnh853VBF6JPID7rKnLPw2AOoRJtNHf4gLeBJTrG6M4cC8EG8Flarsuoxb2w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/hooks": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.8.0.tgz",
+      "integrity": "sha512-5FbiVz6T2Frw45NmPDF9GbAFU8iQy64YSZaM+61tUngB+Uzdv0A4pA8C8WIDPlw16QJXseZ4uLce4U9HlJQ3dw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/html-entities": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.7.0.tgz",
+      "integrity": "sha512-OmHZFHDl1Ai0LmRlqehRAt0broGigW1QCnRS1K82nurCFi9kz8x13C7GWv7wshA9TC4Qp/PLP9SEl/nzcJyIYg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/i18n": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.13.0.tgz",
+      "integrity": "sha512-eMlOvg2vYKmGV4C1vPrWuOEyskxMeCGoQJ0N3mQ6t7iWKs4bKWAJGlGL5QXMwN7xJJ863h3L7mrbLM3zKVrF1g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "gettext-parser": "^1.3.1",
+        "lodash": "^4.17.15",
+        "memize": "^1.1.0",
+        "sprintf-js": "^1.1.1",
+        "tannin": "^1.2.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "dev": true
+        }
+      }
+    },
+    "@wordpress/icons": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-OiT0dZn/RmjaezF9V5kIK6Rd8iXRGQMV41wgtB7ZAZmfDtksgfehaTDYoBWVrJQbAxV11ZsBnpMRWCG0WQGWRA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/primitives": "^1.5.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/is-shallow-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.0.0.tgz",
+      "integrity": "sha512-Xv8b3Jno/3Td6nyj1J+skW96sbyfX7W4sk0TLwN2C2Pz6iQTSTQyGrXmTZWShITt4SOeA8gKpP6kAwSZ4O0HOQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/keyboard-shortcuts": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-1.6.0.tgz",
+      "integrity": "sha512-NfJSDpP6kjViErmSbgZrrx3TT0rRZiqHtwdyZ9r0o0VHYMdFPbwt9OY0ldyave9YZN9nYsJYstsmFoqXwbXrOw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/data": "^4.19.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/keycodes": "^2.13.0",
+        "lodash": "^4.17.15",
+        "rememo": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/keycodes": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.13.0.tgz",
+      "integrity": "sha512-Bm3N4Qf5qLXds+eflM+JXD15VEW/7IQ7eqWt9/UhsssuDTMTMbXnYjxOAh5zoVi2toAMSMs8EYpV28V+Qv0ZjA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/i18n": "^3.13.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/media-utils": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-1.12.0.tgz",
+      "integrity": "sha512-acq5boZtOXGzPORtar1vN4qcLNyfpjJyFEhP3EhsWxqAWPByH68IUcnm2HVAnkAj99Pxp0q7GsopZtXWRRF0Vw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/api-fetch": "^3.16.0",
+        "@wordpress/blob": "^2.8.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/i18n": "^3.13.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/notices": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-2.5.0.tgz",
+      "integrity": "sha512-bY5ADn0bygJhNjShA9UXW66qYAQlVTmU8HChG37qrlitiZEJPaOCfuBKnR8KD4RFRKbh7bpNYa3dPsOLqny8fg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/a11y": "^2.10.0",
+        "@wordpress/data": "^4.19.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/plugins": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.17.0.tgz",
+      "integrity": "sha512-D5UK8o4Jnl90tUm6PxL3MgiTq0/ml+JQBJ/M7g9JJ7IgKQa1coAH0A+Q1ds41iqkMQEhBBuk3WpQ3V84Om89JA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/hooks": "^2.8.0",
+        "@wordpress/icons": "^2.1.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/primitives": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.5.0.tgz",
+      "integrity": "sha512-SHP95z2AwRHN5egYzUdyvefdvescYTpDNHhp2klTPUNLIme3yNCdL43rihYb+cUEZCgVKEod8Y9EIE7xB9g5YQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/element": "^2.14.0",
+        "classnames": "^2.2.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/priority-queue": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.6.0.tgz",
+      "integrity": "sha512-G2fa+W48U9YRByY+870iWnUKeX7YH13bpqtLaF9HhaykYrLeo41oHsIdiydgeCG49k5A4+mXuNnAWZvEcxgsbA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/redux-routine": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.9.0.tgz",
+      "integrity": "sha512-5CWZK6+g69apZt/hIJE3aL13CPpPnpMmPwzwSfonwis70g9f2Y3SKl/F7BquOAR/MAb5bzjWPPn/ZYzJkNLCRA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "is-promise": "^4.0.0",
+        "lodash": "^4.17.15",
+        "rungen": "^0.3.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "is-promise": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+          "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+          "dev": true
+        }
+      }
+    },
+    "@wordpress/rich-text": {
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.17.0.tgz",
+      "integrity": "sha512-aHcJdCldfmOv2j0IQrbWcg/YJaSYU7c88t2mxwzBiLVtrqC2UsnR0Bxol7NNbM+u08I9s1Sj3g6NKti1na9I3A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/data": "^4.19.0",
+        "@wordpress/deprecated": "^2.8.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/escape-html": "^1.8.0",
+        "@wordpress/is-shallow-equal": "^2.0.0",
+        "@wordpress/keycodes": "^2.13.0",
+        "classnames": "^2.2.5",
+        "lodash": "^4.17.15",
+        "memize": "^1.1.0",
+        "rememo": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/server-side-render": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.13.0.tgz",
+      "integrity": "sha512-Okkk87LT6o/wfpFlwQDH++4xkJtn4TBLwlN6IzCnnw3aXxHLCSS1JGWHEJH37PVtcYuIn+6WZE8YdLGoSz4p8w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/api-fetch": "^3.16.0",
+        "@wordpress/components": "^9.7.0",
+        "@wordpress/data": "^4.19.0",
+        "@wordpress/deprecated": "^2.8.0",
+        "@wordpress/element": "^2.14.0",
+        "@wordpress/i18n": "^3.13.0",
+        "@wordpress/url": "^2.15.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/shortcode": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-2.7.0.tgz",
+      "integrity": "sha512-ltcQK3FxnG45T/E7UVynzunXl/KknXk2+5+63MQ0gEhYvN8IvS2thFxWG1uwmIyAjW/oWl3kFsI11Sxwh5cFPg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "lodash": "^4.17.15",
+        "memize": "^1.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/token-list": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-1.10.0.tgz",
+      "integrity": "sha512-vw0+DU5XDqMEf0xGMhlTk9CKoKu3G7uQZWxYU7UylzuV8QG+NBQ3AhnaEEQxcoLBZcUf4O1aqjs5mD32DmBTNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/url": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.15.0.tgz",
+      "integrity": "sha512-nDGZslWZ6TMve3/09O9b2vGaCP2JXoe95uIrkChkw1DVH3tq/tCg1gwQsPXvhBIw5OmopzwlSEuwwp348hyaCA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "lodash": "^4.17.15",
+        "qs": "^6.5.2",
+        "react-native-url-polyfill": "^1.1.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/viewport": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.18.0.tgz",
+      "integrity": "sha512-uJhcbEtFWYvm/QEVeBUaUzDVOHXzqKP9frunzI/VvwjgduGXY1h+ntPXGD+KKPDtsj9ORgPn9BMrpPNmHI2VjQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/compose": "^3.16.0",
+        "@wordpress/data": "^4.19.0",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
+    "@wordpress/warning": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.1.0.tgz",
+      "integrity": "sha512-n1GDCX2yxxhFF9PeXWq1bInvdwYkYqbeBLHPIChGrS+B57FY4vWebVfKQbOoxZ8CZD1RBIj/KOv/sihuAdHDhg==",
+      "dev": true
+    },
+    "@wordpress/wordcount": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-2.8.0.tgz",
+      "integrity": "sha512-veM3WRmz6mijEjn0kwn2pt3CASIKUxezUCzDe60i9I8spaYAL1hQiykrXx5U3x/hehQaOw2enoqPPdtHIm1XHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -7239,6 +8399,24 @@
         "string.prototype.padend": "^3.0.0",
         "string.prototype.padstart": "^3.0.0",
         "symbol.prototype.description": "^1.0.0"
+      }
+    },
+    "airbnb-prop-types": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
+      "integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
+      "dev": true,
+      "requires": {
+        "array.prototype.find": "^2.1.0",
+        "function.prototype.name": "^1.1.1",
+        "has": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.9.0"
       }
     },
     "ajv": {
@@ -7895,6 +9073,16 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "array.prototype.find": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
+      "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.4"
+      }
+    },
     "array.prototype.flat": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
@@ -8093,6 +9281,12 @@
         "postcss": "^7.0.30",
         "postcss-value-parser": "^4.1.0"
       }
+    },
+    "autosize": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
+      "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -8859,6 +10053,12 @@
         }
       }
     },
+    "body-scroll-lock": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.0.3.tgz",
+      "integrity": "sha512-EUryImgD6Gv87HOjJB/yB2WIGECiZMhmcUK+DrqVRFDDa64xR+FsK0LgvLPnBxZDTxIl+W80/KJ8i6gp2IwOHQ==",
+      "dev": true
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -9016,6 +10216,12 @@
         }
       }
     },
+    "brcast": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-2.0.2.tgz",
+      "integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg==",
+      "dev": true
+    },
     "breakword": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/breakword/-/breakword-1.0.5.tgz",
@@ -9160,6 +10366,16 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-crc32": {
@@ -9350,6 +10566,12 @@
           "dev": true
         }
       }
+    },
+    "camelize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
+      "dev": true
     },
     "can-use-dom": {
       "version": "0.1.0",
@@ -9673,7 +10895,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
       "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
-      "optional": true,
       "requires": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
@@ -9906,6 +11127,18 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.14.tgz",
+      "integrity": "sha512-mKDjINe3tc6hGelUMNDzuhorIUZ7kS7BwyY0r2wQd2HOH2tRuJykiC06iSEX8y1TuhNzvz4GcJnK16mM2J1NMQ==",
+      "dev": true
+    },
+    "computed-style": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
+      "integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -9951,6 +11184,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
+    "consolidated-events": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
+      "integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ==",
       "dev": true
     },
     "constantinople": {
@@ -10271,6 +11510,12 @@
       "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==",
       "dev": true
     },
+    "css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+      "dev": true
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -10352,6 +11597,12 @@
         }
       }
     },
+    "css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=",
+      "dev": true
+    },
     "css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -10369,6 +11620,25 @@
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "dev": true
+    },
+    "css-to-react-native": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
+      "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "dev": true,
+      "requires": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^3.3.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
+        }
+      }
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
@@ -10932,8 +12202,7 @@
     "delegate": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -11011,6 +12280,12 @@
         }
       }
     },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -11057,6 +12332,12 @@
         }
       }
     },
+    "direction": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
+      "integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ==",
+      "dev": true
+    },
     "doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -11072,6 +12353,15 @@
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
       "dev": true
+    },
+    "document.contains": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.1.tgz",
+      "integrity": "sha512-A1KqlZq1w605bwiiLqVZehWE9S9UYlUXPoduFWi64pNVNQ9vy6wwH/7BS+iEfSlF1YyZgcg5PZw5HqDi7FCrUw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
     },
     "dom-accessibility-api": {
       "version": "0.4.4",
@@ -11108,6 +12398,12 @@
           }
         }
       }
+    },
+    "dom-scroll-into-view": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
+      "integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=",
+      "dev": true
     },
     "dom-serializer": {
       "version": "0.2.2",
@@ -11217,6 +12513,29 @@
       "dev": true,
       "requires": {
         "dotenv-defaults": "^1.0.2"
+      }
+    },
+    "downshift": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-4.1.0.tgz",
+      "integrity": "sha512-GODZOZC65a8n8YD/S/87hR2t5PJfqZ7+lwEBJsNi/AJnhImfle+CFD/ZPde4l+nB8QNHfn0GbE1W9djEFOj1yQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "compute-scroll-into-view": "^1.0.9",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "dts-bundle-generator": {
@@ -11524,6 +12843,15 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -11575,6 +12903,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
+    },
+    "equivalent-key-map": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+      "integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
       "dev": true
     },
     "errno": {
@@ -12916,6 +14250,12 @@
         "time-stamp": "^1.0.0"
       }
     },
+    "fast-average-color": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-4.3.0.tgz",
+      "integrity": "sha512-k8FXd6+JeXoItmdNqB3hMwFgArryjdYBLuzEM8fRY/oztd/051yhSHU6GUrMOfIQU9dDHyFDcIAkGrQKlYtpDA==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -12946,6 +14286,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-memoize": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
+      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
       "dev": true
     },
     "fastparse": {
@@ -12988,6 +14334,29 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
+      }
+    },
+    "fbjs": {
+      "version": "0.8.17",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
+      "requires": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
       }
     },
     "fd-slicer": {
@@ -13787,6 +15156,16 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dev": true,
+      "requires": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "github-slugger": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
@@ -13913,6 +15292,16 @@
       "requires": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
+      }
+    },
+    "global-cache": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/global-cache/-/global-cache-1.2.1.tgz",
+      "integrity": "sha512-EOeUaup5DgWKlCMhA9YFqNRIlZwoxt731jCh47WBV9fQqHgXhr3Fa55hfgIUqilIcPsfdNKN7LHjrNY+Km40KA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "is-symbol": "^1.0.1"
       }
     },
     "global-dirs": {
@@ -14045,7 +15434,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "optional": true,
       "requires": {
         "delegate": "^3.1.2"
       }
@@ -14054,6 +15442,12 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
+    },
+    "gradient-parser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
+      "integrity": "sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw=",
       "dev": true
     },
     "grapheme-splitter": {
@@ -14919,6 +16313,12 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "dev": true
+    },
+    "hpq": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
+      "integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA==",
       "dev": true
     },
     "hsl-regex": {
@@ -16082,6 +17482,12 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-touch-device": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
+      "integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw==",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -16150,6 +17556,28 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -16657,6 +18085,15 @@
         "object.map": "^1.0.0",
         "rechoir": "^0.6.2",
         "resolve": "^1.1.7"
+      }
+    },
+    "line-height": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
+      "integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
+      "dev": true,
+      "requires": {
+        "computed-style": "~0.1.3"
       }
     },
     "lines-and-columns": {
@@ -17411,6 +18848,12 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "memize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+      "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg==",
+      "dev": true
+    },
     "memoize-one": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
@@ -17898,6 +19341,21 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true
+    },
+    "moment-timezone": {
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "dev": true,
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
+    "mousetrap": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
       "dev": true
     },
     "move-concurrently": {
@@ -20426,6 +21884,17 @@
         "react-is": "^16.8.1"
       }
     },
+    "prop-types-exact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "reflect.ownkeys": "^0.2.0"
+      }
+    },
     "property-information": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
@@ -20790,6 +22259,15 @@
         }
       }
     },
+    "re-resizable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.4.0.tgz",
+      "integrity": "sha512-E8WOtM8RfcGv4kOdasdR10jw8IU45j5jVift/rSA6AZMnaBRxJdt6YAkPHFv/04vsMNNvNu3G8vlyNOsVwqPpA==",
+      "dev": true,
+      "requires": {
+        "fast-memoize": "^2.5.1"
+      }
+    },
     "react": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
@@ -20799,6 +22277,27 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-addons-shallow-compare": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz",
+      "integrity": "sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=",
+      "dev": true,
+      "requires": {
+        "fbjs": "^0.8.4",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "react-autosize-textarea": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.3.tgz",
+      "integrity": "sha512-iOSZK7RUuJ+iEwkJ9rqYciqtjQgrG1CCRFL6h8Bk61kODnRyEq4tS74IgXpI1t4S6jBBZVm+6ugaU+tWTlVxXg==",
+      "dev": true,
+      "requires": {
+        "autosize": "^4.0.0",
+        "line-height": "^0.3.1",
+        "prop-types": "^15.5.6"
       }
     },
     "react-clientside-effect": {
@@ -20822,6 +22321,27 @@
         "prop-types": "^15.5.10",
         "reactcss": "^1.2.0",
         "tinycolor2": "^1.4.1"
+      }
+    },
+    "react-dates": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-17.2.0.tgz",
+      "integrity": "sha512-RDlerU8DdRRrlYS0MQ7Z9igPWABGLDwz6+ykBNff67RM3Sset2TDqeuOr+R5o00Ggn5U47GeLsGcSDxlZd9cHw==",
+      "dev": true,
+      "requires": {
+        "airbnb-prop-types": "^2.10.0",
+        "consolidated-events": "^1.1.1 || ^2.0.0",
+        "is-touch-device": "^1.0.1",
+        "lodash": "^4.1.1",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.0.4",
+        "prop-types": "^15.6.1",
+        "react-addons-shallow-compare": "^15.6.2",
+        "react-moment-proptypes": "^1.6.0",
+        "react-outside-click-handler": "^1.2.0",
+        "react-portal": "^4.1.5",
+        "react-with-styles": "^3.2.0",
+        "react-with-styles-interface-css": "^4.0.2"
       }
     },
     "react-dev-utils": {
@@ -21237,6 +22757,38 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
     },
+    "react-moment-proptypes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.7.0.tgz",
+      "integrity": "sha512-ZbOn/P4u469WEGAw5hgkS/E+g1YZqdves2BjYsLluJobzUZCtManhjHiZKjniBVT7MSHM6D/iKtRVzlXVv3ikA==",
+      "dev": true,
+      "requires": {
+        "moment": ">=1.6.0"
+      }
+    },
+    "react-native-url-polyfill": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.1.2.tgz",
+      "integrity": "sha512-RPYwjW+4udnAf26xUCQP2dn4t2tnRFo3Ii4s/hy7Ivpe7xYtXp7CMVX505CR8X3p0f8NKmOJ4MQEFMMnbd/Y/Q==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.4.3",
+        "whatwg-url-without-unicode": "8.0.0-1"
+      }
+    },
+    "react-outside-click-handler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
+      "integrity": "sha512-Te/7zFU0oHpAnctl//pP3hEAeobfeHMyygHB8MnjP6sX5OR8KHT1G3jmLsV3U9RnIYo+Yn+peJYWu+D5tUS8qQ==",
+      "dev": true,
+      "requires": {
+        "airbnb-prop-types": "^2.15.0",
+        "consolidated-events": "^1.1.1 || ^2.0.0",
+        "document.contains": "^1.0.1",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-popper": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
@@ -21273,6 +22825,15 @@
         }
       }
     },
+    "react-portal": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
+      "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-redux": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.0.tgz",
@@ -21296,6 +22857,12 @@
           }
         }
       }
+    },
+    "react-resize-aware": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.0.1.tgz",
+      "integrity": "sha512-HdPzwdcAv+BMFQEgyacFB40G4IxNMO7tSqaMjbnAouot8LXi5/Rx3/Fv+LU2cQekqiivE1LF4sGnwQ7SnoHrpg==",
+      "dev": true
     },
     "react-select": {
       "version": "3.1.0",
@@ -21334,6 +22901,16 @@
         "invariant": "^2.2.4",
         "shallowequal": "^1.1.0",
         "throttle-debounce": "^2.1.0"
+      }
+    },
+    "react-spring": {
+      "version": "8.0.27",
+      "resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
+      "integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "prop-types": "^15.5.8"
       }
     },
     "react-syntax-highlighter": {
@@ -21380,6 +22957,58 @@
             "regenerator-runtime": "^0.13.4"
           }
         }
+      }
+    },
+    "react-use-gesture": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-7.0.15.tgz",
+      "integrity": "sha512-vHQkaa7oUbSDTAcFk9huQXa7E8KPrZH91erPuOMoqZT513qvtbb/SzTQ33lHc71/kOoJkMbzOkc4uoA4sT7Ogg==",
+      "dev": true
+    },
+    "react-with-direction": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.1.tgz",
+      "integrity": "sha512-aGcM21ZzhqeXFvDCfPj0rVNYuaVXfTz5D3Rbn0QMz/unZe+CCiLHthrjQWO7s6qdfXORgYFtmS7OVsRgSk5LXQ==",
+      "dev": true,
+      "requires": {
+        "airbnb-prop-types": "^2.10.0",
+        "brcast": "^2.0.2",
+        "deepmerge": "^1.5.2",
+        "direction": "^1.0.2",
+        "hoist-non-react-statics": "^3.3.0",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.0.4",
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.5.2.tgz",
+          "integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ==",
+          "dev": true
+        }
+      }
+    },
+    "react-with-styles": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
+      "integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
+      "dev": true,
+      "requires": {
+        "hoist-non-react-statics": "^3.2.1",
+        "object.assign": "^4.1.0",
+        "prop-types": "^15.6.2",
+        "react-with-direction": "^1.3.0"
+      }
+    },
+    "react-with-styles-interface-css": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz",
+      "integrity": "sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==",
+      "dev": true,
+      "requires": {
+        "array.prototype.flat": "^1.2.1",
+        "global-cache": "^1.2.1"
       }
     },
     "reactcss": {
@@ -21456,6 +23085,43 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "reakit": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.0.3.tgz",
+      "integrity": "sha512-EB5nuRVpT5d7h3WtfG0P6+rDNCaMvZWzrMhciIwcsza5NVcpEBrdGh4jCX+4QLv01G1KEH45vTopCbfbX5NShA==",
+      "dev": true,
+      "requires": {
+        "@popperjs/core": "^2.4.0",
+        "body-scroll-lock": "^3.0.2",
+        "reakit-system": "^0.12.2",
+        "reakit-utils": "^0.12.1",
+        "reakit-warning": "^0.3.1"
+      }
+    },
+    "reakit-system": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.12.2.tgz",
+      "integrity": "sha512-+/tZ/atDbHhDOapcIxniNZd7z0cze1L9MJBEnvykqM/bdqUE59Eb/OQ6odPZwK35gcN1lNyZtw7DgnFrmsDi4w==",
+      "dev": true,
+      "requires": {
+        "reakit-utils": "^0.12.1"
+      }
+    },
+    "reakit-utils": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.12.1.tgz",
+      "integrity": "sha512-P66TYzmQFD5CqNWcRvbPb6B5nXRLfiWqwTJhVGDUeOJTSdlnjfsBuOIauojfuS+p4yeyFVsUFsFwuBM6uZ8F3A==",
+      "dev": true
+    },
+    "reakit-warning": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.3.1.tgz",
+      "integrity": "sha512-kFGASQG1ogpyknF0vlfab2emptCuW4a2Ku0SOeNkD+WGkMytJMNqrklqqfuWFEPqpuWGkBduOLbmEEyVLgSLZg==",
+      "dev": true,
+      "requires": {
+        "reakit-utils": "^0.12.1"
       }
     },
     "realpath-native": {
@@ -21546,6 +23212,24 @@
         "symbol-observable": "^1.2.0"
       }
     },
+    "redux-multi": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/redux-multi/-/redux-multi-0.1.12.tgz",
+      "integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI=",
+      "dev": true
+    },
+    "redux-optimist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redux-optimist/-/redux-optimist-1.0.0.tgz",
+      "integrity": "sha512-AG1v8o6UZcGXTEH2jVcWG6KD+gEix+Cj9JXAAzln9MPkauSVd98H7N7EOOyT/v4c9N1mJB4sm1zfspGlLDkUEw==",
+      "dev": true
+    },
+    "reflect.ownkeys": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "dev": true
+    },
     "reflexbox": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/reflexbox/-/reflexbox-4.0.6.tgz",
@@ -21581,6 +23265,12 @@
           }
         }
       }
+    },
+    "refx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/refx/-/refx-3.1.1.tgz",
+      "integrity": "sha512-lwN27W5iYyagpCxxYDYDl0IIiKh0Vgi3wvafqfthbzTfBgLOYAstcftp+G2X612xVaB8rhn5wDxd4er4KEeb8A==",
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",
@@ -22237,6 +23927,12 @@
         "autolinker": "~0.28.0"
       }
     },
+    "rememo": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-3.0.0.tgz",
+      "integrity": "sha512-eWtut/7pqMRnSccbexb647iPjN7ir6Tmf4RG92ZVlykFEkHqGYy9tWnpHH3I+FS+WQ6lQ1i1iDgarYzGKgTcRQ==",
+      "dev": true
+    },
     "remove-bom-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
@@ -22626,6 +24322,12 @@
       "integrity": "sha512-K6p9y4ZyL9wPzA+PMDloNQPfoDGTiFYDvdlXznyGKgD10BJpcAosvATKrExRKOrNLgD8E7Um7WGW0lxsnOuNLg==",
       "dev": true
     },
+    "rungen": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+      "integrity": "sha1-QAwJ6+kU57F+C27zJjQA/Cq8fLM=",
+      "dev": true
+    },
     "rxjs": {
       "version": "6.5.5",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
@@ -22955,8 +24657,7 @@
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "self-closing-tags": {
       "version": "1.0.1",
@@ -23211,6 +24912,155 @@
         }
       }
     },
+    "showdown": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+      "dev": true,
+      "requires": {
+        "yargs": "^14.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "side-channel": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
@@ -23225,6 +25075,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "simple-html-tokenizer": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.9.tgz",
+      "integrity": "sha512-w/3FEDN94r4JQ9WoYrIr8RqDIPZdyNkdpbK9glFady1CAEyD97XWCv8HFetQO21w81e7h7Nh59iYTyG1mUJftg==",
       "dev": true
     },
     "simple-swizzle": {
@@ -25384,6 +27240,15 @@
         }
       }
     },
+    "tannin": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tannin/-/tannin-1.2.0.tgz",
+      "integrity": "sha512-U7GgX/RcSeUETbV7gYgoz8PD7Ni4y95pgIP/Z6ayI3CfhSujwKEBlGFTCRN+Aqnuyf4AN2yHL+L8x+TCGjb9uA==",
+      "dev": true,
+      "requires": {
+        "@tannin/plural-forms": "^1.1.0"
+      }
+    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -25965,8 +27830,7 @@
     "tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-glob": {
       "version": "0.2.6",
@@ -26136,6 +28000,12 @@
           "dev": true
         }
       }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
     },
     "trim": {
       "version": "0.0.1",
@@ -26412,6 +28282,12 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "turbo-combine-reducers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
+      "integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw==",
+      "dev": true
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -26626,6 +28502,12 @@
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
       "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
       "dev": true
     },
     "uglify-js": {
@@ -27120,6 +29002,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.3.tgz",
       "integrity": "sha512-DPBPh1i2adCZoIArRlTuKRy7yue7QogtEnfv0AKrWsY+GA+4EKe37zhRDouNnyWMoNQFYZZRF+2dLHsWE4YvJA==",
+      "dev": true
+    },
+    "use-memo-one": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
+      "integrity": "sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==",
       "dev": true
     },
     "use-sidecar": {
@@ -27628,6 +29516,12 @@
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
       "dev": true
     },
+    "webidl-conversions": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "dev": true
+    },
     "webpack": {
       "version": "4.43.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.43.0.tgz",
@@ -27807,6 +29701,21 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
+    },
+    "whatwg-url-without-unicode": {
+      "version": "8.0.0-1",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-1.tgz",
+      "integrity": "sha512-0Uy8mjsG5O8Y53327XL+ZqsrMdxO1CL/6m840SmW5iyRWFvU2zlxS2RzpD3pFFVKYOKCmsKn5JKzWxQ+bImnWA==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@typescript-eslint/eslint-plugin": "3.1.0",
     "@typescript-eslint/parser": "3.1.0",
     "@whitespace/storybook-addon-html": "1.2.1",
+    "@wordpress/block-library": "^2.19.0",
     "babel-loader": "8.1.0",
     "browserify-transform-tools": "1.7.0",
     "css-loader": "3.5.3",

--- a/src/vendor/wordpress/gutenberg.stories.mdx
+++ b/src/vendor/wordpress/gutenberg.stories.mdx
@@ -1,5 +1,6 @@
 import { Story, Preview, Meta } from '@storybook/addon-docs/blocks';
 import codeBlockDemo from '../../design/typography/demo/code-block.twig';
+import '@wordpress/block-library/build-style/style.css';
 
 <Meta title="Vendor/WordPress/Gutenberg" />
 


### PR DESCRIPTION
## Overview

So far, we have not been including the WordPress default styles for Gutenberg block elements in Storybook. This PR imports the missing stylesheet into our Gutenberg story documentation. 

## Screenshots

Observe the before and after presentation of various block elements

**Before:** 
![Screen Shot 2020-06-04 at 11 43 25 AM](https://user-images.githubusercontent.com/1427548/83818549-7e19d880-a67c-11ea-9237-322e1be01286.png)

**After:** 
![Screen Shot 2020-06-04 at 3 45 04 PM](https://user-images.githubusercontent.com/1427548/83818559-870aaa00-a67c-11ea-81a0-4ccb233da284.png)

**Before:**
![Screen Shot 2020-06-04 at 3 48 35 PM](https://user-images.githubusercontent.com/1427548/83818568-8d992180-a67c-11ea-806e-525bfd5ddbf8.png)

**After:** 
![Screen Shot 2020-06-04 at 3 45 18 PM](https://user-images.githubusercontent.com/1427548/83818578-92f66c00-a67c-11ea-8aa6-42a0adb1df8d.png)

## Notes

After installing `@wordpress/block-library` via NPM I observed these security audits in my terminal:

![Screen Shot 2020-06-04 at 3 39 37 PM](https://user-images.githubusercontent.com/1427548/83818999-95a59100-a67d-11ea-86d8-c3b17c24d3ed.png)

I assumed the Renovate bot would address these so no action was taken in this PR. 

## Testing

1. Compare the Gutenberg stories in the [master branch](https://v-next--cloudfour-patterns.netlify.app/?path=/docs/vendor-wordpress-gutenberg--core-audio) to the same blocks in the [deploy preview](https://deploy-preview-778--cloudfour-patterns.netlify.app/) for this PR. 

---

See: https://developer.wordpress.org/block-editor/packages/packages-block-library/
See: #710