### PR TITLE
Run PostCSS in buildSass

### DIFF
--- a/.changeset/green-grapes-unite.md
+++ b/.changeset/green-grapes-unite.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix for missing SVGs in compiled CSS

--- a/gulpfile.js/tasks/build-sass.js
+++ b/gulpfile.js/tasks/build-sass.js
@@ -18,6 +18,7 @@ const buildSass = () => {
         ],
       }).on('error', sass.logError)
     )
+    .pipe(postcss())
     .pipe(rename({ basename: 'standalone' }))
     .pipe(dest(outDir))
     .pipe(postcss([cssnano()]))


### PR DESCRIPTION
## Overview

No inlined SVGs in CSS files were included in the output CSS. This is because we weren't running PostCSS outside of Webpack except for minification.

This adds PostCSS as a step in our `buildSass` task.

## Testing

1. Observe [the latest version of `standalone.css`](https://unpkg.com/@cloudfour/patterns@0.3.0/dist/standalone.css), confirm that it includes uncompiled `svg-load()` functions in its output (which it should not).
1. Check out branch locally.
1. Run `npm run build:sass`
1. Confirm that `dist/standalone.css` and `dist/standalone.min.css` include `url("data:image/svg+xml;...")` strings instead of `svg-load()` functions.
