### PR TITLE
Make sure a fresh z-index is set for o-bunch

### DIFF
--- a/.changeset/rude-singers-hope.md
+++ b/.changeset/rude-singers-hope.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix for potential z-index issue with Bunch in certain containers

--- a/src/objects/bunch/bunch.scss
+++ b/src/objects/bunch/bunch.scss
@@ -7,7 +7,10 @@
  * 2. Ideally this component won't be over-stuffed, but just in case, let's
  *    wrap children if there are too many of them or they're too big.
  * 3. Keeps z-index values of child elements relative to this to avoid
- *    disrupting outside stacking order.
+ *    disrupting outside stacking order. We shouldn't have to set a base
+ *    `z-index` as well, but some browsers don't establish a new stacking order
+ *    without this, which can cause children to display beneath outside
+ *    elements.
  */
 
 .o-bunch {
@@ -15,6 +18,7 @@
   display: flex;
   flex-wrap: wrap; /* 2 */
   position: relative; /* 3 */
+  z-index: 0; /* 3 */
 }
 
 /**


### PR DESCRIPTION
## Overview

Sets `z-index: 0` on `.o-bunch` so its children won't display beneath outside elements in Chrome.

## Screenshots

<img width="1637" alt="Screen Shot 2021-06-01 at 1 58 28 PM" src="https://user-images.githubusercontent.com/69633/120390004-05c31300-c2e2-11eb-9835-f2afe1c833a2.png">

## Testing

[Test `o-bunch` in deploy preview](https://deploy-preview-1255--cloudfour-patterns.netlify.app/?path=/docs/objects-bunch--of-avatars#bunch)

---

- Fixes #1243 

