### PR TITLE
Chore: improve default Gutenberg embed block presentation

### DIFF
--- a/.changeset/itchy-clouds-fold.md
+++ b/.changeset/itchy-clouds-fold.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Updates object mixin and improves default Gutenberg embed block presentation

--- a/src/design-tokens/sizes.yml
+++ b/src/design-tokens/sizes.yml
@@ -112,4 +112,3 @@ props:
     value: 3
     type: modular/em
     category: spacing
-

--- a/src/design-tokens/sizes.yml
+++ b/src/design-tokens/sizes.yml
@@ -100,3 +100,16 @@ props:
     value: 3
     type: modular/em
     category: rhythm
+  - name: spacing_horizontal_condensed
+    value: -1
+    type: modular/em
+    category: spacing
+  - name: spacing_horizontal
+    value: 1
+    type: modular/em
+    category: spacing
+  - name: spacing_horizontal_generous
+    value: 3
+    type: modular/em
+    category: spacing
+

--- a/src/mixins/_embed.scss
+++ b/src/mixins/_embed.scss
@@ -84,20 +84,28 @@ $default-aspect-ratio: aspect-ratio.$square;
   }
 }
 
-@mixin object {
+/**
+ * We declare a "default value" for our mixin's `$aspect-ratio` argument so
+ * it may be used (as expected) without passing any arguments. This allows us
+ * to override the "default" aspect ratio for use cases like WordPress
+ * Gutenberg blocks, where it may be more desirable to redefine the default
+ * aspect-ratio instead of adding additional modifier classes
+ */
+
+@mixin object($aspect-ratio:#{$default-aspect-ratio}) {
   @supports (--custom: property) {
     /**
-   * Here's where the magic happens! 🦄
-   *
-   * 1. We default to a square aspect ratio. This is suitable for icons, profile
-   *    images, etc. It's also the simplest default.
-   * 2. Required for rounded corners to work as expected. We could apply this
-   *    by default, but then circular rounding would appear elliptical in older
-   *    browsers.
-   * 3. Required to absolute-position child elements.
-   */
+     * Here's where the magic happens! 🦄
+     *
+     * 1. We default to a square aspect ratio. This is suitable for icons,
+     *    profile images, etc. It's also the simplest default.
+     * 2. Required for rounded corners to work as expected. We could apply this
+     *    by default, but then circular rounding would appear elliptical in
+     *    older browsers.
+     * 3. Required to absolute-position child elements.
+    */
 
-    --aspect-ratio: #{$default-aspect-ratio}; /* 1 */
+    --aspect-ratio: #{$aspect-ratio}; /* 1 */
     overflow: hidden; /* 2 */
     position: relative; /* 3 */
 

--- a/src/mixins/_embed.scss
+++ b/src/mixins/_embed.scss
@@ -85,14 +85,14 @@ $default-aspect-ratio: aspect-ratio.$square;
 }
 
 /**
- * We declare a "default value" for our mixin's `$aspect-ratio` argument so
+ * We declare a "default value" for our mixin's `$ratio` argument so
  * it may be used (as expected) without passing any arguments. This allows us
- * to override the "default" aspect ratio for use cases like WordPress
+ * to override the "default" aspect ratio for use cases such as WordPress
  * Gutenberg blocks, where it may be more desirable to redefine the default
- * aspect-ratio instead of adding additional modifier classes
+ * aspect-ratio instead of adding additional modifier classes.
  */
 
-@mixin object($aspect-ratio:#{$default-aspect-ratio}) {
+@mixin object($ratio:#{$default-aspect-ratio}) {
   @supports (--custom: property) {
     /**
      * Here's where the magic happens! 🦄
@@ -105,7 +105,7 @@ $default-aspect-ratio: aspect-ratio.$square;
      * 3. Required to absolute-position child elements.
     */
 
-    --aspect-ratio: #{$aspect-ratio}; /* 1 */
+    --aspect-ratio: #{$ratio}; /* 1 */
     overflow: hidden; /* 2 */
     position: relative; /* 3 */
 

--- a/src/mixins/_embed.scss
+++ b/src/mixins/_embed.scss
@@ -88,7 +88,7 @@ $default-aspect-ratio: aspect-ratio.$square;
  * We declare a "default value" for our mixin's `$ratio` argument so
  * it may be used without passing any arguments. This allows us
  * to override the "default" aspect ratio for use cases such as WordPress
- * Gutenberg blocks, where it may be more desirable to redefine the default
+ * Gutenberg blocks, where it may be more desirable to re-define the default
  * aspect-ratio instead of adding additional modifier classes.
  */
 

--- a/src/mixins/_embed.scss
+++ b/src/mixins/_embed.scss
@@ -86,7 +86,7 @@ $default-aspect-ratio: aspect-ratio.$square;
 
 /**
  * We declare a "default value" for our mixin's `$ratio` argument so
- * it may be used (as expected) without passing any arguments. This allows us
+ * it may be used without passing any arguments. This allows us
  * to override the "default" aspect ratio for use cases such as WordPress
  * Gutenberg blocks, where it may be more desirable to redefine the default
  * aspect-ratio instead of adding additional modifier classes.

--- a/src/mixins/_embed.scss
+++ b/src/mixins/_embed.scss
@@ -92,7 +92,7 @@ $default-aspect-ratio: aspect-ratio.$square;
  * aspect-ratio instead of adding additional modifier classes.
  */
 
-@mixin object($ratio:#{$default-aspect-ratio}) {
+@mixin object($ratio: #{$default-aspect-ratio}) {
   @supports (--custom: property) {
     /**
      * Here's where the magic happens! 🦄

--- a/src/mixins/_layout.scss
+++ b/src/mixins/_layout.scss
@@ -1,0 +1,9 @@
+/**
+ * Enables an element to extend the full width of the available viewport by of
+ * releasing a child element from its fixed-width container
+ */
+
+@mixin fullwidth {
+  margin-left: calc(-50vw + 50%);
+  margin-right: calc(-50vw + 50%);
+}

--- a/src/mixins/_layout.scss
+++ b/src/mixins/_layout.scss
@@ -1,5 +1,5 @@
 /**
- * Enables an element to extend the full width of the available viewport by of
+ * Enables an element to extend the full width of the available viewport by
  * releasing a child element from its fixed-width container
  */
 

--- a/src/mixins/_layout.scss
+++ b/src/mixins/_layout.scss
@@ -1,6 +1,6 @@
 /**
  * Enables an element to extend the full width of the available viewport by
- * releasing a child element from its fixed-width container
+ * releasing a child element from its fixed-width container.
  */
 
 @mixin fullwidth {

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -7,6 +7,32 @@
 @use "../../mixins/table";
 
 /**
+ * Custom alignment styles for Gutenberg blocks
+ */
+
+@mixin fullwidth {
+  margin-left: calc(-50vw + 50%);
+  margin-right: calc(-50vw + 50%);
+}
+
+.alignfull {
+  @include fullwidth;
+}
+
+/**
+ * 1. Applies an opinionated wide-image width that allows an image element to
+ *    spill slightly outsides its container at larger viewports.
+ */
+
+.alignwide {
+  @include fullwidth;
+  @media (min-width: breakpoint.$l) {
+    margin-left: -6vw; /* 1 */
+    margin-right: -6vw; /* 1 */
+  }
+}
+
+/**
  * Gutenberg block: Button
  * Applies our pattern library styles to buttons generated via Gutenberg blocks.
  */
@@ -63,35 +89,17 @@ $wp-button-gap: sizes.$list-inline-gap;
  */
 
 .wp-block-embed {
-
+  // @todo use design token values instead of `1em`
   &.alignleft {
     float: left;
     margin-right: 1em;
   }
 
   &.alignright {
+    // @todo use design token values instead of `1em`
     float: right;
     margin-left: 1em;
   }
-
-  &.alignfull {
-    margin-left: calc(-50vw + 50%);
-    margin-right: calc(-50vw + 50%);
-  }
-
-  /*
-   * 1. Applies an opinionated wide-image width that allows an image element to
-   *    spill slightly outsides its container at larger viewports.
-   */
-  &.alignwide {
-    margin-left: calc(-50vw + 50%);
-    margin-right: calc(-50vw + 50%);
-    @media (min-width: breakpoint.$l) {
-      margin-left: -6vw; /* 1 */
-      margin-right: -6vw; /* 1 */
-    }
-  }
-
 }
 
 .wp-block-embed__wrapper {
@@ -168,28 +176,6 @@ $wp-button-gap: sizes.$list-inline-gap;
    */
   &.aligncenter {
     width: 100%;
-  }
-
-  /**
-   * Releases a full-width child element from its limited width container
-   * @see https://cloudfour.com/thinks/breaking-out-with-viewport-units-and-calc/#flipping-the-script
-   */
-  &.alignfull {
-    margin-left: calc(-50vw + 50%);
-    margin-right: calc(-50vw + 50%);
-  }
-
-  /*
-   * 1. Applies an opinionated wide-image width that allows an image element to
-   *    spill slightly outsides its container at larger viewports.
-   */
-  &.alignwide {
-    margin-left: calc(-50vw + 50%);
-    margin-right: calc(-50vw + 50%);
-    @media (min-width: breakpoint.$l) {
-      margin-left: -6vw; /* 1 */
-      margin-right: -6vw; /* 1 */
-    }
   }
 
   /* Since we are applying `margin-top` to CMS content via our o-rhythm

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -62,6 +62,38 @@ $wp-button-gap: sizes.$list-inline-gap;
  * Applies our pattern library styles to gutenberg embeded blocks
  */
 
+.wp-block-embed {
+
+  &.alignleft {
+    float: left;
+    margin-right: 1em;
+  }
+
+  &.alignright {
+    float: right;
+    margin-left: 1em;
+  }
+
+  &.alignfull {
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+  }
+
+  /*
+   * 1. Applies an opinionated wide-image width that allows an image element to
+   *    spill slightly outsides its container at larger viewports.
+   */
+  &.alignwide {
+    margin-left: calc(-50vw + 50%);
+    margin-right: calc(-50vw + 50%);
+    @media (min-width: breakpoint.$l) {
+      margin-left: -6vw; /* 1 */
+      margin-right: -6vw; /* 1 */
+    }
+  }
+
+}
+
 .wp-block-embed__wrapper {
   @include embed.object-fallback;
   @include embed.object(aspect-ratio.$wide);

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -90,7 +90,6 @@ $wp-button-gap: sizes.$list-inline-gap;
  */
 
 .wp-block-embed {
-
   &.o-embed--square .wp-block-embed__wrapper {
     --aspect-ratio: #{aspect-ratio.$square};
   }

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -99,12 +99,12 @@ $wp-button-gap: sizes.$list-inline-gap;
 
   &.alignleft {
     float: left;
-    margin-right: #{sizes.$rhythm-space};
+    margin-right: #{sizes.$spacing-horizontal};
   }
 
   &.alignright {
     float: right;
-    margin-left: #{sizes.$rhythm-space};
+    margin-left: #{sizes.$spacing-horizontal};
   }
 }
 

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -1,4 +1,3 @@
-@use 'sass:meta';
 @use "../../design-tokens/aspect-ratio.yml";
 @use "../../design-tokens/breakpoint.yml";
 @use "../../design-tokens/colors.yml";

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -1,7 +1,9 @@
+@use '../../design-tokens/aspect-ratio.yml';
 @use "../../design-tokens/breakpoint.yml";
 @use "../../design-tokens/colors.yml";
 @use "../../design-tokens/sizes.yml";
 @use "../../mixins/button";
+@use '../../mixins/embed';
 @use "../../mixins/table";
 
 /**
@@ -53,6 +55,16 @@ $wp-button-gap: sizes.$list-inline-gap;
   &.is-style-outline .wp-block-button__link {
     @include button.secondary;
   }
+}
+
+/**
+ * Gutenberg block: Embed
+ * Applies our pattern library styles to gutenberg embeded blocks
+ */
+
+.wp-block-embed__wrapper {
+  @include embed.object-fallback;
+  @include embed.object(aspect-ratio.$wide);
 }
 
 /**

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -1,4 +1,5 @@
-@use '../../design-tokens/aspect-ratio.yml';
+@use 'sass:meta';
+@use "../../design-tokens/aspect-ratio.yml";
 @use "../../design-tokens/breakpoint.yml";
 @use "../../design-tokens/colors.yml";
 @use "../../design-tokens/sizes.yml";
@@ -89,16 +90,27 @@ $wp-button-gap: sizes.$list-inline-gap;
  */
 
 .wp-block-embed {
-  // @todo use design token values instead of `1em`
+
+  &.o-embed--square .wp-block-embed__wrapper {
+    --aspect-ratio: #{aspect-ratio.$square};
+  }
+
+  &.o-embed--full .wp-block-embed__wrapper {
+    --aspect-ratio: #{aspect-ratio.$full};
+  }
+
+  &.o-embed--cinema .wp-block-embed__wrapper {
+    --aspect-ratio: #{aspect-ratio.$cinema};
+  }
+
   &.alignleft {
     float: left;
-    margin-right: 1em;
+    margin-right: #{sizes.$rhythm-space};
   }
 
   &.alignright {
-    // @todo use design token values instead of `1em`
     float: right;
-    margin-left: 1em;
+    margin-left: #{sizes.$rhythm-space};
   }
 }
 

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -2,6 +2,7 @@
 @use "../../design-tokens/breakpoint.yml";
 @use "../../design-tokens/colors.yml";
 @use "../../design-tokens/sizes.yml";
+@use "../../mixins/layout";
 @use "../../mixins/button";
 @use '../../mixins/embed';
 @use "../../mixins/table";
@@ -10,13 +11,8 @@
  * Custom alignment styles for Gutenberg blocks
  */
 
-@mixin fullwidth {
-  margin-left: calc(-50vw + 50%);
-  margin-right: calc(-50vw + 50%);
-}
-
 .alignfull {
-  @include fullwidth;
+  @include layout.fullwidth;
 }
 
 /**
@@ -25,7 +21,7 @@
  */
 
 .alignwide {
-  @include fullwidth;
+  @include layout.fullwidth;
   @media (min-width: breakpoint.$l) {
     margin-left: -6vw; /* 1 */
     margin-right: -6vw; /* 1 */


### PR DESCRIPTION
## Overview

This pull requests attempts to address the final incomplete task identified in #710. 

- Modifies embed `object` mixin introduced in #754 in order to optimize baseline styles for gutenberg embed blocks
- "Refactors" `alignfull` and `alignwide` classes introduced in #802 to account for gutenberg blocks other than images
- Ensures embed blocks are capable of being styled with WordPress `alignleft`, `aligncenter`, `alignright`, `alignfull`, and `alignwide` classes
- Configures blocks to respect `aspect-ratio` values established from token values by allowing block to accepts additional classes to be added to the embed block (`o-embed--square`, `o-embed--full,` `o-embed-cinema`). 

## Screenshots

Storybook Gutenberg embed example before changes: 

<img width="1031" alt="Screen Shot 2020-08-18 at 2 48 36 PM" src="https://user-images.githubusercontent.com/1427548/90569049-00854500-e162-11ea-8a63-bf2c83b1bcc3.png">

Storybook Gutenberg embed example after changes: 

<img width="1928" alt="Screen Shot 2020-08-18 at 11 52 28 AM" src="https://user-images.githubusercontent.com/1427548/90569149-29a5d580-e162-11ea-9b13-dd4d0973d8fc.png">

Example of youtube and codepen embeds in post preview:

<img width="864" alt="Screen Shot 2020-08-18 at 12 00 05 PM" src="https://user-images.githubusercontent.com/1427548/90569254-5fe35500-e162-11ea-9fab-b354904fc6ae.png">

Embed with `alignwide`:

<img width="1777" alt="Screen Shot 2020-08-18 at 12 36 19 PM" src="https://user-images.githubusercontent.com/1427548/90569438-bf416500-e162-11ea-9254-7626216cc0d8.png">

Embed with `alignfull`:

<img width="1122" alt="Screen Shot 2020-08-18 at 12 20 53 PM" src="https://user-images.githubusercontent.com/1427548/90569576-fa439880-e162-11ea-9aef-ebe68f75f8d4.png">

Embed with `alignleft` and `alignright`:

<img width="811" alt="Screen Shot 2020-08-18 at 3 03 29 PM" src="https://user-images.githubusercontent.com/1427548/90570185-0d0a9d00-e164-11ea-8cea-65a271daae54.png">

Test to ensure toggling `aligncenter` (and other alignment classes) don't cause inconsistent shifts in whitespace:

![embed-aligncenter-whitespace](https://user-images.githubusercontent.com/1427548/90569795-55758b00-e163-11ea-995a-d4fe20d88ec3.gif)

Compatible with `o-embed--square`:

<img width="2549" alt="--square" src="https://user-images.githubusercontent.com/1427548/90573598-a7221380-e16b-11ea-9e16-7789b046df5a.png">

Compatible with `o-embed--full`:
<img width="2553" alt="--full" src="https://user-images.githubusercontent.com/1427548/90573608-ac7f5e00-e16b-11ea-8f24-a635f6123957.png">

Compatible with `o-embed--cinema`:
<img width="2425" alt="--cinema" src="https://user-images.githubusercontent.com/1427548/90573658-c91b9600-e16b-11ea-9255-41e77700303b.png">




## Testing

1. View [deploy preview](https://deploy-preview-909--cloudfour-patterns.netlify.app/)
1. Confirm that [non WordPress embed examples](https://deploy-preview-909--cloudfour-patterns.netlify.app/?path=/docs/objects-embed--image#embed) are unchanged
1. Confirm that the WordPress Gutenberg embed example has an aspect ratio of `1.7777777778`
1. Provide design feedback and code review
 


---

See #710 
