### PR TITLE
paddings.disabled → paddings.disable

### DIFF
--- a/src/components/cloud-cover/cloud-cover.stories.mdx
+++ b/src/components/cloud-cover/cloud-cover.stories.mdx
@@ -9,7 +9,7 @@ import robotImage from './demo/robot.svg';
   title="Components/Cloud Cover"
   parameters={{
     docs: { inlineStories: false },
-    paddings: { disabled: true },
+    paddings: { disable: true },
     themes: { disable: true },
   }}
 />

--- a/src/components/ground-nav/ground-nav.stories.mdx
+++ b/src/components/ground-nav/ground-nav.stories.mdx
@@ -66,7 +66,7 @@ embedded examples.
 
 <Meta
   title="Components/Ground Nav"
-  parameters={{ docs: { inlineStories: false }, paddings: { disabled: true } }}
+  parameters={{ docs: { inlineStories: false }, paddings: { disable: true } }}
 />
 
 # Ground Nav

--- a/src/objects/container/container.stories.mdx
+++ b/src/objects/container/container.stories.mdx
@@ -24,7 +24,7 @@ embedded examples.
 
 <Meta
   title="Objects/Container"
-  parameters={{ docs: { inlineStories: false }, paddings: { disabled: true } }}
+  parameters={{ docs: { inlineStories: false }, paddings: { disable: true } }}
   argTypes={{
     prose: {
       control: {

--- a/src/objects/page/page.stories.mdx
+++ b/src/objects/page/page.stories.mdx
@@ -4,7 +4,7 @@ import exampleDemo from './demo/example.twig';
 
 <Meta
   title="Objects/Page"
-  parameters={{ docs: { inlineStories: false }, paddings: { disabled: true } }}
+  parameters={{ docs: { inlineStories: false }, paddings: { disable: true } }}
 />
 
 # Page

--- a/src/prototypes/articles/articles.stories.js
+++ b/src/prototypes/articles/articles.stories.js
@@ -8,7 +8,7 @@ export default {
   title: 'Prototypes/Articles',
   parameters: {
     docs: { page: null },
-    paddings: { disabled: true },
+    paddings: { disable: true },
   },
 };
 

--- a/src/prototypes/card-variations/card-variations.stories.js
+++ b/src/prototypes/card-variations/card-variations.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Prototypes/Card Variations',
   parameters: {
     docs: { page: null },
-    paddings: { disabled: true },
+    paddings: { disable: true },
   },
 };
 

--- a/src/prototypes/cloud-divider/clouds.stories.js
+++ b/src/prototypes/cloud-divider/clouds.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Prototypes/Clouds',
   parameters: {
     docs: { page: null },
-    paddings: { disabled: true },
+    paddings: { disable: true },
   },
 };
 

--- a/src/prototypes/comment-thread/thread.stories.js
+++ b/src/prototypes/comment-thread/thread.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Prototypes/Comment Thread',
   parameters: {
     docs: { page: null },
-    paddings: { disabled: true },
+    paddings: { disable: true },
   },
 };
 


### PR DESCRIPTION
## Overview

I noticed while reviewing #1259 that the `paddings.disabled` attribute wasn't working. Then I noticed it had stopped working on several stories.

It looks like [the add-on we're using](https://github.com/rbardini/storybook-addon-paddings) updated the property at some point (which is more consistent with other add-ons now), so this PR updates the property key accordingly. 

## Testing

View affected stories on deploy preview, confirm that in canvas view they have no additional padding visible (meet the edge of the canvas).
