### PR TITLE
Add breakpoint helper mixins

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -7,6 +7,7 @@
 @use '../../mixins/fluid';
 @use '../../mixins/focus';
 @use '../../mixins/headings';
+@use '../../mixins/media-query';
 @use '../../mixins/ms';
 
 /// We can't use `grid-gap` exclusively due to some containers only being
@@ -65,46 +66,31 @@ $_focus-overflow: (sizes.$edge-large * -1);
   ); /* 3 */
 }
 
-/// Defines horizontal modifier styles for re-use within media queries to keep
-/// things DRY.
-///
-/// We define the layout as three columns instead of `2fr 1fr` so that the
-/// gaps will line up with three-column elements below. The `fr` rows on the
-/// ends keep the content rows vertically centered.
-///
-/// @todo Coordinate this with the eventual card grid object.
-/// @access private
-
-@mixin _horizontal {
-  grid-template-areas:
-    'cover cover .'
-    'cover cover header'
-    'cover cover content'
-    'cover cover footer'
-    'cover cover .';
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: 1fr repeat(3, minmax(0, auto)) 1fr;
-}
-
 /**
  * Responsive horizontal modifiers
+ *
+ * 1. We define the layout as three columns instead of `2fr 1fr` so that the
+ *    gaps will line up with three-column elements below.
+ * 2. The `fr` rows on the
+ *    ends keep the content rows vertically centered.
+ *
+ * @todo Coordinate this with the eventual card grid object.
  */
 
