### PR TITLE
Add c-card--contained modifier

### DIFF
--- a/.changeset/swift-avocados-worry.md
+++ b/.changeset/swift-avocados-worry.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add `c-card--contained` modifier

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -67,7 +67,7 @@ $_focus-overflow: (size.$edge-large * -1);
 }
 
 .c-card--contained {
-  border-radius: 0.375em;
+  border-radius: size.$border-radius-large;
   padding: ms.step(1);
 
   @include theme.unthemed-styles() {

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -10,6 +10,7 @@
 @use '../../mixins/media-query';
 @use '../../mixins/ms';
 @use '../../mixins/ratio-box';
+@use '../../mixins/theme';
 
 /// We can't use `grid-gap` exclusively due to some containers only being
 /// present some of the time, so we re-use this value to define the space
@@ -63,6 +64,15 @@ $_focus-overflow: (size.$edge-large * -1);
     size.$spacing-gap-fluid-min,
     size.$spacing-gap-fluid-max
   ); /* 3 */
+}
+
+.c-card--contained {
+  border-radius: 0.375em;
+  padding: ms.step(1);
+
+  @include theme.unthemed-styles() {
+    background-color: var(--theme-color-background-secondary);
+  }
 }
 
 /**
@@ -154,6 +164,17 @@ $_focus-overflow: (size.$edge-large * -1);
     right: $_focus-overflow;
     top: $_focus-overflow;
     z-index: 1;
+
+    /**
+     * Do not overflow when the card's edges are distinct
+     */
+
+    .c-card--contained & {
+      bottom: 0;
+      left: 0;
+      right: 0;
+      top: 0;
+    }
   }
 
   /**

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -4,6 +4,7 @@ const singleDemoStory = (args) => {
   const props = {
     href: args.href,
   };
+  const classNames = [];
   const modifiers = [];
   if (args.show.length > 0) {
     for (const block of args.show) {
@@ -13,8 +14,17 @@ const singleDemoStory = (args) => {
   if (args.horizontal !== 'none') {
     modifiers.push(`horizontal${args.horizontal}`);
   }
+  if (args.contained) {
+    modifiers.push('contained');
+  }
   if (modifiers.length > 0) {
-    props.class = modifiers.map((modifier) => `c-card--${modifier}`).join(' ');
+    classNames.push(...modifiers.map((modifier) => `c-card--${modifier}`));
+  }
+  if (args.theme !== 'none') {
+    classNames.push(`t-${args.theme}`);
+  }
+  if (classNames.length > 0) {
+    props.class = classNames.join(' ');
   }
   return singleDemo(props);
 };
@@ -33,6 +43,12 @@ const singleDemoStory = (args) => {
     horizontal: {
       type: { name: 'string' },
       control: { type: 'inline-radio', options: ['none', '@m', '@l', '@xl'] },
+      defaultValue: 'none',
+    },
+    contained: { type: { name: 'boolean' } },
+    theme: {
+      type: { name: 'string' },
+      control: { type: 'inline-radio', options: ['none', 'light', 'dark'] },
       defaultValue: 'none',
     },
   }}
@@ -92,7 +108,32 @@ If a card with a cover is meant to occupy its full container width, it may be pr
 
 Horizontal cards will attempt to span all available columns of a CSS Grid Layout. This comes in handy when displaying them [in a Deck](/docs/objects-deck--horizontal-card#with-horizontal-cards).
 
+## Contained
+
+A card with the `c-card--contained` class will gain a background color, padding and rounded corners. This can be helpful for offsetting the card visually from its surroundings.
+
+<Canvas>
+  <Story
+    name="Contained"
+    args={{ href: '#', horizontal: '@m', contained: true }}
+  >
+    {singleDemoStory.bind({})}
+  </Story>
+</Canvas>
+
+When the card is a focal point and more contrast is desired, you may also attach a [theme class](/docs/design-themes--light) to the card. In this example, the card has a class of `t-light` within a `t-dark` container:
+
+<Canvas>
+  <Story
+    name="Themed"
+    parameters={{ theme: 't-dark' }}
+    args={{ href: '#', horizontal: '@m', contained: true, theme: 'light' }}
+  >
+    {singleDemoStory.bind({})}
+  </Story>
+</Canvas>
+
 ## Coming soon
 
 - Progressive enhancement based on CSS Grid support
-- Contained and themed cards for PWA Stats use case
+- Distinctly contained footers for PWA Stats (if necessary)

--- a/src/design/demo/theme.twig
+++ b/src/design/demo/theme.twig
@@ -5,9 +5,15 @@
     <h1>t-{{theme}}</h1>
     {% include '@cloudfour/design/typography/demo/inline-elements.twig' only %}
     {% include '@cloudfour/components/button/demo/styles.twig' only %}
-    {# TODO: Replace padding and corner modifiers once card component can
-        handle these variations natively #}
-    {% set _card_class = 'c-card--horizontal@m u-pad-1 u-rounded' %}
+    {% set _card_class = 'c-card--horizontal@m c-card--contained' %}
+    {% include '@cloudfour/components/card/demo/single.twig' with {
+      class: _card_class,
+      href: '#',
+      show_heading: true,
+      show_content: true,
+      show_cover: true,
+      show_footer: true
+    } only %}
     {% if theme == 'light' %}
       {% set _card_class = _card_class ~ ' t-dark' %}
     {% else %}

--- a/src/mixins/_theme.scss
+++ b/src/mixins/_theme.scss
@@ -36,6 +36,16 @@ $default-theme: light;
   }
 }
 
+/// Apply these styles only if this element is a container without an explicit
+/// theme. Useful for patterns that are only optionally a container, such as
+/// 'c-card'.
+/// @content
+@mixin unthemed-styles() {
+  &:not([class^='t-']):not([class*=' t-']) {
+    @content;
+  }
+}
+
 /// Establish the minimal rules needed for a theme's root element, specifically
 /// a `background-color` and default text color. Without this, the theme root
 /// won't be visually offset from its parent and its contents may not be very

--- a/src/tokens/size/border.json
+++ b/src/tokens/size/border.json
@@ -4,6 +4,7 @@
       "radius": {
         "small": { "value": "0.125em" },
         "medium": { "value": "0.25em" },
+        "large": { "value": "0.5em" },
         "full": {
           "value": "9999px",
           "comment": "A value of 50% would be more intuitive, but results in unexpectedly oblong rounding for non-square shapes. We use `px` to save the browser the trouble of recalculating the stupidly large value."


### PR DESCRIPTION
## Overview

- Adds `c-card--contained` modifier, giving cards distinct boundaries to offset them from their containing element.
- Adds an `unthemed-styles` mixin to define styles that should apply only when a theme class is not directly attached to the element.

This PR does _not_ include the distinctly separated footer from the rest of the card contents. I realized partway into this task that making this happen would represent 95% of the effort, but that design detail is only present on PWA Stats. Because there's another issue blocked by this and many more directly related to our short-term goals, it felt odd to spend many more hours (if not days) refactoring for this design detail we wouldn't use right away. I plan to create another issue to address that detail at a later date.

## Screenshots

![Screenshot 2021-06-07 at 14-26-36 Storybook](https://user-images.githubusercontent.com/69633/121090382-5ed8ee00-c79d-11eb-8b9f-9dae6cb5c20e.png)

![Screenshot 2021-06-07 at 14-25-56 Storybook](https://user-images.githubusercontent.com/69633/121090384-60a2b180-c79d-11eb-8a70-dc56acea42eb.png)

## Testing

[Deploy preview](https://deploy-preview-1287--cloudfour-patterns.netlify.app/?path=/docs/components-card--contained#contained)

---

- Fixes #1283 