### PR TITLE
Ignore /ts-dist folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 /dist
+/ts-dist
 /src/design-tokens/generated
 /storybook-static
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 /dist
+/ts-dist
 /src/design-tokens/generated
 /storybook-static
 


### PR DESCRIPTION
## Overview

This commit adds `/ts-dist` to both the Prettier and ESLint ignore lists, to avoid lint failures for generated files.

## Testing

1. run `npm run type` (to generate the `ts-dist` folder)
1. run `npm run check-lint`

There should be no lint failures.