-.c-card--horizontal\@m {
-  @media (width >= breakpoint.$m) {
-    @include _horizontal();
-  }
-}
-
-.c-card--horizontal\@l {
-  @media (width >= breakpoint.$l) {
-    @include _horizontal();
-  }
-}
-
-.c-card--horizontal\@xl {
-  @media (width >= breakpoint.$xl) {
-    @include _horizontal();
+.c-card--horizontal {
+  @include media-query.breakpoint-classes(
+    $from: m,
+    $to: xl,
+    $include-default: false
+  ) {
+    grid-template-areas:
+      'cover cover .'
+      'cover cover header'
+      'cover cover content'
+      'cover cover footer'
+      'cover cover .';
+    grid-template-columns: repeat(3, 1fr); /* 1 */
+    grid-template-rows: 1fr repeat(3, minmax(0, auto)) 1fr; /* 2 */
   }
 }
 
@@ -206,22 +192,13 @@ $_focus-overflow: (sizes.$edge-large * -1);
   &:not(:only-child) {
     margin-bottom: $_cover-gap;
 
-    .c-card--horizontal\@m & {
-      @media (width >= breakpoint.$m) {
-        margin-bottom: 0;
-      }
-    }
-
-    .c-card--horizontal\@l & {
-      @media (width >= breakpoint.$l) {
-        margin-bottom: 0;
-      }
-    }
-
-    .c-card--horizontal\@xl & {
-      @media (width >= breakpoint.$xl) {
-        margin-bottom: 0;
-      }
+    @include media-query.breakpoint-parent-classes(
+      $selector: '.c-card--horizontal',
+      $from: m,
+      $to: xl,
+      $include-default: false
+    ) {
+      margin-bottom: 0;
     }
   }
 }

--- a/src/mixins/_embed.scss
+++ b/src/mixins/_embed.scss
@@ -1,59 +1,29 @@
-@use 'sass:meta';
 @use '../design-tokens/aspect-ratio.yml';
-@use '../design-tokens/breakpoint.yml';
+@use '../mixins/media-query';
+@use 'sass:meta';
 
-/**
- * We define the default ratio up-front to avoid outputting unnecessary modifier
- * classes for it.
- */
-
+/// The default aspect ratio will not be output outside of a media query.
+/// @type Number
 $default-aspect-ratio: aspect-ratio.$square;
 
-/* stylelint-disable suitcss/custom-property-no-outside-root */
+/// Saving a map of aspect ratio values makes it easier to loop through.
+/// @type Map
+$aspect-ratio-map: meta.module-variables('aspect-ratio');
 
-/**
- * Makes ratio modifier classes based on the `aspect-ratio` and `breakpoint`
- * design tokens. Intended to be included from within the base class.
-
- * We iterate over breakpoints before ratios so wider breakpoints will be later
- * in the cascade. If we iterated over aspect ratios first, then a narrower
- * breakpoint would override a wider one if its aspect ratio came first in our
- * design token file.
- */
-
+/// Makes ratio modifier classes based on the `aspect-ratio` and `breakpoint`
+/// design tokens. Intended to be included from within a base class.
+///
+/// @param {String} $default-aspect-ratio [$default-aspect-ratio] - We won't
+/// output this property again outside of a breakpoint since it shouldn't be
+/// necessary.
+/// @output Ratio modifier classes for supported breakpoints.
 @mixin aspect-ratio-modifiers($default-aspect-ratio: $default-aspect-ratio) {
-  @each $name, $ratio in meta.module-variables('aspect-ratio') {
-    @if $ratio != $default-aspect-ratio {
-      /**
-       * Sass will not compile variables applied to custom properties without
-       * this syntax for compatibility reasons.
-       *
-       * @see https://sass-lang.com/documentation/breaking-changes/css-vars
-       *
-       * Note also that while we avoid using Sass to construct BEM selectors,
-       * (see https://github.com/cloudfour/cloudfour.com-patterns/issues/671)
-       * in this case it's approprate, because this mixin could be used
-       * elsewhere, and we'd want it to work under any selector.
-       */
-
-      &--#{$name} {
+  @each $name, $ratio in $aspect-ratio-map {
+    &--#{$name} {
+      @include media-query.breakpoint-classes(
+        $include-default: $ratio != $default-aspect-ratio
+      ) {
         --aspect-ratio: #{$ratio};
-      }
-    }
-  }
-  @each $suffix, $breakpoint in meta.module-variables('breakpoint') {
-    @media (min-width: $breakpoint) {
-      @each $name, $ratio in meta.module-variables('aspect-ratio') {
-        /**
-         * The backslash in the selector is required for the `@` character.
-         *
-         * 1. It's not super DRY to repeat this line twice in the mixin, but
-         *    every alternative I explored took a lot more code.
-         */
-
-        &--#{$name}\@#{$suffix} {
-          --aspect-ratio: #{$ratio}; /* 1 */
-        }
       }
     }
   }
@@ -139,5 +109,3 @@ $default-aspect-ratio: aspect-ratio.$square;
     @include aspect-ratio-modifiers();
   }
 }
-
-/* stylelint-enable */

--- a/src/mixins/_media-query.scss
+++ b/src/mixins/_media-query.scss
@@ -1,0 +1,108 @@
+@use '../design-tokens/breakpoint.yml';
+@use 'sass:list';
+@use 'sass:map';
+@use 'sass:meta';
+
+/// A map of all breakpoint token variables we can reference using Sass's map
+/// utilities.
+/// @type Map
+$breakpoint-map: meta.module-variables(breakpoint);
+
+/// A list of breakpoint keys, also for looping over to generate different class
+/// name variations.
+/// @type List
+$breakpoint-keys: map.keys($breakpoint-map);
+
+/// The first/narrowest breakpoint, used as a default in multiple mixins.
+/// @type String
+$first-breakpoint: list.nth($breakpoint-keys, 1);
+
+/// The last/widest breakpoint, used as a default in multiple mixins.
+/// @type String
+$last-breakpoint: list.nth($breakpoint-keys, -1);
+
+/// Output some CSS content for multiple breakpoints.
+///
+/// @param {String} $from [$first-breakpoint] - The first/narrowest breakpoint
+/// token key to start looping over.
+/// @param {String} $to [$last-breakpoint] - The last/widest breakpoint token
+/// key to finish looping over.
+/// @content [Receives the current breakpoint `$key`]
+/// @output The `@content` output within each breakpoint's `min-width` media
+/// query.
+@mixin breakpoint-loop($from: $first-breakpoint, $to: $last-breakpoint) {
+  $start: list.index($breakpoint-keys, $from);
+  $end: list.index($breakpoint-keys, $to);
+
+  @for $i from $start through $end {
+    $key: list.nth($breakpoint-keys, $i);
+    $value: map.get($breakpoint-map, $key);
+
+    @media (width >= $value) {
+      @content ($key);
+    }
+  }
+}
+
+/// Repeat a chunk of CSS for multiple standard breakpoints. Useful for keeping
+/// responsive CSS nice and DRY.
+///
+/// @param {String} $from [$first-breakpoint] - The first/narrowest breakpoint
+/// token key to start looping over.
+/// @param {String} $to [$last-breakpoint] - The last/widest breakpoint token
+/// key to finish looping over.
+/// @param {Bool} $include-default [true] - If true, the `@content` will be
+/// output in the current parent before any media queries.
+/// @content
+/// @output The `@content` nested within variations of the parent class that
+/// include media query token segments.
+@mixin breakpoint-classes(
+  $from: $first-breakpoint,
+  $to: $last-breakpoint,
+  $include-default: true
+) {
+  @if ($include-default) {
+    @content;
+  }
+
+  @include breakpoint-loop($from, $to) using ($key) {
+    &\@#{$key} {
+      @content;
+    }
+  }
+}
+
+/// Works the same as `breakpoint-classes`, except the breakpoint keys will be
+/// appended to a `$selector`, and the `@content` will be applied to `&`. This
+/// is useful for styling children of other breakpoint classes, for example
+/// `.parent\@s .parent__child`.
+///
+/// @param {String} $selector - The parent class that will be prepended to the
+/// current context.
+/// @param {String} $from [$first-breakpoint] - The first/narrowest breakpoint
+/// token key to start looping over.
+/// @param {String} $to [$last-breakpoint] - The last/widest breakpoint token
+/// key to finish looping over.
+/// @param {Bool} $include-default [true] - If true, the `@content` will be
+/// output in the current parent before any media queries.
+/// @content
+/// @output The `@content` nested within variations of the parent class that
+/// include media query token segments.
+@mixin breakpoint-parent-classes(
+  $selector,
+  $from: $first-breakpoint,
+  $to: $last-breakpoint,
+  $include-default: true
+) {
+  @if $include-default {
+    #{$selector} & {
+      @content;
+    }
+  }
+
+  @include breakpoint-loop($from, $to) using ($key) {
+    #{$selector}\@#{$key} & {
+      @content;
+    }
+  }
+}


