### PR TITLE
Expose Design Tokens in npm Package

### DIFF
--- a/.changeset/serious-candles-cough.md
+++ b/.changeset/serious-candles-cough.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Expose design tokens in npm package

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "types": "./dist/cloudfour-patterns.d.ts",
   "files": [
     "/dist",
+    "/src/compiled/tokens",
     "/src/**/*.scss",
     "/src/**/*.twig",
     "!/src/**/demo/**/*.twig",


### PR DESCRIPTION
## Overview

This PR adds our compiled design tokens to the npm package output for
consumption in the WordPress theme.

## Testing

To the best of my knowledge, there's no way to test this without publishing the package, which I can't do until this PR is merged. That said, the change is really simple, and I'm confident in it.

---

- Fixes #1095
