### PR TITLE
Change renovate to not create PR's until after stabilityDays

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,6 @@
   "prConcurrentLimit": 5,
   "schedule": ["before 9am on monday"],
   "stabilityDays": 3,
+  "prCreation": "not-pending",
   "dependencyDashboard": true
 }


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days

I didn't realize this setting was necessary. If this setting had been set, [this PR](https://github.com/cloudfour/cloudfour.com-patterns/pull/964) wouldn't have been opened yet.