### PR TITLE
Remove theme property from container object

### DIFF
--- a/.changeset/polite-rings-taste.md
+++ b/.changeset/polite-rings-taste.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Remove unnecessary theme prop from container which would conflict with Timber/WordPress prop of same name

--- a/src/objects/container/container.twig
+++ b/src/objects/container/container.twig
@@ -1,4 +1,4 @@
-<div class="o-container{% if class %} {{class}}{% endif %}{% if theme %} t-{{theme}}{% endif %}">
+<div class="o-container{% if class %} {{class}}{% endif %}">
   <div class="o-container__content{% if content_class %} {{content_class}}{% endif %}">
     {% block content %}{% endblock %}
   </div>


### PR DESCRIPTION
## Overview

The container object included a separate `theme` property in addition to `class`. Unfortunately this property conflicts with the `theme` property in Timber templates, which is not a string and causes errors. While these are resolvable by passing `only` to the include or embed, since this is the only pattern we had that included this property it seemed simpler to remove it.