### PR TITLE
Add pseudo states add-on

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -20,6 +20,7 @@ module.exports = {
     '@storybook/addon-a11y',
     'storybook-mobile',
     'storybook-addon-paddings',
+    'storybook-addon-pseudo-states',
     '@whitespace/storybook-addon-html',
     '@storybook/addon-postcss',
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "sass": "1.34.0",
         "sass-loader": "10.2.0",
         "storybook-addon-paddings": "4.0.0",
+        "storybook-addon-pseudo-states": "^1.0.0",
         "storybook-mobile": "0.1.31",
         "style-dictionary": "2.10.3",
         "style-loader": "2.0.0",
@@ -33263,6 +33264,29 @@
         "@storybook/theming": "^6.1.10",
         "core-js": "^3.6.5",
         "memoizerific": "^1.11.3"
+      }
+    },
+    "node_modules/storybook-addon-pseudo-states": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-1.0.0.tgz",
+      "integrity": "sha512-pRbPB/L2IB5jFX2snE3qS+/Fhsb9vej/s30opUgD+vrUTShvatUHJpajI5cDOxT6Gape6YWKg06/L75OW2vu/g==",
+      "dev": true,
+      "peerDependencies": {
+        "@storybook/addons": "^6.1.14",
+        "@storybook/api": "^6.1.14",
+        "@storybook/components": "^6.1.14",
+        "@storybook/core-events": "^6.1.14",
+        "@storybook/theming": "^6.1.14",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/storybook-mobile": {
@@ -67665,6 +67689,13 @@
         "core-js": "^3.6.5",
         "memoizerific": "^1.11.3"
       }
+    },
+    "storybook-addon-pseudo-states": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-pseudo-states/-/storybook-addon-pseudo-states-1.0.0.tgz",
+      "integrity": "sha512-pRbPB/L2IB5jFX2snE3qS+/Fhsb9vej/s30opUgD+vrUTShvatUHJpajI5cDOxT6Gape6YWKg06/L75OW2vu/g==",
+      "dev": true,
+      "requires": {}
     },
     "storybook-mobile": {
       "version": "0.1.31",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "sass": "1.34.0",
     "sass-loader": "10.2.0",
     "storybook-addon-paddings": "4.0.0",
+    "storybook-addon-pseudo-states": "^1.0.0",
     "storybook-mobile": "0.1.31",
     "style-dictionary": "2.10.3",
     "style-loader": "2.0.0",


### PR DESCRIPTION
## Overview

Adds [storybook-addon-pseudo-states](https://storybook.js.org/addons/storybook-addon-pseudo-states), a rather magical add-on that spoofs pseudo states dynamically, allowing you to toggle various pseudo states in Storybook.

It isn't perfect. There's no API for toggling dev tools pseudo states, so it works by rewriting pseudo classes on the fly and re-applying those styles. This means it doesn't work for things like our `focus-visible` polyfill, because that's not using pseudo elements in the same way. (But that may be worth reconsidering in the future anyway.) But I believe I would find it very helpful for prototyping in the short-term, for documenting (or even testing?) designs in the long-term.

## Screenshots

![pseudo](https://user-images.githubusercontent.com/69633/120867108-1a074a00-c546-11eb-96cb-ab905e1d8791.gif)
