### PR TITLE
Add Theo support to Rollup configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
       "rules": {
         "@typescript-eslint/explicit-module-boundary-types": "off", // inference is usually useful, even for module boundaries
         "@typescript-eslint/no-unused-vars": "off", // TypeScript itself checks this via the "noUnusedLocals"/"noUnusedParameters" options
+        "@typescript-eslint/no-unsafe-member-access": "off", // Makes importing from Theo token files troublesome
         "@typescript-eslint/ban-ts-comment": [
           "error",
           { "ts-expect-error": false }

--- a/.theo/formats/stories.mdx.js
+++ b/.theo/formats/stories.mdx.js
@@ -1,4 +1,5 @@
 const groupBy = require('lodash/groupBy');
+const camelCase = require('lodash/camelCase');
 const kebabCase = require('lodash/kebabCase');
 const startCase = require('lodash/startCase');
 const { basename, extname } = require('path');
@@ -129,6 +130,9 @@ function mdxStoriesFormat(result) {
   const slug = basename(filename, extname(filename));
   const title = startCase(slug);
   const props = result.get('props').toJS();
+  const firstProp = props[0];
+  const firstNameSass = kebabCase(firstProp.name);
+  const firstNameJs = camelCase(firstProp.name);
   const categories = groupBy(props, 'category');
   const mdxCategories = Object.keys(categories).map((category) =>
     categoryToMdx(category, categories[category])
@@ -142,7 +146,12 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/addon-docs/blocks';
 
 \`\`\`scss
 @use 'path/to/${filename}';
-$example: ${slug}.$${kebabCase(props[0].name)}; // => ${props[0].value}
+$example: ${slug}.$${firstNameSass}; // => ${firstProp.value}
+\`\`\`
+
+\`\`\`javascript
+import { ${firstNameJs} } from 'path/to/${filename}';
+console.log(${firstNameJs}); // => ${firstProp.value}
 \`\`\`
 
 ${mdxCategories.join('\n\n')}`.trim();

--- a/.theo/formats/stories.mdx.js
+++ b/.theo/formats/stories.mdx.js
@@ -128,6 +128,7 @@ function mdxStoriesFormat(result) {
   const file = result.getIn(['meta', 'file']);
   const filename = basename(file);
   const slug = basename(filename, extname(filename));
+  const objectName = camelCase(slug);
   const title = startCase(slug);
   const props = result.get('props').toJS();
   const firstProp = props[0];
@@ -150,8 +151,10 @@ $example: ${slug}.$${firstNameSass}; // => ${firstProp.value}
 \`\`\`
 
 \`\`\`javascript
-import { ${firstNameJs} } from 'path/to/${filename}';
-console.log(${firstNameJs}); // => ${firstProp.value}
+import * as ${objectName} from 'path/to/${filename}';
+console.log(${objectName}.${firstNameJs}); // => ${JSON.stringify(
+    firstProp.value
+  )}
 \`\`\`
 
 ${mdxCategories.join('\n\n')}`.trim();

--- a/.theo/rollup-plugin.js
+++ b/.theo/rollup-plugin.js
@@ -1,0 +1,44 @@
+const theo = require('.');
+const ext = /\.ya?ml$/;
+
+/**
+ * Rollup plugin that lets you import Theo design token files in YAML format as
+ * ES6 modules in Theo's `module.js` format.
+ *
+ * @returns {function}
+ * @see https://github.com/salesforce-ux/theo#modulejs
+ * @see https://rollupjs.org/guide/en/#transformers
+ * @see https://github.com/rollup/plugins/blob/master/packages/yaml/src/index.js
+ */
+
+function theoPlugin() {
+  return {
+    name: 'theo',
+    async transform(_content, id) {
+      // Only transform YAML files. If this were a separate plugin, we could
+      // do one better by using the createFilter function from
+      // `@rollup/pluginutils`, but that adds some heavy install time, so it
+      // seemed unnecessary.
+      if (!ext.test(id)) return null;
+
+      // Asynchronously convert the Theo file to the desired format.
+      // Unfortunately we can't just pass in content from Rollup: Theo couldn't
+      // import other files in that case.
+      const code = await theo.convert({
+        transform: {
+          file: id,
+        },
+        format: {
+          type: 'module.js',
+        },
+      });
+
+      return {
+        code,
+        map: { mappings: '' }, // Theo doesn't have source maps
+      };
+    },
+  };
+}
+
+module.exports = { theoPlugin };

--- a/gulpfile.js/tasks/build-scripts.js
+++ b/gulpfile.js/tasks/build-scripts.js
@@ -3,6 +3,7 @@ const path = require('path');
 const nodeResolve = require('@rollup/plugin-node-resolve').default;
 const { terser } = require('rollup-plugin-terser');
 const { getBabelInputPlugin } = require('@rollup/plugin-babel');
+const { theoPlugin } = require('../../.theo/rollup-plugin');
 const fs = require('fs').promises;
 const tsGenerator = require('dts-bundle-generator');
 const glob = require('tiny-glob');
@@ -50,6 +51,7 @@ const buildJS = async () => {
       virtualRootPlugin(),
       getBabelInputPlugin({ extensions, babelHelpers: 'bundled' }),
       nodeResolve({ extensions }),
+      theoPlugin(),
     ],
   });
   await Promise.all([

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,3 +2,9 @@ declare module '*.twig' {
   function template(opts: Record<string, unknown>): string;
   export default template;
 }
+
+declare module '*.yml' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const tokens: Record<string, any>;
+  export = tokens;
+}


### PR DESCRIPTION
## Overview

Adds support for importing tokens from Theo configuration files in YAML format. (There is [a Rollup plugin for Theo](https://www.npmjs.com/package/rollup-plugin-theo), but it appears to only transform to CSS.)

Tokens use [the `module.js` format](https://github.com/salesforce-ux/theo#modulejs), which converts tokens into ES exports.

So given a token file like this:

```yaml
aliases:
  black_transparent_85: 'rgba(0, 0, 0, 0.85)'
props:
  - name: text_dark
    value: '{!black_transparent_85}'
    category: text-color
    comment: Accessible on white and lightest gray.
```

And JavaScript source like this:

```js
import * as colors from 'path/to/design-tokens/colors.yml';

console.log(colors.textDark);
```

The compiled JavaScript will look like this:

```js
/* Accessible on white and lightest gray. */
const textDark = "rgba(0, 0, 0, 0.85)";

console.log(textDark);
```

This also adds usage examples in JavaScript to the design token pages.

## Screenshots

<img width="1066" alt="Screen Shot 2020-06-10 at 12 11 35 PM" src="https://user-images.githubusercontent.com/69633/84308543-8dcd6d00-ab13-11ea-9208-f256e250e33e.png">

## Testing

1. Check out branch locally.
1. Attempt to import a design token of your choosing using one of those documented in Storybook. (To avoid having to create a new file, try adding it to the Elastic Textarea script.)
1. Run `npm run build`
1. See if the token made it to `dist/cloudfour-patterns.js`.

---

- Resolves #787
