### PR TITLE
Support non-link pagination items

### DIFF
--- a/.changeset/selfish-moons-whisper.md
+++ b/.changeset/selfish-moons-whisper.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix for non-link pagination items

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ cloudfour.com-patterns
 
 Before you submit a PR, if that PR has changes that will affect consumers of this package, you should run `npx changeset` on your branch. It will ask you [the scope of your changes](https://semver.org/#summary), and it will ask you to describe them.
 
-If you forget to run `npx changelog`, changeset-bot will pester you in your PR. It will provide a link you can use to create the changesets file from the GitHub interface.
+If you forget to run `npx changeset`, changeset-bot will pester you in your PR. It will provide a link you can use to create the changesets file from the GitHub interface.
 
 ## Publishing to npm
 

--- a/src/components/pagination/pagination.twig
+++ b/src/components/pagination/pagination.twig
@@ -11,21 +11,26 @@
             <span class="u-hidden-visually">Page</span>
             <span class="c-pagination__number">{{page.title}}</span>
           </a>
-        {% elseif page.link == pagination.prev.link %}
+        {% elseif page.link and page.link == pagination.prev.link %}
           <a class="c-pagination__action is-previous" href="{{page.link}}">
             <span class="u-hidden-visually">Previous: Page</span>
             <span class="c-pagination__number">{{page.title}}</span>
           </a>
-        {% elseif page.link == pagination.next.link %}
+        {% elseif page.link and page.link == pagination.next.link %}
           <a class="c-pagination__action is-next" href="{{page.link}}">
             <span class="u-hidden-visually">Next: Page</span>
             <span class="c-pagination__number">{{page.title}}</span>
           </a>
-        {% else %}
+        {% elseif page.link %}
           <a class="c-pagination__action" href="{{page.link}}">
             <span class="u-hidden-visually">Page</span>
             <span class="c-pagination__number">{{page.title}}</span>
           </a>
+        {% else %}
+          {# Fallback for non-link pages like ellipsis gaps for first/last pages #}
+          <span class="c-pagination__action">
+            {{page.title}}
+          </span>
         {% endif %}
       </li>
     {% endfor %}


### PR DESCRIPTION
## Overview

It's possible in WordPress or Timber through certain configurations to output pagination items without any links, for example a "…" item preceding a jump to the very last page number. This PR prevents those actions from outputting empty links anyway.

## Testing

Review [the pagination component in the deploy preview](https://deploy-preview-1005--cloudfour-patterns.netlify.app/?path=/story/components-pagination--example). It should work the same as before.