### PR TITLE
Fix broken documentation links

### DIFF
--- a/.changeset/metal-ways-thank.md
+++ b/.changeset/metal-ways-thank.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Fix broken documentation links

--- a/src/components/avatar/avatar.stories.mdx
+++ b/src/components/avatar/avatar.stories.mdx
@@ -35,7 +35,7 @@ const avatarStory = (args) => {
 
 Displays a user, organization or product [avatar](<https://en.wikipedia.org/wiki/Avatar_(computing)>) or profile picture.
 
-The size is fixed to the value of [our `sizes.$avatar-medium` token by default](/docs/design-tokens-sizes--page#sizing), making this an ideal pattern to use within [a Media object](/docs/objects-media--image). If the pattern contains no image, it will show a plain color.
+The size is fixed to the value of [our `sizes.$avatar-medium` token by default](/docs/design-tokens-size--page#sizing), making this an ideal pattern to use within [a Media object](/docs/objects-media--image). If the pattern contains no image, it will show a plain color.
 
 <Canvas>
   <Story name="Empty">{avatarStory.bind({})}</Story>

--- a/src/components/avatar/avatar.stories.mdx
+++ b/src/components/avatar/avatar.stories.mdx
@@ -35,7 +35,7 @@ const avatarStory = (args) => {
 
 Displays a user, organization or product [avatar](<https://en.wikipedia.org/wiki/Avatar_(computing)>) or profile picture.
 
-The size is fixed to the value of [our `sizes.$avatar-medium` token by default](/?path=/docs/design-tokens-sizes--page#sizing), making this an ideal pattern to use within [a Media object](/?path=/docs/objects-media--image). If the pattern contains no image, it will show a plain color.
+The size is fixed to the value of [our `sizes.$avatar-medium` token by default](/docs/design-tokens-sizes--page#sizing), making this an ideal pattern to use within [a Media object](/docs/objects-media--image). If the pattern contains no image, it will show a plain color.
 
 <Canvas>
   <Story name="Empty">{avatarStory.bind({})}</Story>
@@ -78,8 +78,8 @@ The `c-avatar--full` modifier sizes the component to `100%` of its container.
 
 ## See Also
 
-To display multiple avatars in a visual cluster, see [the Bunch object](/?path=/docs/objects-bunch--of-avatars).
+To display multiple avatars in a visual cluster, see [the Bunch object](/docs/objects-bunch--of-avatars).
 
-To display images and other embedded media at a fluid but consistent aspect ratio, see [the Embed object](/?path=/docs/objects-embed--image).
+To display images and other embedded media at a fluid but consistent aspect ratio, see [the Embed object](/docs/objects-embed--image).
 
-To size and color icons based on surrounding text, see [the Icon component](/?path=/docs/components-icon--basic).
+To size and color icons based on surrounding text, see [the Icon component](/docs/components-icon--basic).

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -31,7 +31,7 @@ Some buttons may not require as much emphasis as others. The `c-button--secondar
   <Story name="Styles">{(args) => stylesDemo(args)}</Story>
 </Canvas>
 
-All the above visual styles will appear slightly different within [our dark theme](/docs/themes--dark). These versions retain their visual emphasis relative to one another while remaining visually distinct from form inputs.
+All the above visual styles will appear slightly different within [our dark theme](/docs/design-themes--dark). These versions retain their visual emphasis relative to one another while remaining visually distinct from form inputs.
 
 <Canvas>
   <Story name="Styles (Dark)" parameters={{ theme: 't-dark' }}>

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -31,7 +31,7 @@ Some buttons may not require as much emphasis as others. The `c-button--secondar
   <Story name="Styles">{(args) => stylesDemo(args)}</Story>
 </Canvas>
 
-All the above visual styles will appear slightly different within [our dark theme](/?path=/docs/themes--dark). These versions retain their visual emphasis relative to one another while remaining visually distinct from form inputs.
+All the above visual styles will appear slightly different within [our dark theme](/docs/themes--dark). These versions retain their visual emphasis relative to one another while remaining visually distinct from form inputs.
 
 <Canvas>
   <Story name="Styles (Dark)" parameters={{ theme: 't-dark' }}>

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -72,7 +72,7 @@ If an `href` property is provided, the `heading` (if present) will include a lin
 
 ## With cover
 
-An optional `cover` block may be provided containing an image or other visual object. This will display using our `wide` [aspect ratio token](/?path=/story/design-tokens-aspect-ratio--page), and includes an effect on hover if the card includes an `href` (see above).
+An optional `cover` block may be provided containing an image or other visual object. This will display using our `wide` [aspect ratio token](/story/design-tokens-aspect-ratio--page), and includes an effect on hover if the card includes an `href` (see above).
 
 <Canvas>
   <Story name="Cover Image" args={{ href: '#' }}>
@@ -82,7 +82,7 @@ An optional `cover` block may be provided containing an image or other visual ob
 
 ## Horizontal
 
-If a card with a cover is meant to occupy its full container width, it may be preferable to display it horizontally at larger [breakpoints](/?path=/docs/design-tokens-breakpoint--page). The `c-card--horizontal@m`, `c-card--horizontal@l` and `c-card--horizontal@xl` modifier classes will do that from their respective breakpoints.
+If a card with a cover is meant to occupy its full container width, it may be preferable to display it horizontally at larger [breakpoints](/docs/design-tokens-breakpoint--page). The `c-card--horizontal@m`, `c-card--horizontal@l` and `c-card--horizontal@xl` modifier classes will do that from their respective breakpoints.
 
 <Canvas>
   <Story name="Horizontal" args={{ href: '#', horizontal: '@m' }}>
@@ -90,7 +90,7 @@ If a card with a cover is meant to occupy its full container width, it may be pr
   </Story>
 </Canvas>
 
-Horizontal cards will attempt to span all available columns of a CSS Grid Layout. This comes in handy when displaying them [in a Deck](/?path=/docs/objects-deck--horizontal-card#with-horizontal-cards).
+Horizontal cards will attempt to span all available columns of a CSS Grid Layout. This comes in handy when displaying them [in a Deck](/docs/objects-deck--horizontal-card#with-horizontal-cards).
 
 ## Coming soon
 

--- a/src/components/checkbox/checkbox.stories.mdx
+++ b/src/components/checkbox/checkbox.stories.mdx
@@ -11,7 +11,7 @@ import './demo/styles.scss';
 
 # Checkbox
 
-`c-checkbox` may be applied to any `<input type="checkbox">` element. They are larger than native checkboxes and more visually consistent with our [input](/?path=/docs/components-input--text-elements) and [button](/?path=/docs/components-button--elements) components.
+`c-checkbox` may be applied to any `<input type="checkbox">` element. They are larger than native checkboxes and more visually consistent with our [input](/docs/components-input--text-elements) and [button](/docs/components-button--elements) components.
 
 <Canvas>
   <Story name="Enabled" height="120px" args={{ disabled: false }}>

--- a/src/components/cloud-cover/cloud-cover.stories.mdx
+++ b/src/components/cloud-cover/cloud-cover.stories.mdx
@@ -16,7 +16,7 @@ import robotImage from './demo/robot.svg';
 
 # Cloud Cover
 
-A containing element for introductory page content, for example a heading and subtitle. The clouds offer a whimsical, illustrative element to help transition from the page title and [Sky Nav](/?path=/docs/components-sky-nav--dark) to the main body content.
+A containing element for introductory page content, for example a heading and subtitle. The clouds offer a whimsical, illustrative element to help transition from the page title and [Sky Nav](/docs/components-sky-nav--dark) to the main body content.
 
 <Canvas>
   <Story name="Content" height="400px">

--- a/src/components/dot-leader/dot-leader.stories.mdx
+++ b/src/components/dot-leader/dot-leader.stories.mdx
@@ -41,7 +41,7 @@ If `c-dot-leader` is an `<a>` element, it will gain some additional styles.
   </Story>
 </Canvas>
 
-Although `c-dot-leader` applies to a single row, the pattern works best as part of [a list object](/?path=/docs/objects-list--default-story). The dotted lines clearly associate each column even when content lengths vary.
+Although `c-dot-leader` applies to a single row, the pattern works best as part of [a list object](/docs/objects-list--default-story). The dotted lines clearly associate each column even when content lengths vary.
 
 <Canvas>
   <Story name="List">{listDemo({ topics })}</Story>

--- a/src/components/event-log/event-log.stories.mdx
+++ b/src/components/event-log/event-log.stories.mdx
@@ -9,7 +9,7 @@ const eventsDemoStory = (args) => eventsDemo({ items: events, ...args });
 
 Displays a list of event details in chronological order. Designed to show the presentation history for talks, workshops or other events we’ve conducted.
 
-For a less specialized display of tabular data, consider using [Table](/?path=/docs/components-table--basic). For simple string/number pairs, consider [Dot Leader](/?path=/docs/components-dot-leader--list). To display a single or upcoming date, consider using [Calendar Date](/?path=/docs/components-calendar-date--basic) (optionally combined with [Media](/?path=/docs/objects-media--event-summary)).
+For a less specialized display of tabular data, consider using [Table](/docs/components-table--basic). For simple string/number pairs, consider [Dot Leader](/docs/components-dot-leader--list). To display a single or upcoming date, consider using [Calendar Date](/docs/components-calendar-date--basic) (optionally combined with [Media](/docs/objects-media--event-summary)).
 
 <Canvas>
   <Story name="Example">{eventsDemoStory.bind({})}</Story>
@@ -25,7 +25,7 @@ For a less specialized display of tabular data, consider using [Table](/?path=/d
 ### Item
 
 - `date`: A string that is parseable by [Twig's `date` filter](https://twig.symfony.com/doc/3.x/functions/date.html). Used for the date display and for a semantic `time` element.
-- `extras` (Block): Additional supporting content, for example an [inline list](/?path=/docs/objects-list--inline) of related links.
+- `extras` (Block): Additional supporting content, for example an [inline list](/docs/objects-list--inline) of related links.
 - `heading_level`: Specifies the level of `h*` element to use. Should be one lower than whatever the preceding section heading is to preserve the document outline. Defaults to `3`.
 - `link`: An external URL for the event.
 - `location`: The location of the event, for example "Portland, OR" or "Online."

--- a/src/components/ground-nav/ground-nav.stories.mdx
+++ b/src/components/ground-nav/ground-nav.stories.mdx
@@ -73,7 +73,7 @@ embedded examples.
 
 **Note:** This component is currently a work in progress.
 
-The yin to [Sky Nav](/?path=/docs/components-sky-nav--dark)'s yang, the Ground Nav sits at the bottom of all our pages. It includes a call to action, contact information, an expanded navigation menu for lost users and any legal copy.
+The yin to [Sky Nav](/docs/components-sky-nav--dark)'s yang, the Ground Nav sits at the bottom of all our pages. It includes a call to action, contact information, an expanded navigation menu for lost users and any legal copy.
 
 <Canvas>
   <Story
@@ -166,7 +166,7 @@ Stay tuned!
   - `leadIn`: The heading text that precedes the button.
   - `title`: The title of the action link. Named `title` for consistency with menus.
   - `link`: The URL for the action link. Named `link` for consistency with menus.
-  - `icon`: Optional key to one of [our icons](/?path=/docs/design-icons--page) for display in the link.
+  - `icon`: Optional key to one of [our icons](/docs/design-icons--page) for display in the link.
 - `organization`: Object containing Cloud Four details for contact information and copyright. Structure and property names are based on the [the Organization schema](https://schema.org/Organization).
   - `name`
   - `address`
@@ -180,4 +180,4 @@ Stay tuned!
   - `url`
   - `foundingDate`: Used for start date of default legal content.
 - `menu`: An object containing navigation menu `items` to iterate over in the same structure as that expected by [Timber menus](https://timber.github.io/docs/guides/menus/).
-- `social`: The same structure as `menu` but for social links. Each item must also contain an `icon` property corresponding to a key from [our icon library](/?path=/docs/design-icons--page).
+- `social`: The same structure as `menu` but for social links. Each item must also contain an `icon` property corresponding to a key from [our icon library](/docs/design-icons--page).

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -6,7 +6,7 @@ import permalinksDemo from './demo/permalinks.twig';
 
 # Heading
 
-It's important for accessibility and for search engines that page sections include helpful heading elements in a logical, descending order ([more info](https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/headings.html)). But there are times when [our default `<h1>` through `<h6>` styles](/?path=/docs/design-typography--headings) may not be enough:
+It's important for accessibility and for search engines that page sections include helpful heading elements in a logical, descending order ([more info](https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/headings.html)). But there are times when [our default `<h1>` through `<h6>` styles](/docs/design-typography--headings) may not be enough:
 
 - The most appropriate heading element may look too small or too large visually.
 - You may want to apply heading styles to a different element: A short introductory `<p>`, a `<legend>`, etc.
@@ -44,7 +44,7 @@ The `c-heading` class may include a permalink using [a technique from Marcy Sutt
 - `c-heading__content`: The actual semantic heading element (usually `<h1>` – `<h6>`), including the `id` referenced by `c-heading__permalink`.
 - `c-heading__permalink`: The `<a>` element that exposes the permalink to the user. This element is kept separate from the actual heading so it won't disrupt a user's ability to navigate via headings.
 
-Note that the layout of this pattern is optimized for [our prose containers](/?path=/docs/objects-container--prose#prose) with generous horizontal whitespace.
+Note that the layout of this pattern is optimized for [our prose containers](/docs/objects-container--prose#prose) with generous horizontal whitespace.
 
 <!--
 This example isn't inlined so any media queries affecting the container will

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -8,7 +8,7 @@ import inlineDemo from './demo/inline.twig';
 
 The `c-icon` class causes an SVG element to inherit its size and default color from its parent element's `font-size` and `color` value.
 
-For a list of available icons, visit [the Icons page](/?path=/docs/design-icons--page).
+For a list of available icons, visit [the Icons page](/docs/design-icons--page).
 
 <Canvas>
   <Story
@@ -36,7 +36,7 @@ Icons without a flex or grid container may appear [slightly low in comparison to
 
 The component template supports the following unique properties:
 
-- `name`: The name of the intended icon [in our library](/?path=/docs/design-icons--page).
+- `name`: The name of the intended icon [in our library](/docs/design-icons--page).
 - `fallback`: The name of an icon to display if the first doesn't exist. Useful if you are displaying unique icons based on dynamic content. Defaults to `close`.
 - `inline`: When `true`, the inline modifier will be applied.
 - `class`: Will append to `c-icon` and any other modifier classes.

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -17,7 +17,7 @@ different settings within the same file, React syncs all their properties.
 
 # Input
 
-The `c-input` class styles text and text-like form elements in a consistent way. It works great with an adjacent [button component](/?path=/story/components-button--elements).
+The `c-input` class styles text and text-like form elements in a consistent way. It works great with an adjacent [button component](/story/components-button--elements).
 
 <Canvas>
   <Story

--- a/src/components/pagination/pagination.stories.mdx
+++ b/src/components/pagination/pagination.stories.mdx
@@ -10,7 +10,7 @@ Displays a horizontal list of page number links, including extra affordances for
 
 The component supports variable amounts of page numbers and will adjust its layout accordingly. For best results on small screens, we recommend a maximum link count of 5.
 
-As the viewport widens, individual numbers may drift awkwardly far apart. You can prevent this by wrapping the component in [a container](/?path=/docs/objects-container--basic).
+As the viewport widens, individual numbers may drift awkwardly far apart. You can prevent this by wrapping the component in [a container](/docs/objects-container--basic).
 
 <Canvas>
   <Story
@@ -45,7 +45,7 @@ In addition to the usual hover, active and focus states, `c-pagination__action` 
 Like all navigation patterns, pagination is potentially fraught with accessibility issues. Here's what we've done to make this component more inclusive:
 
 - The outer `<nav>` element clearly identifies this component as navigation to assistive devices.
-- Said element includes an `aria-labelledby` attribute, which maps to the ID of a [visually hidden](/?path=/docs/utilities-display--hidden-visually) heading element within. We use `aria-labelledby` instead of `aria-label` to improve [compatibility with translation tools](https://heydonworks.com/article/aria-label-is-a-xenophobe/).
+- Said element includes an `aria-labelledby` attribute, which maps to the ID of a [visually hidden](/docs/utilities-display--hidden-visually) heading element within. We use `aria-labelledby` instead of `aria-label` to improve [compatibility with translation tools](https://heydonworks.com/article/aria-label-is-a-xenophobe/).
 - The `<ul>` element containing list items includes a `role="list"` attribute to avoid [an issue in Safari/VoiceOver](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html).
 - All page actions include [visually hidden text for context](https://www.a11ymatters.com/pattern/pagination/#2--labeling-the-navigation-links) ("Page 4" instead of simply "4").
 - The current page action is identified using [the `aria-current` attribute](https://tink.uk/using-the-aria-current-attribute/).

--- a/src/components/sky-nav/sky-nav.stories.mdx
+++ b/src/components/sky-nav/sky-nav.stories.mdx
@@ -24,7 +24,7 @@ Our primary navigation component, intended for the very top of a page layout. It
 - In wider viewports, menu items are visible by default. They are displayed on multiple rows as needed.
 - At even wider viewports, the menu items are displayed in a single row.
 
-The Sky Nav is intended for use with our [our dark theme](/?path=/docs/themes--dark):
+The Sky Nav is intended for use with our [our dark theme](/docs/themes--dark):
 
 <Canvas>
   <Story
@@ -75,7 +75,7 @@ But it works without a theme, too, just in case:
 ## Elements
 
 - `c-sky-nav`: A containing `<div>` element. This element should also have the `js-sky-nav` class, which is used for the open/close animation. The animation uses it to figure out which elements below the containing element need to be pushed up or down.
-- `c-sky-nav__skip`: A link to the main content area, visibly hidden until focus. Works great with [our `c-button` pattern](/?path=/docs/components-button--elements).
+- `c-sky-nav__skip`: A link to the main content area, visibly hidden until focus. Works great with [our `c-button` pattern](/docs/components-button--elements).
 - `c-sky-nav__content`: A `<header>` element representing the actual menu contents.
 - `c-sky-nav__masthead`: Containing element for the logo and menu toggle.
 - `c-sky-nav__logo`: A link to the homepage containing our logo as an inline SVG.
@@ -94,7 +94,7 @@ As the primary navigation element for our site, it's imperative we think through
 
 - All interactive elements contain specially designed focus outlines. This is especially important since some browser's default outlines virtually disappear against our blue!
 - The "skip to main content" link precedes the header and navigation elements and can be used to skip them entirely. It is visually hidden until focus but always detectable by screen readers.
-- The logo link fallback text and `<nav>` heading are defined using [visually hidden](/?path=/docs/utilities-display--hidden-visually) elements rather than attributes to improve [compatibility with translation tools](https://heydonworks.com/article/aria-label-is-a-xenophobe/).
+- The logo link fallback text and `<nav>` heading are defined using [visually hidden](/docs/utilities-display--hidden-visually) elements rather than attributes to improve [compatibility with translation tools](https://heydonworks.com/article/aria-label-is-a-xenophobe/).
 - The logo SVG has its `focusable` attribute set to `false` to avoid [an IE issue with SVGs nested in focusable elements](http://simplyaccessible.com/article/7-solutions-svgs/#acc-heading-4).
 - The list of menu items has a `role` attribute of `list` to avoid [an issue in Safari/VoiceOver](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html).
 - The current page action is identified using [the `aria-current` attribute](https://tink.uk/using-the-aria-current-attribute/).

--- a/src/components/sky-nav/sky-nav.stories.mdx
+++ b/src/components/sky-nav/sky-nav.stories.mdx
@@ -24,7 +24,7 @@ Our primary navigation component, intended for the very top of a page layout. It
 - In wider viewports, menu items are visible by default. They are displayed on multiple rows as needed.
 - At even wider viewports, the menu items are displayed in a single row.
 
-The Sky Nav is intended for use with our [our dark theme](/docs/themes--dark):
+The Sky Nav is intended for use with our [our dark theme](/docs/design-themes--dark):
 
 <Canvas>
   <Story

--- a/src/design/colors.stories.mdx
+++ b/src/design/colors.stories.mdx
@@ -34,7 +34,7 @@ Our secondary palette consists of green, purple, fuchsia, and orange. These colo
 
 The extended palette is intended to be ever evolving, it offers an additional range of colors work with. The number of different values was determined by cataloging the current use of color throughout our site to create a sufficient number of variations. Usage of these colors will vary, but they should come in handy for illustrations and components.
 
-[See our Design Token documentation](/?path=/docs/design-tokens-colors--page) for a full list of variable names and accessibility details.
+[See our Design Token documentation](/docs/design-tokens-colors--page) for a full list of variable names and accessibility details.
 
 <ColorPalette>
   <ColorItem

--- a/src/design/fallback-images/fallback-images.stories.mdx
+++ b/src/design/fallback-images/fallback-images.stories.mdx
@@ -12,7 +12,7 @@ Article summaries appear more interesting and cohesive when they have an image, 
 
 Loosely inspired by classic television test patterns, the goal was to have them coexist with feature images without stealing too much attention, all while staying on brand.
 
-This design also leaves room to add more categories if desired. Ideally, the icons are two-toned, with a singular color for each design. The core colors are from our [color palette](/?path=/story/design-colors--page), but the entire range of each color can be used, including values that may not be visibly included on that page (the pinks in the gauge example are not shown on our color palette page, but are derivatives of that base pink color). The design includes a light icon on a dark background to keep the focus on the icon and category of that article.
+This design also leaves room to add more categories if desired. Ideally, the icons are two-toned, with a singular color for each design. The core colors are from our [color palette](/story/design-colors--page), but the entire range of each color can be used, including values that may not be visibly included on that page (the pinks in the gauge example are not shown on our color palette page, but are derivatives of that base pink color). The design includes a light icon on a dark background to keep the focus on the icon and category of that article.
 
 The captions below each fallback image aren't set in stone, more so just ideas that these designs could be used for.
 

--- a/src/design/icons/icons.stories.mdx
+++ b/src/design/icons/icons.stories.mdx
@@ -44,7 +44,7 @@ const brandIconElements = brandIconDir.keys().map((key) => {
 
 Our icons are designed to be compact yet friendly. They embrace bold shapes, rounded corners and circular caps. They work well adjacent to text, but should rarely be used on their own to convey meaning.
 
-For icon usage examples, see [the icon object](/?path=/docs/components-icon--basic).
+For icon usage examples, see [the icon object](/docs/components-icon--basic).
 
 <IconGallery>{iconElements}</IconGallery>
 

--- a/src/design/modular-scale.stories.mdx
+++ b/src/design/modular-scale.stories.mdx
@@ -32,7 +32,7 @@ for (let i = minimumStep; i <= maximumStep; i++) {
 
 # Modular Scale
 
-Most typographic and whitespace measurements in our patterns are based on steps of [our modular scale](/?path=/docs/design-tokens-modular-scale--page). This has several benefits for text-heavy projects like ours:
+Most typographic and whitespace measurements in our patterns are based on steps of [our modular scale](/docs/design-tokens-modular-scale--page). This has several benefits for text-heavy projects like ours:
 
 - Encourages designers to think in terms of relative proportion rather than hard-set sizes, which makes patterns more versatile in responsive designs.
 - Minimizes loss of text alignment in complex layouts.

--- a/src/design/typography/typography.stories.mdx
+++ b/src/design/typography/typography.stories.mdx
@@ -26,7 +26,7 @@ This section is currently a work in progress.
   <Story name="Paragraphs">{paragraphsDemo}</Story>
 </Canvas>
 
-Blockquote children get some default spacing. For finer control of this spacing, use [the rhythm object](/?path=/docs/objects-rhythm--default-story).
+Blockquote children get some default spacing. For finer control of this spacing, use [the rhythm object](/docs/objects-rhythm--default-story).
 
 <Canvas>
   <Story name="Blockquote">{blockquoteDemo}</Story>
@@ -41,7 +41,7 @@ Blockquote children get some default spacing. For finer control of this spacing,
   <Story name="Description List">{descriptionListDemo}</Story>
 </Canvas>
 
-A default code block element is demonstrated below. To see this pattern with syntax highlighting applied, refer to [our Prism theme](/?path=/docs/vendor-prism--css).
+A default code block element is demonstrated below. To see this pattern with syntax highlighting applied, refer to [our Prism theme](/docs/vendor-prism--css).
 
 <Canvas>
   <Story name="Code Block">{codeBlockDemo}</Story>

--- a/src/objects/bunch/bunch.stories.mdx
+++ b/src/objects/bunch/bunch.stories.mdx
@@ -27,7 +27,7 @@ const avatarsDemoStory = (args) => {
 
 # Bunch
 
-A tight cluster of visual elements with a small amount of overlap. Useful for displaying [avatars](/?path=/docs/components-avatar--empty) alongside bylines where multiple authors are equally credited.
+A tight cluster of visual elements with a small amount of overlap. Useful for displaying [avatars](/docs/components-avatar--empty) alongside bylines where multiple authors are equally credited.
 
 <Canvas>
   <Story name="Of avatars">{avatarsDemoStory.bind({})}</Story>

--- a/src/objects/container/container.stories.mdx
+++ b/src/objects/container/container.stories.mdx
@@ -72,4 +72,4 @@ Modifiers may be added to apply a consistent amount of responsive padding to con
 - `o-container--pad-block`: Adds vertical padding.
 - `o-container--pad-inline`: Adds horizontal padding.
 
-Custom padding amounts may be applied through the use of [padding utilities](/?path=/docs/utilities-spacing--padding).
+Custom padding amounts may be applied through the use of [padding utilities](/docs/utilities-spacing--padding).

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -43,7 +43,7 @@ const articlesStory = (args) => articlesDemo({ items: articles, ...args });
 
 # Deck
 
-What do you call a group of multiple [Cards](/?path=/docs/components-card--content-blocks)?
+What do you call a group of multiple [Cards](/docs/components-card--content-blocks)?
 
 A “stack” of cards? Sure, but that may imply verticality…
 
@@ -61,7 +61,7 @@ By default, the `o-deck` class will use CSS Grid Layout to arrange child element
 
 While automatic columns are convenient, there are times when a specific column count is desired. For example, you may want to limit a design to three columns at larger breakpoints to align with adjacent elements.
 
-To do this, add a modifier class in the format of `o-deck--X-column@Y`, where `X` is the desired column count (from 2 to 3) and `Y` is the desired [breakpoint](/?path=/docs/design-tokens-breakpoint--page) (from `s` to `xl`). In this example, we force the grid to display three columns starting from the `m` breakpoint.
+To do this, add a modifier class in the format of `o-deck--X-column@Y`, where `X` is the desired column count (from 2 to 3) and `Y` is the desired [breakpoint](/docs/design-tokens-breakpoint--page) (from `s` to `xl`). In this example, we force the grid to display three columns starting from the `m` breakpoint.
 
 <Canvas>
   <Story
@@ -78,7 +78,7 @@ To do this, add a modifier class in the format of `o-deck--X-column@Y`, where `X
 
 ## With Horizontal Cards
 
-[Horizontal cards](/?path=/docs/components-card--content-blocks#horizontal) will automatically span all available columns.
+[Horizontal cards](/docs/components-card--content-blocks#horizontal) will automatically span all available columns.
 
 <Canvas>
   <Story

--- a/src/objects/embed/embed.stories.mdx
+++ b/src/objects/embed/embed.stories.mdx
@@ -30,7 +30,7 @@ Specifying aspect ratios for imagery and embedded media is important to prevent 
 
 Embed objects support two methods for specifying the desired aspect ratio:
 
-1. Via a modifier class. All of our [aspect ratio tokens](/?path=/docs/design-tokens-aspect-ratio--page) are supported. Example: `o-embed--wide`
+1. Via a modifier class. All of our [aspect ratio tokens](/docs/design-tokens-aspect-ratio--page) are supported. Example: `o-embed--wide`
 1. Via the `--aspect-ratio` custom property. This can be helpful for one-off images in articles or other content that do not conform to a typical size. Example: `--aspect-ratio: 320/480`
 
 ## Basic Examples
@@ -67,7 +67,7 @@ Embed objects support two methods for specifying the desired aspect ratio:
 
 ## Rounded
 
-Embeds may be combined with [rounded corner utilities](/?path=/docs/utilities-rounded-corners--sizes). In this example, a square embed becomes circular thanks to `u-rounded-full`.
+Embeds may be combined with [rounded corner utilities](/docs/utilities-rounded-corners--sizes). In this example, a square embed becomes circular thanks to `u-rounded-full`.
 
 <Canvas>
   <Story name="Rounded">
@@ -83,7 +83,7 @@ Embeds may be combined with [rounded corner utilities](/?path=/docs/utilities-ro
 
 An additional benefit of modifier classes is support for breakpoint-specific ratios. This can be helpful for interactive embeds (CodePen, etc.) or simply for art direction.
 
-In this example, the aspect ratio starts square but becomes wider with each successive breakpoint. All [breakpoint tokens](/?path=/docs/design-tokens-breakpoint--page) are supported.
+In this example, the aspect ratio starts square but becomes wider with each successive breakpoint. All [breakpoint tokens](/docs/design-tokens-breakpoint--page) are supported.
 
 <Canvas>
   <Story

--- a/src/objects/media/media.stories.mdx
+++ b/src/objects/media/media.stories.mdx
@@ -55,7 +55,7 @@ The order of `o-media__object` and `o-media__content` will not affect this patte
 
 ## Checkbox Label
 
-In this example, `o-media` is applied to a `<label>` element, `o-media__object` to [a Checkbox component](/?path=/docs/components-checkbox--enabled), and `o-media__content` to a `<span>`.
+In this example, `o-media` is applied to a `<label>` element, `o-media__object` to [a Checkbox component](/docs/components-checkbox--enabled), and `o-media__content` to a `<span>`.
 
 <Canvas>
   <Story name="Checkbox Label">{checkboxDemo}</Story>
@@ -63,7 +63,7 @@ In this example, `o-media` is applied to a `<label>` element, `o-media__object` 
 
 ## Event Summary
 
-In this example, the object is [a Calendar Date component](/?path=/docs/components-calendar-date--basic). Even though it's included _after_ the heading to promote a sensible document outline, it still visually precedes the content.
+In this example, the object is [a Calendar Date component](/docs/components-calendar-date--basic). Even though it's included _after_ the heading to promote a sensible document outline, it still visually precedes the content.
 
 <Canvas>
   <Story name="Event Summary">{calendarDateDemo}</Story>

--- a/src/utilities/rounded/rounded.stories.mdx
+++ b/src/utilities/rounded/rounded.stories.mdx
@@ -10,7 +10,7 @@ Utilities for controlling the `border-radius` of an element.
 
 ## Sizes
 
-`u-rounded` applies the default rounded corner size, as seen in components like [Button](/?path=/docs/components-button--elements) and [Input](/?path=/docs/components-input--text-elements).
+`u-rounded` applies the default rounded corner size, as seen in components like [Button](/docs/components-button--elements) and [Input](/docs/components-input--text-elements).
 
 `u-rounded-full` applies as much rounding as possible evenly. This results in circular or pill-shaped elements.
 

--- a/src/utilities/spacing/spacing.stories.mdx
+++ b/src/utilities/spacing/spacing.stories.mdx
@@ -66,7 +66,7 @@ The following utilities pad the _inside_ of the element:
 - `u-pad-inline-start-{amount}`
 - `u-pad-inline-end-{amount}`
 
-`{amount}` may be a step of [our modular scale](/?path=/docs/design-modular-scale--page) or `none`.
+`{amount}` may be a step of [our modular scale](/docs/design-modular-scale--page) or `none`.
 
 <Canvas>
   <Story name="Padding" argTypes={{ step: stepArg }}>
@@ -86,7 +86,7 @@ The following utilities apply space _outside_ the element:
 - `u-space-inline-start-{amount}`
 - `u-space-inline-end-{amount}`
 
-`{amount}` may be a step of [our modular scale](/?path=/docs/design-modular-scale--page), `auto` or `none`.
+`{amount}` may be a step of [our modular scale](/docs/design-modular-scale--page), `auto` or `none`.
 
 <Canvas>
   <Story name="Margin" argTypes={{ step: stepArg }}>
@@ -94,7 +94,7 @@ The following utilities apply space _outside_ the element:
   </Story>
 </Canvas>
 
-To add consistent spacing between adjacent block elements, see [the rhythm object](/?path=/docs/objects-rhythm--default-story).
+To add consistent spacing between adjacent block elements, see [the rhythm object](/docs/objects-rhythm--default-story).
 
 ## Negative Margin
 
@@ -108,7 +108,7 @@ The following utilities _pull_ an element one direction or another by applying a
 - `u-pull-inline-start-{amount}`
 - `u-pull-inline-end-{amount}`
 
-`{amount}` may be a step of [our modular scale](/?path=/docs/design-modular-scale--page).
+`{amount}` may be a step of [our modular scale](/docs/design-modular-scale--page).
 
 <Canvas>
   <Story name="Negative Margin">

--- a/src/vendor/wordpress/gutenberg.stories.mdx
+++ b/src/vendor/wordpress/gutenberg.stories.mdx
@@ -244,7 +244,7 @@ The file block allows downloading or opening media or page attachment content.
 This block creates a parent `div` with a `wp-block-file` class name, which
 wraps a single `a` element. The Gutenberg editor allows file downloads to be
 displayed as buttons (`wp-block-file__button`) or text-only links. Our CSS
-styles both configurations as [buttons](/?path=/docs/components-button--elements).
+styles both configurations as [buttons](/docs/components-button--elements).
 
 The `c-button--secondary` and `c-button-tertiary` class names can be added to the file block's "Advanced → Additional CSS class(es)" input, to output additional button styles.
 


### PR DESCRIPTION
## Overview

This fixes broken links in the documentation.

## Testing

Before: https://v-next--cloudfour-patterns.netlify.app/
After: https://deploy-preview-1248--cloudfour-patterns.netlify.app/

1. Browse around and confirm links are working

---

- Closes #1247 