### PR TITLE
Use container padding where possible in Ground Nav

### DIFF
--- a/.changeset/real-comics-play.md
+++ b/.changeset/real-comics-play.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Make Ground Nav component whitespace consistent with Container object

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -14,13 +14,28 @@ $_ground-nav-border-width: sizes.$edge-medium;
 $_ground-nav-border-style: solid;
 $_ground-nav-border-color: colors.$gray-light;
 
-.c-ground-nav__action,
-.c-ground-nav__content {
-  padding: $_ground-nav-space;
+/**
+ * 1. We establish vertical whitespace for the action to simplify alignment of
+ *    the illustration, but other whitespace is assumed to be handled by the
+ *    container object to promote alignment with adjacent sections.
+ * 2. Allow illustration to be positioned relative to this container.
+ */
+
+.c-ground-nav__action {
+  padding-bottom: $_ground-nav-space; /* 1 */
+  padding-top: $_ground-nav-space; /* 1 */
+  position: relative; /* 2 */
 }
 
 .c-ground-nav__action-inner {
-  position: relative;
+  /**
+   * Starting at this viewport, we want to position the illustration relative to
+   * the inner element (away from the nearest horizontal edge).
+   */
+
+  @media (min-width: breakpoint.$m) {
+    position: relative;
+  }
 
   @media (min-width: breakpoint.$l) {
     align-items: center;
@@ -47,13 +62,19 @@ $_ground-nav-border-color: colors.$gray-light;
  */
 
 .c-ground-nav__action-illustration {
-  bottom: $_ground-nav-negative-space;
+  bottom: 0;
   position: absolute;
-  right: $_ground-nav-negative-space;
+  right: 0;
   width: 40%;
 
+  /**
+   * We position ourselves relative to a max-width container starting at this
+   * breakpoint, so we have to adjust the bottom position to account for the
+   * change in whitespace.
+   */
+
   @media (min-width: breakpoint.$m) {
-    right: 0;
+    bottom: $_ground-nav-negative-space;
     width: calc(100% / 3);
   }
 

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -12,7 +12,7 @@
 
 <footer class="c-ground-nav">
   {% with action|default({}) %}
-  <div class="c-ground-nav__action o-container">
+  <div class="c-ground-nav__action o-container o-container--pad-inline">
     <div class="o-container__content c-ground-nav__action-inner">
       <h2 class="c-ground-nav__action-lead-in">
         {{leadIn}}
@@ -42,7 +42,7 @@
   </div>
   {% endwith %}
 
-  <div class="c-ground-nav__content o-container">
+  <div class="c-ground-nav__content o-container o-container--pad">
     <div class="c-ground-nav__content-inner o-container__content">
       <h2 class="u-hidden-visually">
         Contact info


### PR DESCRIPTION
## Overview

The Ground Nav pattern was built before we had standard container padding, which change depending on breakpoint. This updates that pattern to use the standard container padding where possible to promote alignment with adjacent content sections.

The main visual changes are to horizontal padding for the top ("action") and bottom ("content") sections, and vertical padding for the bottom section. Vertical padding for the top section is unchanged to avoid disrupting the composition of the illustration relative to the call to action.

## Screenshots

### Before

<img width="1508" alt="Screen Shot 2020-11-17 at 2 19 17 PM" src="https://user-images.githubusercontent.com/69633/99457710-3dd3ad00-28e0-11eb-896c-69bb47ed43e1.png">

### After

<img width="1510" alt="Screen Shot 2020-11-17 at 2 19 28 PM" src="https://user-images.githubusercontent.com/69633/99457720-44fabb00-28e0-11eb-8748-801ea6c74fbd.png">

---

/CC @dromo77 
