### PR TITLE
Support Twig highlights in Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,12 +1,17 @@
 import { Parser } from 'html-to-react';
 import { withPaddings } from 'storybook-addon-paddings';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+import ReactSyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
+import twig from 'react-syntax-highlighter/dist/esm/languages/prism/twig';
 import { withTheme } from './theme-decorator';
 import tokens from '../src/compiled/tokens/js/tokens';
 import 'focus-visible';
 import '../src/index-with-dependencies.scss';
 import './preview.scss';
 const breakpoints = tokens.size.breakpoint;
+
+// Extend the languages Storybook will highlight
+ReactSyntaxHighlighter.registerLanguage('twig', twig);
 
 // Padding values from modular scale
 const paddings = { values: [], default: 'Step 0' };

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "postcss-media-minmax": "5.0.0",
         "prettier": "2.3.0",
         "raw-loader": "4.0.2",
+        "react-syntax-highlighter": "^13.5.3",
         "remark-preset-lint-recommended": "5.0.0",
         "remark-preset-prettier": "0.4.1",
         "resolve": "1.20.0",
@@ -23008,47 +23009,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/escodegen": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-      "dev": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/jsdom/node_modules/estraverse": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/jsdom/node_modules/tough-cookie": {
@@ -59053,32 +59013,6 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
           "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
           "dev": true
-        },
-        "escodegen": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
-          "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
-          "dev": true,
-          "requires": {
-            "esprima": "^4.0.1",
-            "estraverse": "^5.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
         },
         "tough-cookie": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "postcss-media-minmax": "5.0.0",
     "prettier": "2.3.0",
     "raw-loader": "4.0.2",
+    "react-syntax-highlighter": "^13.5.3",
     "remark-preset-lint-recommended": "5.0.0",
     "remark-preset-prettier": "0.4.1",
     "resolve": "1.20.0",


### PR DESCRIPTION
## Overview

Storybook's kind of weird. It seems to use tree-shaking to dynamically include highlight language definitions for doc blocks, but not for code blocks specified via Markdown. Thankfully, they're using a well-documented library for code definitions, so I was able to extend that from our `preview.js`.

With this change, any Twig blocks in our docs should receive syntax highlighting.

## Screenshots

Before:
<img width="1044" alt="Screen Shot 2021-06-01 at 4 20 23 PM" src="https://user-images.githubusercontent.com/69633/120401899-cc949e00-c2f5-11eb-9d7b-89d76a2d05dd.png">

After:
<img width="1032" alt="Screen Shot 2021-06-01 at 4 19 30 PM" src="https://user-images.githubusercontent.com/69633/120401913-d3231580-c2f5-11eb-98be-8588c22fe4b5.png">

## Testing

Try adding a Markdown code block with the language `twig` to any `.stories.mdx` file.

---

- Related to #1004 and #1240

/CC @gerardo-rodriguez 
