### PR TITLE
Optimize striped table component for dark theme and fix caption color

### DIFF
--- a/src/mixins/_table.scss
+++ b/src/mixins/_table.scss
@@ -2,10 +2,25 @@
 @use "../compiled/tokens/scss/font-weight";
 @use "../compiled/tokens/scss/size";
 @use "./ms";
+@use "./theme";
 
 $table-border-color: color.$base-gray-light;
 $table-border-thin: size.$edge-small solid $table-border-color;
 $table-border-thick: size.$edge-medium solid $table-border-color;
+
+/**
+ * Themed properties
+ */
+
+@include theme.props() {
+  --theme-color-table-striped: #{color.$base-gray-lighter};
+  --theme-color-table-caption: #{color.$base-gray-dark};
+}
+
+@include theme.props(dark) {
+  --theme-color-table-striped: #{color.$brand-primary-dark};
+  --theme-color-table-caption: #{color.$base-gray-lighter};
+}
 
 /**
  * Our base table component
@@ -42,7 +57,7 @@ $table-border-thick: size.$edge-medium solid $table-border-color;
 
 @mixin t-caption {
   caption-side: bottom;
-  color: color.$base-gray-dark;
+  color: var(--theme-color-table-caption);
   font-size: ms.step(-1);
   font-style: italic;
   padding: ms.step(-1) 0;
@@ -57,7 +72,7 @@ $table-border-thick: size.$edge-medium solid $table-border-color;
 }
 
 @mixin t-striped {
-  background-color: color.$base-gray-lighter;
+  background-color: var(--theme-color-table-striped);
 }
 
 /**


### PR DESCRIPTION
## Overview

There was an issue where the striped variation of the table component didn't look right on the dark theme. The caption of the table also remained a dark gray on the dark theme as well. This PR changes the stripes from a light gray to a dark blue and changes the caption color to a lighter gray.

## Screenshots

<img width="1227" alt="Screen Shot 2021-05-26 at 3 50 42 PM" src="https://user-images.githubusercontent.com/24928337/119741230-23076580-be3a-11eb-8013-8e3ca96c2c45.png">

## Testing

1. [Deploy link](https://deploy-preview-1242--cloudfour-patterns.netlify.app/?path=/story/components-table--striped)

---

- Fixes https://github.com/cloudfour/cloudfour.com-patterns/issues/1229
