### PR TITLE
Upgrade Cypress GH action to fix failed build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,6 @@ jobs:
       - name: Run Build (necessary for including css file in cypress tests)
         run: npm run build
       - name: Cypress run
-        uses: cypress-io/github-action@v1
+        uses: cypress-io/github-action@v2
         with:
           install: false


### PR DESCRIPTION
Here is the failure: https://github.com/cloudfour/cloudfour.com-patterns/runs/1408782567

https://github.com/cypress-io/github-action/issues/229

## Testing

👀 The `test` action passed ✅ 