### PR TITLE
Component: Event Log

### DIFF
--- a/.changeset/eight-jokes-report.md
+++ b/.changeset/eight-jokes-report.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Adds Event Log component

--- a/src/components/event-log/demo/events.json
+++ b/src/components/event-log/demo/events.json
@@ -1,6 +1,6 @@
 [
   {
-    "date": "Dec 11, 2017",
+    "date": "2017-12-11",
     "title": "An Event Apart",
     "link": "https://aneventapart.com/event/denver-2017",
     "location": "Denver, CO",
@@ -16,31 +16,31 @@
     ]
   },
   {
-    "date": "Jul 13, 2017",
+    "date": "2017-07-13",
     "title": "Portland Digital Summit",
     "link": "https://portland.digitalsummit.com/agenda/",
     "location": "Portland, OR"
   },
   {
-    "date": "Jul 10, 2017",
+    "date": "2017-07-10",
     "title": "An Event Apart",
     "link": "https://aneventapart.com/event/washington-dc-2017",
     "location": "Washington, DC"
   },
   {
-    "date": "Jun 6, 2017",
+    "date": "2017-06-06",
     "title": "PADNUG",
     "link": "https://www.meetup.com/PADNUG/events/237142614/",
     "location": "Hillsboro, OR"
   },
   {
-    "date": "May 15, 2017",
+    "date": "2017-05-15",
     "title": "An Event Apart",
     "link": "https://aneventapart.com/event/boston-2017",
     "location": "Boston, MA"
   },
   {
-    "date": "Apr 4, 2017",
+    "date": "2017-04-04",
     "title": "Smashing Conference",
     "link": "https://smashingconf.com/",
     "location": "San Francisco, CA",
@@ -52,7 +52,7 @@
     ]
   },
   {
-    "date": "Nov 7, 2016",
+    "date": "2016-11-07",
     "title": "Velocity",
     "link": "http://conferences.oreilly.com/velocity/devops-web-performance-eu",
     "location": "Amsterdam, NL",

--- a/src/components/event-log/demo/events.json
+++ b/src/components/event-log/demo/events.json
@@ -1,0 +1,66 @@
+[
+  {
+    "date": "Dec 11, 2017",
+    "name": "An Event Apart",
+    "link": "https://aneventapart.com/event/denver-2017",
+    "location": "Denver, CO",
+    "links": [
+      {
+        "title": "Luke Wroblewski's Notes",
+        "link": "https://www.lukew.com/ff/entry.asp?1984"
+      },
+      {
+        "title": "Video",
+        "link": "https://vimeo.com/288220564"
+      }
+    ]
+  },
+  {
+    "date": "Jul 13, 2017",
+    "name": "Portland Digital Summit",
+    "link": "https://portland.digitalsummit.com/agenda/",
+    "location": "Portland, OR"
+  },
+  {
+    "date": "Jul 10, 2017",
+    "name": "An Event Apart",
+    "link": "https://aneventapart.com/event/washington-dc-2017",
+    "location": "Washington, DC"
+  },
+  {
+    "date": "Jun 6, 2017",
+    "name": "PADNUG",
+    "link": "https://www.meetup.com/PADNUG/events/237142614/",
+    "location": "Hillsboro, OR"
+  },
+  {
+    "date": "May 15, 2017",
+    "name": "An Event Apart",
+    "link": "https://aneventapart.com/event/boston-2017",
+    "location": "Boston, MA"
+  },
+  {
+    "date": "Apr 4, 2017",
+    "name": "Smashing Conference",
+    "link": "https://smashingconf.com/",
+    "location": "San Francisco, CA",
+    "links": [
+      {
+        "title": "Video",
+        "link": "https://vimeo.com/214425867"
+      }
+    ]
+  },
+  {
+    "date": "Nov 7, 2016",
+    "name": "Velocity",
+    "link": "http://conferences.oreilly.com/velocity/devops-web-performance-eu",
+    "location": "Amsterdam, NL",
+    "links": [
+      {
+        "title": "Video",
+        "link": "https://www.youtube.com/watch?v=IFuYYrb5EMQ"
+      }
+    ]
+  }
+]

--- a/src/components/event-log/demo/events.json
+++ b/src/components/event-log/demo/events.json
@@ -1,12 +1,12 @@
 [
   {
     "date": "Dec 11, 2017",
-    "name": "An Event Apart",
+    "title": "An Event Apart",
     "link": "https://aneventapart.com/event/denver-2017",
     "location": "Denver, CO",
     "links": [
       {
-        "title": "Luke Wroblewski's Notes",
+        "title": "Luke Wroblewski’s Notes",
         "link": "https://www.lukew.com/ff/entry.asp?1984"
       },
       {
@@ -17,31 +17,31 @@
   },
   {
     "date": "Jul 13, 2017",
-    "name": "Portland Digital Summit",
+    "title": "Portland Digital Summit",
     "link": "https://portland.digitalsummit.com/agenda/",
     "location": "Portland, OR"
   },
   {
     "date": "Jul 10, 2017",
-    "name": "An Event Apart",
+    "title": "An Event Apart",
     "link": "https://aneventapart.com/event/washington-dc-2017",
     "location": "Washington, DC"
   },
   {
     "date": "Jun 6, 2017",
-    "name": "PADNUG",
+    "title": "PADNUG",
     "link": "https://www.meetup.com/PADNUG/events/237142614/",
     "location": "Hillsboro, OR"
   },
   {
     "date": "May 15, 2017",
-    "name": "An Event Apart",
+    "title": "An Event Apart",
     "link": "https://aneventapart.com/event/boston-2017",
     "location": "Boston, MA"
   },
   {
     "date": "Apr 4, 2017",
-    "name": "Smashing Conference",
+    "title": "Smashing Conference",
     "link": "https://smashingconf.com/",
     "location": "San Francisco, CA",
     "links": [
@@ -53,7 +53,7 @@
   },
   {
     "date": "Nov 7, 2016",
-    "name": "Velocity",
+    "title": "Velocity",
     "link": "http://conferences.oreilly.com/velocity/devops-web-performance-eu",
     "location": "Amsterdam, NL",
     "links": [

--- a/src/components/event-log/demo/events.twig
+++ b/src/components/event-log/demo/events.twig
@@ -1,12 +1,7 @@
 {% embed '@cloudfour/components/event-log/event-log.twig' %}
   {% block content %}
     {% for item in items %}
-      {% embed '@cloudfour/components/event-log/item.twig' with {
-        date: item.date,
-        name: item.name,
-        href: item.link,
-        location: item.location
-      } %}
+      {% embed '@cloudfour/components/event-log/item.twig' with item %}
         {% block extra %}
           {%- if item.links -%}
             {% embed '@cloudfour/objects/list/list.twig' with {
@@ -25,39 +20,6 @@
           {%- endif -%}
         {% endblock %}
       {% endembed %}
-      {# <article class="c-event-log__item">
-        <h3 class="c-event-log__heading">{{item.date}}</h3>
-        <div class="c-event-log__content">
-          <div>
-            {% embed '@cloudfour/objects/list/list.twig' with {
-              tag_name: 'div',
-              class: 'o-list--inline'
-            } %}
-              {% block content %}
-                <p><a href="{{item.link}}">{{item.name}}</a></p>
-                <p>{{item.location}}</p>
-              {% endblock %}
-            {% endembed %}
-          </div>
-          {% if item.links %}
-            <div>
-              {% embed '@cloudfour/objects/list/list.twig' with {
-                class: 'o-list--inline'
-              } %}
-                {% block content %}
-                  {% for link in item.links %}
-                    <li>
-                      <a href="{{link.link}}">
-                        {{link.title}}
-                      </a>
-                    </li>
-                  {% endfor %}
-                {% endblock %}
-              {% endembed %}
-            </div>
-          {% endif %}
-        </div>
-      </article> #}
     {% endfor %}
   {% endblock %}
 {% endembed %}

--- a/src/components/event-log/demo/events.twig
+++ b/src/components/event-log/demo/events.twig
@@ -1,0 +1,63 @@
+{% embed '@cloudfour/components/event-log/event-log.twig' %}
+  {% block content %}
+    {% for item in items %}
+      {% embed '@cloudfour/components/event-log/item.twig' with {
+        date: item.date,
+        name: item.name,
+        href: item.link,
+        location: item.location
+      } %}
+        {% block extra %}
+          {%- if item.links -%}
+            {% embed '@cloudfour/objects/list/list.twig' with {
+              class: 'o-list--inline'
+            } %}
+              {% block content %}
+                {% for link in item.links %}
+                  <li>
+                    <a href="{{link.link}}">
+                      {{link.title}}
+                    </a>
+                  </li>
+                {% endfor %}
+              {% endblock %}
+            {% endembed %}
+          {%- endif -%}
+        {% endblock %}
+      {% endembed %}
+      {# <article class="c-event-log__item">
+        <h3 class="c-event-log__heading">{{item.date}}</h3>
+        <div class="c-event-log__content">
+          <div>
+            {% embed '@cloudfour/objects/list/list.twig' with {
+              tag_name: 'div',
+              class: 'o-list--inline'
+            } %}
+              {% block content %}
+                <p><a href="{{item.link}}">{{item.name}}</a></p>
+                <p>{{item.location}}</p>
+              {% endblock %}
+            {% endembed %}
+          </div>
+          {% if item.links %}
+            <div>
+              {% embed '@cloudfour/objects/list/list.twig' with {
+                class: 'o-list--inline'
+              } %}
+                {% block content %}
+                  {% for link in item.links %}
+                    <li>
+                      <a href="{{link.link}}">
+                        {{link.title}}
+                      </a>
+                    </li>
+                  {% endfor %}
+                {% endblock %}
+              {% endembed %}
+            </div>
+          {% endif %}
+        </div>
+      </article> #}
+    {% endfor %}
+  {% endblock %}
+{% endembed %}

--- a/src/components/event-log/event-log.scss
+++ b/src/components/event-log/event-log.scss
@@ -23,24 +23,48 @@ $_breakpoint-wide: breakpoint.$m;
   --theme-opacity-event-log-location: 1;
 }
 
+/**
+ * Main container
+ *
+ * 1. Defining content columns here, which will be referenced by subgrid in the
+ *    items themselves. This will keep the date column nicely sized in supported
+ *    browsers instead of relying on an arbitrary list.
+ */
+
 .c-event-log {
   display: grid;
   grid-column-gap: sizes.$gap-inline-medium;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto 1fr; /* 1 */
 }
 
+/**
+ * Individual item container
+ *
+ * 1. Spans the full width of the container.
+ * 2. In browsers that don't support subgrid, we manually define columns. The
+ *    first column width is a "magic number" that looks okay most of the time
+ *    for a date in the format of "Mon D, YYYY".
+ */
+
 .c-event-log__item {
-  border: 0 solid var(--theme-color-border-event-log-item);
   display: grid;
-  grid-column: span 2;
-  grid-template-columns: 8rem 1fr;
+  grid-column: span 2; /* 1 */
+  grid-template-columns: 8rem 1fr; /* 2 */
+
+  /**
+   * If subgrid is supported, use that instead! ✨
+   */
 
   @supports (grid-template-columns: subgrid) {
     grid-template-columns: subgrid;
   }
 
+  /**
+   * Add space and dividing lines between adjacent items
+   */
+
   &:not(:first-child) {
-    border-top-width: 1px;
+    border-top: 1px solid var(--theme-color-border-event-log-item);
     padding-top: sizes.$cell-pad-vertical;
   }
 
@@ -49,9 +73,25 @@ $_breakpoint-wide: breakpoint.$m;
   }
 }
 
+/**
+ * The date should be a heading element for semantics, but we want it to
+ * blend in visually with surrounding text.
+ */
+
 .c-event-log__date {
   font: inherit;
 }
+
+/**
+ * The content container displays its children in a stack by default, but at
+ * larger widths they are displayed in a single line justified across the
+ * available item width.
+ *
+ * We use flexbox for this instead of grid because we want the content to wrap
+ * if it's too long for the available space. We also don't want to use subgrid
+ * because sometimes the width of elements therein feels more unified if it's
+ * content-specific (rather than shared across all items).
+ */
 
 .c-event-log__content {
   @media (width >= $_breakpoint-wide) {
@@ -61,22 +101,52 @@ $_breakpoint-wide: breakpoint.$m;
   }
 }
 
+/**
+ * Details include the title and location
+ *
+ * We want content therein to mimic whatever the layout and wrapping behavior of
+ * the content container is.
+ */
+
 .c-event-log__details {
   display: inherit;
   flex-wrap: inherit;
+
+  /**
+   * It's possible for a long "extras" section to bump into this content
+   * container. Some browsers support `gap` for this, but since we can't test
+   * for Flexbox gap specifically, we have to use regular ol' margin instead.
+   *
+   * We put this on details because if adjacent sections had `margin-left` but
+   * wrapped to a new line, they'd appear incorrectly aligned.
+   */
 
   @media (width >= $_breakpoint-wide) {
     margin-right: sizes.$gap-inline-medium;
   }
 }
 
+/**
+ * Event title
+ */
+
 .c-event-log__title {
   font-weight: font.$weight-semibold;
+
+  /**
+   * We want the title and location to feel a tad more unified than other
+   * columns, so in this case we're just inserting a character space of margin
+   * between them when they're displayed inline.
+   */
 
   @media (width >= $_breakpoint-wide) {
     margin-right: 1ch;
   }
 }
+
+/**
+ * Location should appear a tad more muted and subtle compared to the title.
+ */
 
 .c-event-log__location {
   opacity: var(--theme-opacity-event-log-location);

--- a/src/components/event-log/event-log.scss
+++ b/src/components/event-log/event-log.scss
@@ -1,8 +1,11 @@
+@use '../../design-tokens/breakpoint.yml';
 @use '../../design-tokens/colors.yml';
 @use '../../design-tokens/font.yml';
 @use '../../design-tokens/opacity.yml';
-@use '../../mixins/ms';
+@use '../../design-tokens/sizes.yml';
 @use '../../mixins/theme';
+
+$_breakpoint-wide: breakpoint.$m;
 
 /**
  * Themed properties
@@ -20,7 +23,7 @@
 
 .c-event-log {
   display: grid;
-  grid-column-gap: ms.step(1, 1rem);
+  grid-column-gap: sizes.$list-inline-gap;
   grid-template-columns: auto 1fr;
 }
 
@@ -28,15 +31,19 @@
   border: 0 solid var(--theme-color-border-event-log-item);
   display: grid;
   grid-column: span 2;
-  grid-template-columns: subgrid;
+  grid-template-columns: 8rem 1fr;
+
+  @supports (grid-template-columns: subgrid) {
+    grid-template-columns: subgrid;
+  }
 
   &:not(:first-child) {
     border-top-width: 1px;
-    padding-top: ms.step(-1, 1rem);
+    padding-top: sizes.$cell-pad-vertical;
   }
 
   &:not(:last-child) {
-    padding-bottom: ms.step(-1, 1rem);
+    padding-bottom: sizes.$cell-pad-vertical;
   }
 }
 
@@ -45,23 +52,28 @@
 }
 
 .c-event-log__content {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
+  @media (width >= $_breakpoint-wide) {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
 }
 
 .c-event-log__details {
-  display: flex;
-  flex-wrap: wrap;
+  display: inherit;
+  flex-wrap: inherit;
+
+  @media (width >= $_breakpoint-wide) {
+    margin-right: sizes.$list-inline-gap;
+  }
 }
 
-.c-event-log__name,
-.c-event-log__location {
-  margin-right: 1ch;
-}
-
-.c-event-log__name {
+.c-event-log__title {
   font-weight: font.$weight-semibold;
+
+  @media (width >= $_breakpoint-wide) {
+    margin-right: 1ch;
+  }
 }
 
 .c-event-log__location {

--- a/src/components/event-log/event-log.scss
+++ b/src/components/event-log/event-log.scss
@@ -1,0 +1,69 @@
+@use '../../design-tokens/colors.yml';
+@use '../../design-tokens/font.yml';
+@use '../../design-tokens/opacity.yml';
+@use '../../mixins/ms';
+@use '../../mixins/theme';
+
+/**
+ * Themed properties
+ */
+
+@include theme.props() {
+  --theme-color-border-event-log-item: #{colors.$gray-light};
+  --theme-opacity-event-log-location: #{opacity.$muted};
+}
+
+@include theme.props(dark) {
+  --theme-color-border-event-log-item: #{colors.$primary-brand-dark};
+  --theme-opacity-event-log-location: 1;
+}
+
+.c-event-log {
+  display: grid;
+  grid-column-gap: ms.step(1, 1rem);
+  grid-template-columns: auto 1fr;
+}
+
+.c-event-log__item {
+  border: 0 solid var(--theme-color-border-event-log-item);
+  display: grid;
+  grid-column: span 2;
+  grid-template-columns: subgrid;
+
+  &:not(:first-child) {
+    border-top-width: 1px;
+    padding-top: ms.step(-1, 1rem);
+  }
+
+  &:not(:last-child) {
+    padding-bottom: ms.step(-1, 1rem);
+  }
+}
+
+.c-event-log__date {
+  font: inherit;
+}
+
+.c-event-log__content {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.c-event-log__details {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.c-event-log__name,
+.c-event-log__location {
+  margin-right: 1ch;
+}
+
+.c-event-log__name {
+  font-weight: font.$weight-semibold;
+}
+
+.c-event-log__location {
+  opacity: var(--theme-opacity-event-log-location);
+}

--- a/src/components/event-log/event-log.scss
+++ b/src/components/event-log/event-log.scss
@@ -5,6 +5,8 @@
 @use '../../design-tokens/sizes.yml';
 @use '../../mixins/theme';
 
+/// The breakpoint at which items should attempt to display in a single line.
+/// @access private
 $_breakpoint-wide: breakpoint.$m;
 
 /**
@@ -23,7 +25,7 @@ $_breakpoint-wide: breakpoint.$m;
 
 .c-event-log {
   display: grid;
-  grid-column-gap: sizes.$list-inline-gap;
+  grid-column-gap: sizes.$gap-inline-medium;
   grid-template-columns: auto 1fr;
 }
 
@@ -64,7 +66,7 @@ $_breakpoint-wide: breakpoint.$m;
   flex-wrap: inherit;
 
   @media (width >= $_breakpoint-wide) {
-    margin-right: sizes.$list-inline-gap;
+    margin-right: sizes.$gap-inline-medium;
   }
 }
 

--- a/src/components/event-log/event-log.stories.mdx
+++ b/src/components/event-log/event-log.stories.mdx
@@ -1,0 +1,13 @@
+import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import events from './demo/events.json';
+import eventsDemo from './demo/events.twig';
+const eventsDemoStory = (args) => eventsDemo({ items: events, ...args });
+console.log(events);
+
+<Meta title="Components/Event Log" />
+
+# Event Log
+
+<Canvas>
+  <Story name="Example">{eventsDemoStory.bind({})}</Story>
+</Canvas>

--- a/src/components/event-log/event-log.stories.mdx
+++ b/src/components/event-log/event-log.stories.mdx
@@ -2,12 +2,31 @@ import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import events from './demo/events.json';
 import eventsDemo from './demo/events.twig';
 const eventsDemoStory = (args) => eventsDemo({ items: events, ...args });
-console.log(events);
 
 <Meta title="Components/Event Log" />
 
 # Event Log
 
+Displays a list of event details in chronological order. Designed to show the presentation history for talks, workshops or other events we’ve conducted.
+
+For a less specialized display of tabular data, consider using [Table](/?path=/docs/components-table--basic). For simple string/number pairs, consider [Dot Leader](/?path=/docs/components-dot-leader--list). To display a single or upcoming date, consider using [Calendar Date](/?path=/docs/components-calendar-date--basic) (optionally combined with [Media](/?path=/docs/objects-media--event-summary)).
+
 <Canvas>
   <Story name="Example">{eventsDemoStory.bind({})}</Story>
 </Canvas>
+
+## Template Properties
+
+### Container
+
+- `class`: Append a class to the `c-event-log` element.
+- `content` (Block): The contents of the containing element, presumably items.
+
+### Item
+
+- `date`: A string that is parseable by [Twig's `date` filter](https://twig.symfony.com/doc/3.x/functions/date.html). Used for the date display and for a semantic `time` element.
+- `extras` (Block): Additional supporting content, for example an [inline list](/?path=/docs/objects-list--inline) of related links.
+- `heading_level`: Specifies the level of `h*` element to use. Should be one lower than whatever the preceding section heading is to preserve the document outline. Defaults to `3`.
+- `link`: An external URL for the event.
+- `location`: The location of the event, for example "Portland, OR" or "Online."
+- `title`: The name of the event, for example "An Event Apart."

--- a/src/components/event-log/event-log.twig
+++ b/src/components/event-log/event-log.twig
@@ -1,3 +1,3 @@
-<div class="c-event-log">
+<div class="c-event-log{% if class %} {{class}}{% endif %}">
   {% block content %}{% endblock %}
 </div>

--- a/src/components/event-log/event-log.twig
+++ b/src/components/event-log/event-log.twig
@@ -1,0 +1,3 @@
+<div class="c-event-log">
+  {% block content %}{% endblock %}
+</div>

--- a/src/components/event-log/item.twig
+++ b/src/components/event-log/item.twig
@@ -1,7 +1,13 @@
+{% set _datetime = date|default('now') %}
+{% set _heading_level = heading_level|default(3) %}
 {% set _extra_block %}{% block extra %}{% endblock %}{% endset %}
 
 <article class="c-event-log__item">
-  <h3 class="c-event-log__date">{{date}}</h3>
+  <h{{_heading_level}} class="c-event-log__date">
+    <time datetime="{{_datetime|date('Y-m-d')}}">
+      {{_datetime|date('M j, Y')}}
+    </time>
+  </h{{_heading_level}}>
   <div class="c-event-log__content">
     <div class="c-event-log__details">
       <p class="c-event-log__title">

--- a/src/components/event-log/item.twig
+++ b/src/components/event-log/item.twig
@@ -1,0 +1,22 @@
+{% set _extra_block %}{% block extra %}{% endblock %}{% endset %}
+
+<article class="c-event-log__item">
+  <h3 class="c-event-log__date">{{date}}</h3>
+  <div class="c-event-log__content">
+    <div class="c-event-log__details">
+      <p class="c-event-log__name">
+        <a href="{{href}}">
+          {{name}}
+        </a>
+      </p>
+      <p class="c-event-log__location">
+        {{location}}
+      </p>
+    </div>
+    {% if _extra_block is not empty %}
+      <div class="c-event-log__extra">
+        {{_extra_block}}
+      </div>
+    {% endif %}
+  </div>
+</article>

--- a/src/components/event-log/item.twig
+++ b/src/components/event-log/item.twig
@@ -4,9 +4,9 @@
   <h3 class="c-event-log__date">{{date}}</h3>
   <div class="c-event-log__content">
     <div class="c-event-log__details">
-      <p class="c-event-log__name">
-        <a href="{{href}}">
-          {{name}}
+      <p class="c-event-log__title">
+        <a href="{{link}}">
+          {{title}}
         </a>
       </p>
       <p class="c-event-log__location">

--- a/src/design-tokens/sizes.yml
+++ b/src/design-tokens/sizes.yml
@@ -64,7 +64,15 @@ props:
     value: 1
     type: modular/em
     category: sizing
-  - name: list_inline_gap
+  - name: gap_inline_small
+    comment: |
+      Horizontal/column gap between media object and content, etc.
+    value: 0
+    type: modular/em
+    category: sizing
+  - name: gap_inline_medium
+    comment: |
+      Horizontal/column gap between cells in inline lists, event logs, etc.
     value: 1
     type: modular/em
     category: sizing
@@ -78,10 +86,6 @@ props:
     comment: |
       Used for table cells or other repeating content rows.
     value: -3
-    type: modular/em
-    category: sizing
-  - name: media_gap
-    value: 0
     type: modular/em
     category: sizing
   - name: rhythm_space_compact

--- a/src/objects/list/list.scss
+++ b/src/objects/list/list.scss
@@ -31,11 +31,11 @@
 .o-list--inline {
   display: flex;
   flex-wrap: wrap;
-  margin-left: sizes.$list-inline-gap / -2;
-  margin-right: sizes.$list-inline-gap / -2;
+  margin-left: sizes.$gap-inline-medium / -2;
+  margin-right: sizes.$gap-inline-medium / -2;
 }
 
 .o-list--inline > * {
-  margin-left: sizes.$list-inline-gap / 2;
-  margin-right: sizes.$list-inline-gap / 2;
+  margin-left: sizes.$gap-inline-medium / 2;
+  margin-right: sizes.$gap-inline-medium / 2;
 }

--- a/src/objects/media/media.scss
+++ b/src/objects/media/media.scss
@@ -25,7 +25,7 @@
 .o-media__object {
   align-self: flex-start; /* 1 */
   flex: none; /* 2 */
-  margin-right: sizes.$media-gap;
+  margin-right: sizes.$gap-inline-small;
   order: -1; /* 3 */
 }
 
@@ -36,7 +36,7 @@
  */
 
 .o-media--reverse .o-media__object {
-  margin-left: sizes.$media-gap;
+  margin-left: sizes.$gap-inline-small;
   margin-right: 0;
   order: 1;
 }

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -9,7 +9,7 @@
  * Applies our pattern library styles to buttons generated via Gutenberg blocks.
  */
 
-$wp-button-gap: sizes.$list-inline-gap;
+$wp-button-gap: sizes.$gap-inline-medium;
 
 /**
  * 1. Align buttons with outer parent


### PR DESCRIPTION
## Overview

> Displays a list of event details in chronological order. Designed to show the presentation history for talks, workshops or other events we’ve conducted.

Improvements from the existing site's pattern ([visible lower on this page](https://cloudfour.com/presents/why-you-should-build-a-progressive-web-app-now/)):

1. Each item has a heading element, which makes them easier to navigate with screen readers.
1. Each date is a `<time>` element, which adds semantic meaning.
1. Uses [Subgrid](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid) in supported ~browsers~ [browser](https://caniuse.com/css-subgrid) ([Microsoft is reported to be adding Chromium support](https://blog.chromium.org/2020/06/improving-chromiums-browser.html), though, so 🤞)
1. No need to manually add `padding` and `border` classes based on loop indexes in templates.
1. Simpler markup, requiring four fewer elements and just over half as many characters as the live version.
1. Works across themes.

This PR also renames the `sizes.$list-inline-gap` and `sizes.$media-gap` tokens to `sizes.$gap-inline-medium` and `sizes.$gap-inline-small`. The previous names were too specific to reflect the scope of their usage.

(Apologies if this is a rather anti-climactic PR after #1064: I started working on this PR while waiting for review on that one! I promise I'll be putting those mixins to use shortly. 😄)

## Screenshots

<img width="370" alt="Screen Shot 2020-12-03 at 3 38 10 PM" src="https://user-images.githubusercontent.com/69633/101104038-1dae1a00-357f-11eb-9ef6-49efcfb46d7c.png">

<img width="638" alt="Screen Shot 2020-12-03 at 3 38 29 PM" src="https://user-images.githubusercontent.com/69633/101104046-1f77dd80-357f-11eb-8ca2-b1b495f7790b.png">

<img width="638" alt="Screen Shot 2020-12-03 at 3 38 42 PM" src="https://user-images.githubusercontent.com/69633/101104049-20a90a80-357f-11eb-9ecd-0556d71fec1d.png">

## Testing

Check out [the Event Log component deploy preview](https://deploy-preview-1065--cloudfour-patterns.netlify.app/?path=/docs/components-event-log--example)

---

/CC @AriannaChau 
