### PR TITLE
Object: Deck

### DIFF
--- a/.changeset/unlucky-colts-serve.md
+++ b/.changeset/unlucky-colts-serve.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add Deck layout object

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -61,8 +61,8 @@ $_focus-overflow: (sizes.$edge-large * -1);
   @include fluid.grid-column-gap(
     breakpoint.$s,
     breakpoint.$xl,
-    ms.step(1, 1rem),
-    ms.step(3, 1rem)
+    ms.step(3, 1rem),
+    ms.step(6, 1rem)
   ); /* 3 */
 }
 

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -69,9 +69,11 @@ $_focus-overflow: (sizes.$edge-large * -1);
 /**
  * Responsive horizontal modifiers
  *
- * 1. We define the layout as three columns instead of `2fr 1fr` so that the
+ * 1. If this is in a multi-column grid layout, this insures it will fill the
+ *    available width.
+ * 2. We define the layout as three columns instead of `2fr 1fr` so that the
  *    gaps will line up with three-column elements below.
- * 2. The `fr` rows on the
+ * 3. The `fr` rows on the
  *    ends keep the content rows vertically centered.
  *
  * @todo Coordinate this with the eventual card grid object.
@@ -83,14 +85,15 @@ $_focus-overflow: (sizes.$edge-large * -1);
     $to: xl,
     $include-default: false
   ) {
+    grid-column: 1 / -1; /* 1 */
     grid-template-areas:
       'cover cover .'
       'cover cover header'
       'cover cover content'
       'cover cover footer'
       'cover cover .';
-    grid-template-columns: repeat(3, 1fr); /* 1 */
-    grid-template-rows: 1fr repeat(3, minmax(0, auto)) 1fr; /* 2 */
+    grid-template-columns: repeat(3, 1fr); /* 2 */
+    grid-template-rows: 1fr repeat(3, minmax(0, auto)) 1fr; /* 3 */
   }
 }
 

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -45,8 +45,6 @@ $_focus-overflow: (sizes.$edge-large * -1);
  *    to this container.
  * 3. We define our column gap here instead of in the `c-card--horizontal`
  *    modifiers so we don't have to define it within multiple media queries.