### PR DESCRIPTION
## Overview

I've been working on a new layout pattern with breakpoint modifiers and I found myself growing a bit tired of typing the same breakpoint class logic over and over. At one point I accidentally mismatched a breakpoint class name with its value (I typed `\@l` but I was still using `breakpoint.$m`) and decided it was time to make a robot do that busy work.

So this PR introduces a new `mixins/_media-query.scss` module. You can see the source for details, but the two most important mixins are `breakpoint-classes` and `breakpoint-parent-classes`.

## Examples

### Before these mixins

```scss
@use 'path/to/design-tokens/breakpoint.yml';

.example--red {
  color: red;
}

.example--red\@m {
  @media (width >= breakpoint.$m) {
    color: red;
  }
}

.example--red\@l {
  @media (width >= breakpoint.$l) {
    color: red;
  }
}

.example__child {
  color: blue;

  .example--red & {
    color: red;
  }

  .example--red\@m & {
    @media (width >= breakpoint.$m) {
      color: red;
    }
  }

  .example--red\@l & {
    @media (width >= breakpoint.$l) {
      color: red;
    }
  }
}
```

### After these mixins

```scss
@use 'path/to/mixins/media-query';

.example--red {
  @include media-query.breakpoint-classes(
    $from: m, 
    $to: l
  ) {
    color: red;
  }
}

.example__child {
  color: blue;

  @include media-query.breakpoint-parent-classes(
    $selector: '.example--red',
    $from: m, 
    $to: l,
    $include-default: false
  ) {
    color: red;
  }
}
```