### PR TITLE
Only use svgr in specific contexts

### DIFF
--- a/.changeset/cuddly-kids-taste.md
+++ b/.changeset/cuddly-kids-taste.md
@@ -1,5 +1,0 @@
----
-'@cloudfour/patterns': patch
----
-
-Fix for issues related to SVG loading

--- a/.changeset/cuddly-kids-taste.md
+++ b/.changeset/cuddly-kids-taste.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix for issues related to SVG loading

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -22,14 +22,6 @@ module.exports = {
   ],
   webpackFinal: async (config) => {
     const isDev = config.mode === 'development';
-    // Remove default SVG processing from default config.
-    // @see https://github.com/storybookjs/storybook/issues/5708#issuecomment-515384927
-    config.module.rules = config.module.rules.map((rule) => {
-      if (/svg\|/.test(String(rule.test))) {
-        rule.test = /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/;
-      }
-      return rule;
-    });
 
     /**
      * For development, leave the default 'cheap-module-source-map', as it's faster and works.
@@ -91,23 +83,6 @@ module.exports = {
         // Import Theo design tokens as JS objects
         test: /\.ya?ml$/,
         use: resolve(__dirname, '../.theo/webpack-loader.js'),
-      },
-      {
-        // Optimize and process SVGs as React elements for use in documentation
-        test: /\.svg$/,
-        issuer: {
-          // If we do `url('___.svg')` in a CSS file, we don't want a react component to get inlined
-          exclude: [/.css$/, /.scss$/],
-        },
-        use: '@svgr/webpack',
-      },
-      {
-        test: /\.svg$/,
-        issuer: {
-          // If we do `url('___.svg')` in a CSS file, we don't want a react component to get inlined
-          include: [/.css$/, /.scss$/],
-        },
-        use: 'file-loader',
       }
     );
 

--- a/src/design/icons/icons.stories.mdx
+++ b/src/design/icons/icons.stories.mdx
@@ -2,7 +2,11 @@ import { Meta, IconGallery, IconItem } from '@storybook/addon-docs/blocks';
 import { extname, relative } from 'path';
 // Import whole directory of icons together
 // @see https://webpack.js.org/guides/dependency-management/#context-module-api
-const iconDir = require.context('../../assets/icons', false, /\.svg$/);
+const iconDir = require.context(
+  '!!@svgr/webpack!../../assets/icons',
+  false,
+  /\.svg$/
+);
 const iconElements = iconDir.keys().map((key) => {
   const Icon = iconDir(key).default;
   // Retains subdirectory if we want to organize with those in the future
@@ -14,7 +18,7 @@ const iconElements = iconDir.keys().map((key) => {
   );
 });
 const brandIconDir = require.context(
-  '../../assets/icons/brands',
+  '!!@svgr/webpack!../../assets/icons/brands',
   true,
   /\.svg$/
 );

--- a/src/design/icons/icons.stories.mdx
+++ b/src/design/icons/icons.stories.mdx
@@ -1,7 +1,10 @@
 import { Meta, IconGallery, IconItem } from '@storybook/addon-docs/blocks';
 import { extname, relative } from 'path';
 // Import whole directory of icons together
+// Using inline loaders to confine SVG to React transform to this doc
 // @see https://webpack.js.org/guides/dependency-management/#context-module-api
+// @see https://webpack.js.org/concepts/loaders/#configuration
+// @see https://react-svgr.com/docs/webpack/
 const iconDir = require.context(
   '!!@svgr/webpack!../../assets/icons',
   false,


### PR DESCRIPTION
## Overview

I started making an unrelated change to a pattern, but on every save I saw errors about SVG loading in the Terminal. These appear to be uncaught issues with changes from #862, which caused the icon listing to fail (which explains its disappearance from [our deploy](https://v-next--cloudfour-patterns.netlify.app/)).

I tried a few different solutions, but there were three points of Webpack configuration around `.svg` files and whenever I fixed _one_ a different one would have issues.

I looked back at the history of _why_ there was so much SVG configuration, and realized it was all due to #503, specifically the need to convert SVG files to React components for the sole purpose of documentation.

Since that's the _only_ context where we'd want to do that, I decided to use inline loaders within that file instead. While that's not a great practice for an entire project, it keeps this complexity confined to the single file that needs it. 

## Screenshots

<img width="1467" alt="Screen Shot 2020-10-23 at 10 54 52 AM" src="https://user-images.githubusercontent.com/69633/97037491-33f79d80-151e-11eb-9d3e-48b3786623b3.png">

## Testing

On [the deploy preview](https://5f931c8716bbef00073f5e90--cloudfour-patterns.netlify.app/)...

1. Observe that [the icon listing](https://5f931c8716bbef00073f5e90--cloudfour-patterns.netlify.app/?path=/story/design-icons--page) is displayed correctly.
1. Confirm that Twig inlined SVGs haven't been affected in [examples like this](https://5f931c8716bbef00073f5e90--cloudfour-patterns.netlify.app/?path=/story/design-brand--logo).
1. Confirm that CSS inlined SVGs haven't been affected by inspecting [elements like this](https://5f931c8716bbef00073f5e90--cloudfour-patterns.netlify.app/?path=/story/components-input--select-element).
1. Confirm that SVGs in [prototypes like this](https://5f931c8716bbef00073f5e90--cloudfour-patterns.netlify.app/?path=/story/prototypes-clouds--example) haven't been affected.

---

/CC @spaceninja @calebeby 