- *
- * @todo Coordinate column gap with eventual card grid object.
  */
 
 .c-card {

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -73,8 +73,6 @@ $_focus-overflow: (sizes.$edge-large * -1);
  *    gaps will line up with three-column elements below.
  * 3. The `fr` rows on the
  *    ends keep the content rows vertically centered.
- *
- * @todo Coordinate this with the eventual card grid object.
  */
 
 .c-card--horizontal {

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -61,8 +61,8 @@ $_focus-overflow: (sizes.$edge-large * -1);
   @include fluid.grid-column-gap(
     breakpoint.$s,
     breakpoint.$xl,
-    ms.step(3, 1rem),
-    ms.step(6, 1rem)
+    sizes.$gap-fluid-min,
+    sizes.$gap-fluid-max
   ); /* 3 */
 }
 

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -90,6 +90,8 @@ If a card with a cover is meant to occupy its full container width, it may be pr
   </Story>
 </Canvas>
 
+Horizontal cards will attempt to span all available columns of a CSS Grid Layout. This comes in handy when displaying them [in a Deck](/?path=/docs/objects-deck--horizontal-card#with-horizontal-cards).
+
 ## Coming soon
 
 - Progressive enhancement based on CSS Grid support

--- a/src/design-tokens/sizes.yml
+++ b/src/design-tokens/sizes.yml
@@ -27,6 +27,12 @@ props:
       trouble of recalculating the stupidly large value.
     type: pixel
     category: radius
+  - name: card_column_min
+    value: 15em
+    comment: |
+      The minimum space to display a default card in a grid.
+    type: relative
+    category: sizing
   - name: control_height
     value: 4
     type: modular/em
@@ -75,6 +81,18 @@ props:
       Horizontal/column gap between cells in inline lists, event logs, etc.
     value: 1
     type: modular/em
+    category: sizing
+  - name: gap_fluid_min
+    comment: |
+      Minimum size of a large content gap, for example gutters between cards.
+    value: 3
+    type: modular/rem
+    category: sizing
+  - name: gap_fluid_max
+    comment: |
+      Maximum size of a large content gap, for example gutters between cards.
+    value: 6
+    type: modular/rem
     category: sizing
   - name: cell_pad_horizontal
     comment: |

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -23,7 +23,7 @@
 
 @for $i from 2 through 3 {
   .o-deck--#{$i}-column {
-    @include media-query.breakpoint-classes() {
+    @include media-query.breakpoint-classes($from: s, $to: xl) {
       grid-template-columns: repeat(#{$i}, 1fr);
     }
   }

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -1,24 +1,24 @@
 @use '../../design-tokens/breakpoint.yml';
+@use '../../design-tokens/sizes.yml';
 @use '../../mixins/fluid';
 @use '../../mixins/media-query';
-@use '../../mixins/ms';
 
 .o-deck {
   display: grid;
+  grid-auto-flow: dense;
   @include fluid.grid-gap(
     breakpoint.$s,
     breakpoint.$xl,
-    ms.step(3, 1rem),
-    ms.step(6, 1rem)
+    sizes.$gap-fluid-min,
+    sizes.$gap-fluid-max
   );
 
   @media (width >= breakpoint.$xs) {
-    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+    grid-template-columns: repeat(
+      auto-fit,
+      minmax(#{sizes.$card-column-min}, 1fr)
+    );
   }
-}
-
-.o-deck--dense {
-  grid-auto-flow: dense;
 }
 
 @for $i from 2 through 3 {

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -3,15 +3,29 @@
 @use '../../mixins/fluid';
 @use '../../mixins/media-query';
 
+/**
+ * 1. If horizontal items are shown at the wrong column count, they will appear
+ *    to break the grid. This rule keeps items densely packed so it will always
+ *    appear visually correct.
+ */
+
 .o-deck {
   display: grid;
-  grid-auto-flow: dense;
+  grid-auto-flow: dense; /* 1 */
   @include fluid.grid-gap(
     breakpoint.$s,
     breakpoint.$xl,
     sizes.$gap-fluid-min,
     sizes.$gap-fluid-max
   );
+
+  /**
+   * We define a media query for our initial grid so child elements will flex
+   * for viewports smaller than our minimum column size.
+   *
+   * Our use of `auto-fit` means columns will be automatically created as space
+   * allows.
+   */
 
   @media (width >= breakpoint.$xs) {
     grid-template-columns: repeat(
@@ -20,6 +34,14 @@
     );
   }
 }
+
+/**
+ * Responsive column count modifiers
+ *
+ * These modifier classes specify a hard-set column count at a particular
+ * breakpoint. This may be used to limit the column count to a particular
+ * maximum or to coordinate with adjacent elements.
+ */
 
 @for $i from 2 through 3 {
   .o-deck--#{$i}-column {

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -1,0 +1,27 @@
+@use '../../design-tokens/breakpoint.yml';
+@use '../../mixins/fluid';
+@use '../../mixins/ms';
+
+.o-deck {
+  display: grid;
+  grid-auto-flow: dense;
+  grid-template-columns: [full-start] 1fr [full-end];
+  @include fluid.grid-gap(
+    breakpoint.$s,
+    breakpoint.$xl,
+    ms.step(3, 1rem),
+    ms.step(6, 1rem)
+  );
+
+  @media (width >= breakpoint.$m) {
+    grid-template-columns: [full-start] repeat(2, 1fr) [full-end];
+  }
+
+  @media (width >= breakpoint.$l) {
+    grid-template-columns: [full-start] repeat(3, 1fr) [full-end];
+  }
+}
+
+.o-deck__full {
+  grid-column: full;
+}

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -7,6 +7,8 @@
  * 1. If horizontal items are shown at the wrong column count, they will appear
  *    to break the grid. This rule keeps items densely packed so it will always
  *    appear visually correct.
+ *
+ * @todo Use progressive enhancement so older browsers get a minimal fallback.
  */
 
 .o-deck {

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -2,31 +2,23 @@
 @use '../../mixins/fluid';
 @use '../../mixins/ms';
 
-@mixin _template-columns($count: 1) {
-  @if $count > 1 {
-    grid-template-columns: [full-start] repeat(#{$count}, 1fr) [full-end];
-  } @else {
-    grid-template-columns: [full-start] 1fr [full-end];
-  }
-}
-
 .o-deck {
   display: grid;
   grid-auto-flow: dense;
+  grid-template-columns: [full-start] repeat(var(--columns, 1), 1fr) [full-end];
   @include fluid.grid-gap(
     breakpoint.$s,
     breakpoint.$xl,
     ms.step(3, 1rem),
     ms.step(6, 1rem)
   );
-  @include _template-columns();
 
   @media (width >= breakpoint.$m) {
-    @include _template-columns(2);
+    --columns: 2;
   }
 
   @media (width >= breakpoint.$l) {
-    @include _template-columns(3);
+    --columns: 3;
   }
 }
 

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -1,5 +1,6 @@
 @use '../../design-tokens/breakpoint.yml';
 @use '../../mixins/fluid';
+@use '../../mixins/media-query';
 @use '../../mixins/ms';
 
 .o-deck {
@@ -12,28 +13,18 @@
     ms.step(3, 1rem),
     ms.step(6, 1rem)
   );
+}
 
-  @media (width >= breakpoint.$m) {
-    --columns: 2;
-  }
-
-  @media (width >= breakpoint.$l) {
-    --columns: 3;
+@for $i from 2 through 3 {
+  .o-deck--#{$i}-column {
+    @include media-query.breakpoint-classes() {
+      --columns: #{$i};
+    }
   }
 }
 
 .o-deck__full {
-  grid-column: full;
-}
-
-.o-deck__full\@m {
-  @media (width >= breakpoint.$m) {
-    grid-column: full;
-  }
-}
-
-.o-deck__full\@l {
-  @media (width >= breakpoint.$l) {
-    grid-column: full;
+  @include media-query.breakpoint-classes() {
+    grid-column: 1 / -1;
   }
 }

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -5,26 +5,26 @@
 
 .o-deck {
   display: grid;
-  grid-auto-flow: dense;
-  grid-template-columns: [full-start] repeat(var(--columns, 1), 1fr) [full-end];
   @include fluid.grid-gap(
     breakpoint.$s,
     breakpoint.$xl,
     ms.step(3, 1rem),
     ms.step(6, 1rem)
   );
+
+  @media (width >= breakpoint.$xs) {
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  }
+}
+
+.o-deck--dense {
+  grid-auto-flow: dense;
 }
 
 @for $i from 2 through 3 {
   .o-deck--#{$i}-column {
     @include media-query.breakpoint-classes() {
-      --columns: #{$i};
+      grid-template-columns: repeat(#{$i}, 1fr);
     }
-  }
-}
-
-.o-deck__full {
-  @include media-query.breakpoint-classes() {
-    grid-column: 1 / -1;
   }
 }

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -2,26 +2,46 @@
 @use '../../mixins/fluid';
 @use '../../mixins/ms';
 
+@mixin _template-columns($count: 1) {
+  @if $count > 1 {
+    grid-template-columns: [full-start] repeat(#{$count}, 1fr) [full-end];
+  } @else {
+    grid-template-columns: [full-start] 1fr [full-end];
+  }
+}
+
 .o-deck {
   display: grid;
   grid-auto-flow: dense;
-  grid-template-columns: [full-start] 1fr [full-end];
   @include fluid.grid-gap(
     breakpoint.$s,
     breakpoint.$xl,
     ms.step(3, 1rem),
     ms.step(6, 1rem)
   );
+  @include _template-columns();
 
   @media (width >= breakpoint.$m) {
-    grid-template-columns: [full-start] repeat(2, 1fr) [full-end];
+    @include _template-columns(2);
   }
 
   @media (width >= breakpoint.$l) {
-    grid-template-columns: [full-start] repeat(3, 1fr) [full-end];
+    @include _template-columns(3);
   }
 }
 
 .o-deck__full {
   grid-column: full;
+}
+
+.o-deck__full\@m {
+  @media (width >= breakpoint.$m) {
+    grid-column: full;
+  }
+}
+
+.o-deck__full\@l {
+  @media (width >= breakpoint.$l) {
+    grid-column: full;
+  }
 }

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -8,7 +8,24 @@ const articlesStory = (args) => articlesDemo({ items: articles, ...args });
   title="Objects/Deck"
   parameters={{ docs: { inlineStories: false } }}
   argTypes={{
-    fullItem: {
+    columns: {
+      control: {
+        type: 'range',
+        min: 2,
+        max: 3,
+        step: 1,
+      },
+      defaultValue: 3,
+    },
+    columnsBreakpoint: {
+      type: { name: 'string' },
+      control: {
+        type: 'inline-radio',
+        options: ['none', '@s', '@m', '@l', '@xl'],
+      },
+      defaultValue: 'none',
+    },
+    horizontalItem: {
       control: {
         type: 'range',
         min: 1,
@@ -17,10 +34,10 @@ const articlesStory = (args) => articlesDemo({ items: articles, ...args });
       },
       defaultValue: 1,
     },
-    fullBreakpoint: {
-      type: { name: 'enum' },
-      control: { type: 'inline-radio', options: ['none', '@m', '@l'] },
-      defaultValue: '@l',
+    horizontalBreakpoint: {
+      type: { name: 'string' },
+      control: { type: 'inline-radio', options: ['none', '@m', '@l', '@xl'] },
+      defaultValue: 'none',
     },
   }}
 />
@@ -29,10 +46,51 @@ const articlesStory = (args) => articlesDemo({ items: articles, ...args });
 
 What do you call a group of multiple [Cards](/?path=/docs/components-card--content-blocks)?
 
-A stack! Wait, no, that implies verticality.
+A “stack” of cards? Sure, but that may imply verticality…
 
-A deck! Yeah, that's the ticket!
+How about a “deck” of cards?
+
+By default, the `o-deck` class will use CSS Grid Layout to arrange child elements in a grid with generous whitespace. Additional columns will appear automatically as space allows.
 
 <Canvas>
-  <Story name="Example">{articlesStory.bind({})}</Story>
+  <Story name="Basic" height="400px">
+    {articlesStory.bind({})}
+  </Story>
+</Canvas>
+
+## Specifying Columns
+
+While automatic columns are convenient, there are times when a specific column count is desired. For example, you may want to limit a design to three columns at larger breakpoints to align with adjacent elements.
+
+To do this, add a modifier class in the format of `o-deck--X-column@Y`, where `X` is the desired column count (from 2 to 3) and `Y` is the desired [breakpoint](/?path=/docs/design-tokens-breakpoint--page) (from `s` to `xl`). In this example, we force the grid to display three columns starting from the `m` breakpoint.
+
+<Canvas>
+  <Story
+    name="Columns"
+    height="400px"
+    args={{
+      columns: 3,
+      columnsBreakpoint: '@m',
+    }}
+  >
+    {articlesStory.bind({})}
+  </Story>
+</Canvas>
+
+## With Horizontal Cards
+
+[Horizontal cards](/?path=/docs/components-card--content-blocks#horizontal) will automatically span all available columns.
+
+<Canvas>
+  <Story
+    name="Horizontal Card"
+    height="500px"
+    args={{
+      columns: 3,
+      columnsBreakpoint: '@l',
+      horizontalBreakpoint: '@m',
+    }}
+  >
+    {articlesStory.bind({})}
+  </Story>
 </Canvas>

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -1,0 +1,16 @@
+import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import template from './deck.twig';
+
+<Meta title="Objects/Deck" parameters={{ docs: { inlineStories: false } }} />
+
+# Deck
+
+What do you call a group of multiple [Cards](/?path=/docs/components-card--content-blocks)?
+
+A stack! Wait, no, that implies verticality.
+
+A deck! Yeah, that's the ticket!
+
+<Canvas>
+  <Story name="WIP">{template}</Story>
+</Canvas>

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -4,7 +4,26 @@ import articlesDemo from './demo/articles.twig';
 import template from './deck.twig';
 const articlesStory = (args) => articlesDemo({ items: articles, ...args });
 
-<Meta title="Objects/Deck" parameters={{ docs: { inlineStories: false } }} />
+<Meta
+  title="Objects/Deck"
+  parameters={{ docs: { inlineStories: false } }}
+  argTypes={{
+    fullItem: {
+      control: {
+        type: 'range',
+        min: 1,
+        max: articles.length,
+        step: 1,
+      },
+      defaultValue: 1,
+    },
+    fullBreakpoint: {
+      type: { name: 'enum' },
+      control: { type: 'inline-radio', options: ['none', '@m', '@l'] },
+      defaultValue: '@l',
+    },
+  }}
+/>
 
 # Deck
 

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -1,7 +1,6 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import articles from './demo/articles.json';
 import articlesDemo from './demo/articles.twig';
-import template from './deck.twig';
 const articlesStory = (args) => articlesDemo({ items: articles, ...args });
 
 <Meta

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -1,5 +1,8 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import articles from './demo/articles.json';
+import articlesDemo from './demo/articles.twig';
 import template from './deck.twig';
+const articlesStory = (args) => articlesDemo({ items: articles, ...args });
 
 <Meta title="Objects/Deck" parameters={{ docs: { inlineStories: false } }} />
 
@@ -12,5 +15,5 @@ A stack! Wait, no, that implies verticality.
 A deck! Yeah, that's the ticket!
 
 <Canvas>
-  <Story name="WIP">{template}</Story>
+  <Story name="Example">{articlesStory.bind({})}</Story>
 </Canvas>

--- a/src/objects/deck/deck.twig
+++ b/src/objects/deck/deck.twig
@@ -1,22 +1,3 @@
-{% embed '@cloudfour/objects/container/container.twig' with {
-  class: 'o-container--pad'
-} %}
-  {% block content %}
-    <div class="o-deck">
-      {% for i in 1..12 %}
-        {% set _card_class = false %}
-        {% if i == 2 %}
-          {% set _card_class = 'c-card--horizontal@m o-deck__full' %}
-        {% endif %}
-        {% include '@cloudfour/components/card/demo/single.twig' with {
-          show_heading: true,
-          show_cover: true,
-          show_content: true,
-          show_footer: true,
-          href: '#',
-          class: _card_class
-        } only %}
-      {% endfor %}
-    </div>
-  {% endblock %}
-{% endembed %}
+<div class="o-deck">
+  {% block content %}{% endblock %}
+</div>

--- a/src/objects/deck/deck.twig
+++ b/src/objects/deck/deck.twig
@@ -1,3 +1,3 @@
-<div class="o-deck">
+<div class="o-deck{% if class %} {{class}}{% endif %}">
   {% block content %}{% endblock %}
 </div>

--- a/src/objects/deck/deck.twig
+++ b/src/objects/deck/deck.twig
@@ -1,0 +1,22 @@
+{% embed '@cloudfour/objects/container/container.twig' with {
+  class: 'o-container--pad'
+} %}
+  {% block content %}
+    <div class="o-deck">
+      {% for i in 1..12 %}
+        {% set _card_class = false %}
+        {% if i == 2 %}
+          {% set _card_class = 'c-card--horizontal@m o-deck__full' %}
+        {% endif %}
+        {% include '@cloudfour/components/card/demo/single.twig' with {
+          show_heading: true,
+          show_cover: true,
+          show_content: true,
+          show_footer: true,
+          href: '#',
+          class: _card_class
+        } only %}
+      {% endfor %}
+    </div>
+  {% endblock %}
+{% endembed %}

--- a/src/objects/deck/demo/articles.json
+++ b/src/objects/deck/demo/articles.json
@@ -1,0 +1,137 @@
+[
+  {
+    "title": "Building Flexible Components With Transparency",
+    "pubDate": "2020-11-19 17:28:54",
+    "link": "https://cloudfour.com/thinks/building-flexible-components-with-transparency/",
+    "guid": "https://cloudfour.com/?p=6017",
+    "author": "Paul Hebert",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/11/transparent-flexible.png",
+    "description": "By adding a touch of transparency, we can design components that automatically adapt to their backgrounds."
+  },
+  {
+    "title": "A GitHub Action for automated deployment to WP Engine",
+    "pubDate": "2020-11-17 08:30:14",
+    "link": "https://cloudfour.com/thinks/a-github-action-for-automated-deployment-to-wp-engine/",
+    "guid": "https://cloudfour.com/?p=5945",
+    "author": "Emerson Loustau",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/06/SpongeBob-SquarePants-Nervous-Sweating.gif",
+    "description": "We recently set up a GitHub Action to automatically upload our site updates to WP Engine whenever we push to a specific branch. we suspect other teams might find it useful, too."
+  },
+  {
+    "title": "Perfectly Broken Code",
+    "pubDate": "2020-10-30 08:00:21",
+    "link": "https://cloudfour.com/thinks/perfectly-broken-code/",
+    "guid": "https://cloudfour.com/?p=5898",
+    "author": "Gerardo Rodriguez",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/10/perfectly-broken-code-preview-2.png",
+    "description": "Join me in exploring a recent experience where I started with flawed logic (without realizing it) and the steps I took to fix my bug. Let’s experience some broken code together. 🎉"
+  },
+  {
+    "title": "Designers, Design Systems and Finding Our Focus",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/thinks/designers-design-systems-and-finding-our-focus/",
+    "guid": "https://cloudfour.com/?p=5944",
+    "author": "Tyler Sticka",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/10/focus-areas-r2.png",
+    "description": "For many designers, the process of finding one's place within a design system can be surprisingly tough."
+  },
+  {
+    "title": "Styling Complex Labels",
+    "pubDate": "2020-09-02 09:00:06",
+    "link": "https://cloudfour.com/thinks/styling-complex-labels/",
+    "guid": "https://cloudfour.com/?p=5959",
+    "author": "Danielle Romo",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/07/custom-label.png",
+    "description": "Consider the common pattern of selecting a pricing plan for a hypothetical service. To make a selection, users need to know the name of the plan, the price, and its features. But if we include all of those details, it gets hard to read: Each option’s plan information is included in a label. To improve […]"
+  },
+  {
+    "title": "Performance is an issue of equity",
+    "pubDate": "2020-08-11 18:28:00",
+    "link": "https://cloudfour.com/thinks/performance-is-an-issue-of-equity/",
+    "guid": "https://cloudfour.com/?p=5981",
+    "author": "Megan Notarte",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/08/perf-equity-r3-alt.png",
+    "description": "Website speed and performance are a question of equity.  Fast and lightweight sites mean that everyone can access your content equally. It’s not only an economic imperative; it’s a moral imperative."
+  },
+  {
+    "title": "Generating complementary gradients with CSS filters",
+    "pubDate": "2020-05-27 15:51:07",
+    "link": "https://cloudfour.com/thinks/generating-complementary-gradients-with-css-filters/",
+    "guid": "https://cloudfour.com/?p=5918",
+    "author": "Paul Hebert",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/05/socks-hero3.png",
+    "description": "CSS filters unlock powerful new opportunities for playing with color. By applying some color theory we can dynamically generate harmonious color combos and gradients. Let's sell some socks!"
+  },
+  {
+    "title": "CSS Animation Timelines: Building a Rube Goldberg Machine",
+    "pubDate": "2020-04-13 15:41:25",
+    "link": "https://cloudfour.com/thinks/css-animation-timelines-building-a-rube-goldberg-machine/",
+    "guid": "https://cloudfour.com/?p=5784",
+    "author": "Paul Hebert",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/04/rgm.gif",
+    "description": "Lately I’ve been using variables to plan out pure CSS timelines for complex animations. I built an SVG and CSS Rube Goldberg machine to put this technique to the test!"
+  },
+  {
+    "title": "Getting Unstuck",
+    "pubDate": "2020-04-03 08:00:06",
+    "link": "https://cloudfour.com/thinks/getting-unstuck/",
+    "guid": "https://cloudfour.com/?p=5752",
+    "author": "Emerson Loustau",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/04/HD.4G.038_10537689444-scaled-e1585787011260.jpg",
+    "description": "Problem-solving is an essential part of software development. Sometimes we get stuck on a particularly baffling problem, and this can feel frustrating and discouraging. The following are some strategies for getting yourself “unstuck.”"
+  },
+  {
+    "title": "Responsive Images the Simple Way",
+    "pubDate": "2020-04-02 17:18:08",
+    "link": "https://cloudfour.com/thinks/responsive-images-the-simple-way/",
+    "guid": "https://cloudfour.com/?p=5773",
+    "author": "Scott Vandehey",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/03/summary.png",
+    "description": "The responsive images spec is fantastic and covers a lot of use cases, but most of the time you’ll only need one: resolution switching using the `srcset` and `sizes` attributes."
+  },
+  {
+    "title": "Navigation for Design Systems and Style Guides",
+    "pubDate": "2020-02-21 16:35:31",
+    "link": "https://cloudfour.com/thinks/navigation-for-design-systems-and-style-guides/",
+    "guid": "https://cloudfour.com/?p=5740",
+    "author": "Danielle Romo",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/02/design-system-navigation.png",
+    "description": "A key part of my job for the past year has been contributing to design systems. To benefit from those contributions though, users need to be able to find them. That’s why it’s not only the content of a design system that’s important but also its usability. Design systems should be easy to navigate, especially..."
+  },
+  {
+    "title": "What Flushing Toilets Taught Me About Web Design",
+    "pubDate": "2020-02-06 16:22:05",
+    "link": "https://cloudfour.com/thinks/what-flushing-toilets-taught-me-about-web-design/",
+    "guid": "https://cloudfour.com/?p=5718",
+    "author": "Paul Hebert",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/02/Sharing-Image.png",
+    "description": " I re-learned an old design lesson from the humble toilet flusher. As new features are added to existing technologies, careful design is required to make their usage clear."
+  },
+  {
+    "title": "Tiny Web Stacks",
+    "pubDate": "2020-02-05 16:47:06",
+    "link": "https://cloudfour.com/thinks/tiny-web-stacks/",
+    "guid": "https://cloudfour.com/?p=5712",
+    "author": "Tyler Sticka",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/02/tiny-web-stacks-r2.png",
+    "description": "When it comes to side projects, micro-sites and one-off experiments, you don't need much to get started."
+  },
+  {
+    "title": "22 Panels That Always Work: Wally Wood’s Legendary Productivity Hack",
+    "pubDate": "2020-01-14 16:49:28",
+    "link": "https://cloudfour.com/thinks/22-panels-that-always-work-wally-woods-legendary-productivity-hack/",
+    "guid": "https://cloudfour.com/?p=5678",
+    "author": "Scott Vandehey",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/01/wallywood22panel1600.jpg",
+    "description": "Comic book artist Wally Wood’s “22 Panels That Always Work” is a legendary bit of productivity hacking. How can you reduce “noodling” in your work?"
+  },
+  {
+    "title": "An HTML attribute potentially worth $4.4M to Chipotle",
+    "pubDate": "2019-09-19 16:57:12",
+    "link": "https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/",
+    "guid": "https://cloudfour.com/?p=5555",
+    "author": "Jason Grigsby",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2019/09/Screen-Shot-2019-09-19-at-9.52.57-AM.png",
+    "description": "My parents are retired. They continue to try to pay for meals. I don't want them to. So we often end up in a competition to see who can pay first. In this case, I knew I had an advantage. My card details were already stored in the browser. I just needed to use autofill..."
+  }
+]

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -3,12 +3,12 @@
 } %}
   {% block content %}
     {% embed '@cloudfour/objects/deck/deck.twig' with {
-      class: 'o-deck--2-column@m o-deck--3-column@l',
+      class: 'o-deck--3-column@l',
     } %}
       {% block content %}
         {% for item in items %}
           {% if loop.index == fullItem and fullBreakpoint and fullBreakpoint != 'none' %}
-            {% set _card_class = 'o-deck__full' ~ fullBreakpoint ~ ' c-card--horizontal' ~ fullBreakpoint %}
+            {% set _card_class = 'c-card--horizontal' ~ fullBreakpoint %}
           {% else %}
             {% set _card_class = '' %}
           {% endif %}

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -7,8 +7,13 @@
     } %}
       {% block content %}
         {% for item in items %}
-
+          {% if loop.index == fullItem and fullBreakpoint and fullBreakpoint != 'none' %}
+            {% set _card_class = 'o-deck__full' ~ fullBreakpoint ~ ' c-card--horizontal' ~ fullBreakpoint %}
+          {% else %}
+            {% set _card_class = '' %}
+          {% endif %}
           {% embed '@cloudfour/components/card/card.twig' with {
+            class: _card_class,
             href: item.link
           } %}
             {% block heading %}

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -1,0 +1,33 @@
+{% embed '@cloudfour/objects/container/container.twig' with {
+  class: 'o-container--pad'
+} %}
+  {% block content %}
+    {% embed '@cloudfour/objects/deck/deck.twig' with {
+      class: '',
+    } %}
+      {% block content %}
+        {% for item in items %}
+
+          {% embed '@cloudfour/components/card/card.twig' with {
+            href: item.link
+          } %}
+            {% block heading %}
+              {{item.title}}
+            {% endblock %}
+            {% block cover %}
+              <img src="{{item.thumbnail}}" alt="">
+            {% endblock %}
+            {% block content %}
+              <p>{{item.description}}</p>
+            {% endblock %}
+            {% block footer %}
+              <p>{{item.author}}</p>
+              <p>{{item.pubDate|date('M j, Y')}}</p>
+            {% endblock %}
+          {% endembed %}
+
+        {% endfor %}
+      {% endblock %}
+    {% endembed %}
+  {% endblock %}
+{% endembed %}

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -1,44 +1,44 @@
-{% embed '@cloudfour/objects/container/container.twig' with {
-  class: 'o-container--pad'
+{% if columns and columns > 1 and columnsBreakpoint and columnsBreakpoint != 'none' %}
+  {% set _deck_class = 'o-deck--' ~ columns ~ '-column' ~ columnsBreakpoint %}
+{% else %}
+  {% set _deck_class = '' %}
+{% endif %}
+
+{% embed '@cloudfour/objects/deck/deck.twig' with {
+  class: _deck_class,
 } %}
   {% block content %}
-    {% embed '@cloudfour/objects/deck/deck.twig' with {
-      class: 'o-deck--3-column@l',
-    } %}
-      {% block content %}
-        {% for item in items %}
-          {% if loop.index == fullItem and fullBreakpoint and fullBreakpoint != 'none' %}
-            {% set _card_class = 'c-card--horizontal' ~ fullBreakpoint %}
-          {% else %}
-            {% set _card_class = '' %}
-          {% endif %}
-          {% embed '@cloudfour/components/card/card.twig' with {
-            class: _card_class,
-            href: item.link
-          } %}
-            {% block heading %}
-              {{item.title}}
-            {% endblock %}
-            {% block cover %}
-              <img src="{{item.thumbnail}}" alt="">
-            {% endblock %}
-            {% block content %}
-              <p>
-                {% if item.description|length > 140 %}
-                  {{item.description|slice(0, 140)|trim}}…
-                {% else %}
-                  {{item.description}}
-                {% endif %}
-              </p>
-            {% endblock %}
-            {% block footer %}
-              <p>{{item.author}}</p>
-              <p>{{item.pubDate|date('M j, Y')}}</p>
-            {% endblock %}
-          {% endembed %}
+    {% for item in items %}
+      {% if loop.index == horizontalItem and horizontalBreakpoint and horizontalBreakpoint != 'none' %}
+        {% set _card_class = 'c-card--horizontal' ~ horizontalBreakpoint %}
+      {% else %}
+        {% set _card_class = '' %}
+      {% endif %}
+      {% embed '@cloudfour/components/card/card.twig' with {
+        class: _card_class,
+        href: item.link
+      } %}
+        {% block heading %}
+          {{item.title}}
+        {% endblock %}
+        {% block cover %}
+          <img src="{{item.thumbnail}}" alt="">
+        {% endblock %}
+        {% block content %}
+          <p>
+            {% if item.description|length > 140 %}
+              {{item.description|slice(0, 140)|trim}}…
+            {% else %}
+              {{item.description}}
+            {% endif %}
+          </p>
+        {% endblock %}
+        {% block footer %}
+          <p>{{item.author}}</p>
+          <p>{{item.pubDate|date('M j, Y')}}</p>
+        {% endblock %}
+      {% endembed %}
 
-        {% endfor %}
-      {% endblock %}
-    {% endembed %}
+    {% endfor %}
   {% endblock %}
 {% endembed %}

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -3,7 +3,7 @@
 } %}
   {% block content %}
     {% embed '@cloudfour/objects/deck/deck.twig' with {
-      class: '',
+      class: 'o-deck--2-column@m o-deck--3-column@l',
     } %}
       {% block content %}
         {% for item in items %}

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -38,7 +38,6 @@
           <p>{{item.pubDate|date('M j, Y')}}</p>
         {% endblock %}
       {% endembed %}
-
     {% endfor %}
   {% endblock %}
 {% endembed %}

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -23,7 +23,13 @@
               <img src="{{item.thumbnail}}" alt="">
             {% endblock %}
             {% block content %}
-              <p>{{item.description}}</p>
+              <p>
+                {% if item.description|length > 140 %}
+                  {{item.description|slice(0, 140)}}…
+                {% else %}
+                  {{item.description}}
+                {% endif %}
+              </p>
             {% endblock %}
             {% block footer %}
               <p>{{item.author}}</p>

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -25,7 +25,7 @@
             {% block content %}
               <p>
                 {% if item.description|length > 140 %}
-                  {{item.description|slice(0, 140)}}…
+                  {{item.description|slice(0, 140)|trim}}…
                 {% else %}
                   {{item.description}}
                 {% endif %}


### PR DESCRIPTION
## Overview

Adds a layout object intended for displaying a grid of card components. By default, columns are created automatically, but they can be explicitly defined from a particular breakpoint. Horizontal cards will automatically span all available columns.

I am open to alternative names. See Docs and CSS comments for more info.

## Screenshots

<img width="1146" alt="Screen Shot 2020-12-07 at 3 58 32 PM" src="https://user-images.githubusercontent.com/69633/101419683-60d0fb80-38a5-11eb-870b-1e227b831d25.png">

## Testing

1. Proofread [docs for new object](https://deploy-preview-1075--cloudfour-patterns.netlify.app/?path=/docs/objects-deck--basic)
1. Try out [canvas view](https://deploy-preview-1075--cloudfour-patterns.netlify.app/?path=/story/objects-deck--horizontal-card), play with controls

