### PR TITLE
Gutenberg corners

### DIFF
--- a/.changeset/hot-bees-relate.md
+++ b/.changeset/hot-bees-relate.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Add border radius to Gutenberg Groups styles when the has-background class is present

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -67,7 +67,7 @@ $_focus-overflow: (size.$edge-large * -1);
 }
 
 .c-card--contained {
-  border-radius: size.$border-radius-large;
+  border-radius: size.$border-radius-card-contained;
   padding: ms.step(1);
 
   @include theme.unthemed-styles() {

--- a/src/tokens/size/border.json
+++ b/src/tokens/size/border.json
@@ -5,6 +5,10 @@
         "small": { "value": "0.125em" },
         "medium": { "value": "0.25em" },
         "large": { "value": "0.5em" },
+        "card-contained": {
+          "value": "{size.border.radius.large.value}",
+          "comment": "Current value for the contained cards."
+        },
         "full": {
           "value": "9999px",
           "comment": "A value of 50% would be more intuitive, but results in unexpectedly oblong rounding for non-square shapes. We use `px` to save the browser the trouble of recalculating the stupidly large value."

--- a/src/tokens/size/border.json
+++ b/src/tokens/size/border.json
@@ -5,10 +5,7 @@
         "small": { "value": "0.125em" },
         "medium": { "value": "0.25em" },
         "large": { "value": "0.5em" },
-        "card-contained": {
-          "value": "{size.border.radius.large.value}",
-          "comment": "Current value for the contained cards."
-        },
+        "card-contained": { "value": "{size.border.radius.large.value}" },
         "full": {
           "value": "9999px",
           "comment": "A value of 50% would be more intuitive, but results in unexpectedly oblong rounding for non-square shapes. We use `px` to save the browser the trouble of recalculating the stupidly large value."

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -266,14 +266,14 @@ $wp-button-gap: size.$spacing-list-inline-gap;
 
 .wp-block-group.has-background {
   border-radius: size.$border-radius-card-contained; /* 1 */
-}
 
-.wp-block-group.has-background.alignfull {
-  border-radius: 0; /* 2 */
-}
+  &.alignfull {
+    border-radius: 0; /* 2 */
+  }
 
-.wp-block-group.has-background.alignwide {
-  @media (max-width: breakpoint.$l) {
-    border-radius: 0; /* 3 */
+  &.alignwide {
+    @media (max-width: breakpoint.$l) {
+      border-radius: 0; /* 3 */
+    }
   }
 }

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -271,5 +271,7 @@ $wp-button-gap: size.$spacing-list-inline-gap;
 }
 
 .wp-block-group.has-background.alignwide {
-  border-radius: 0; /* 2 */
+  @media (max-width: breakpoint.$l) {
+    border-radius: 0; /* 2 */
+  }
 }

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -251,3 +251,12 @@ $wp-button-gap: size.$spacing-list-inline-gap;
   line-height: size.$height-control-multiline; /* 1 */
   padding: size.$padding-control-vertical 0;
 }
+
+/**
+ * Groups
+ * Rounds the corners for groups when the has-background class is applied.
+ */
+
+.wp-block-group.has-background {
+  border-radius: size.$border-radius-large;
+}

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -263,7 +263,7 @@ $wp-button-gap: size.$spacing-list-inline-gap;
  */
 
 .wp-block-group.has-background {
-  border-radius: size.$border-radius-large; /* 1 */
+  border-radius: size.$border-radius-card-contained; /* 1 */
 }
 
 .wp-block-group.has-background.alignfull {

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -255,8 +255,21 @@ $wp-button-gap: size.$spacing-list-inline-gap;
 /**
  * Groups
  * Rounds the corners for groups when the has-background class is applied.
+ * 1. This value is added to keep the Cloud Four card containers and
+ * the Gutenberg styles consistent.
+ * 2. When the classes alignfull or alignwide are applied with these classes
+ * the border radius will go back to 0 to keep the corners flesh with the edge
+ * of the page.
  */
 
 .wp-block-group.has-background {
-  border-radius: size.$border-radius-large;
+  border-radius: size.$border-radius-large; /* 1 */
+}
+
+.wp-block-group.has-background.alignfull {
+  border-radius: 0; /* 2 */
+}
+
+.wp-block-group.has-background.alignwide {
+  border-radius: 0; /* 2 */
 }

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -257,9 +257,11 @@ $wp-button-gap: size.$spacing-list-inline-gap;
  * Rounds the corners for groups when the has-background class is applied.
  * 1. This value is added to keep the Cloud Four card containers and
  * the Gutenberg styles consistent.
- * 2. When the classes alignfull or alignwide are applied with these classes
- * the border radius will go back to 0 to keep the corners flesh with the edge
- * of the page.
+ * 2. When the alignfull class is applied the border radius will go
+ * back to 0 to keep the corners flesh with the edge of the page.
+ * 3. The alignwide class will have the border-radius set to 0 until it hits
+ * the large breakpoint because at that point, it no longer sits along the
+ * edge of the screen. It's intended to be applied within a container.
  */
 
 .wp-block-group.has-background {
@@ -272,6 +274,6 @@ $wp-button-gap: size.$spacing-list-inline-gap;
 
 .wp-block-group.has-background.alignwide {
   @media (max-width: breakpoint.$l) {
-    border-radius: 0; /* 2 */
+    border-radius: 0; /* 3 */
   }
 }


### PR DESCRIPTION
## Overview

This PR adds a border-radius to the Gutenberg Group styles when `has-background` class is present.


## Screenshots

<img width="1144" alt="Screen Shot 2021-06-09 at 11 52 10 AM" src="https://user-images.githubusercontent.com/24928337/121412053-2100d480-c919-11eb-87ce-a4ea86055fdb.png">

## Testing

1. [Deploy link](https://deploy-preview-1297--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-gutenberg--core-group)

---

- Fixes https://github.com/cloudfour/cloudfour.com-patterns/issues/1269

