### PR TITLE
Add dynamic toggle icon button prototype

### DIFF
--- a/src/prototypes/buttons/buttons.stories.js
+++ b/src/prototypes/buttons/buttons.stories.js
@@ -1,0 +1,11 @@
+import toggleIconsPrototype from './toggle-icons.twig';
+import './toggle-icons.scss';
+
+export default {
+  title: 'Prototypes/Buttons',
+  parameters: {
+    docs: { page: null },
+  },
+};
+
+export const ToggleIcons = () => toggleIconsPrototype({});

--- a/src/prototypes/buttons/toggle-icons.scss
+++ b/src/prototypes/buttons/toggle-icons.scss
@@ -1,0 +1,59 @@
+@use '../../compiled/tokens/scss/size';
+@use '../../mixins/ms';
+
+#tcs-button-toggle-icons {
+  .c-button {
+    align-items: center;
+    display: inline-flex;
+    vertical-align: middle;
+  }
+
+  .c-button__extra {
+    display: flex;
+    font-size: ms.step(1);
+    margin: 0 ms.step(-4);
+    position: relative;
+
+    &:first-child {
+      margin-left: ms.step(-4) * -1;
+    }
+
+    &:last-child {
+      margin-right: ms.step(-4) * -1;
+    }
+
+    &::after {
+      background: currentColor;
+      border-radius: size.$border-radius-full;
+      content: '';
+      height: size.$edge-medium;
+      left: 0;
+      position: absolute;
+      transform: rotate(-30deg);
+      top: 50%;
+      width: 100%;
+    }
+
+    $clip-path: polygon(
+      -5% -5%,
+      105% -5%,
+      105% 23%,
+      -5% 87%,
+      -5% 101.4711%,
+      105% 37.9626%,
+      105% 105%,
+      -5% 105%
+    );
+
+    & > * {
+      clip-path: $clip-path;
+      height: 100%;
+      transform: translate(0, 0);
+      width: 100%;
+
+      @supports (clip-path: view-box) {
+        clip-path: view-box $clip-path;
+      }
+    }
+  }
+}

--- a/src/prototypes/buttons/toggle-icons.twig
+++ b/src/prototypes/buttons/toggle-icons.twig
@@ -1,0 +1,27 @@
+<div id="tcs-button-toggle-icons">
+  <button class="c-button">
+    <span class="c-button__content">
+      Content only
+    </span>
+  </button>
+  <button class="c-button">
+    <span class="c-button__extra">
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'notifications'
+      } only %}
+    </span>
+    <span class="c-button__content">
+      With start
+    </span>
+  </button>
+  <button class="c-button">
+    <span class="c-button__content">
+      With end
+    </span>
+    <span class="c-button__extra">
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'notifications'
+      } only %}
+    </span>
+  </button>
+</div>


### PR DESCRIPTION
## Overview

This PR introduces a prototype of how dynamic toggle icons should look within toggle buttons. It is intended to be a point of reference for #1094 and #1298.

If this PR's designs are reflected in #1298 prior to this PR's approval, it can be safely closed. Because this applies prototype styles to `.c-button` classes directly, it is likely to break eventually anyway, so no need to be precious with it.

Some changes from what is in #1298 as of this writing:

- The icons are larger visually, which I believe makes them a bit more balanced.
- The button content was given a wrapper to make its alignment to the adjacent iconography more predictable.
- The spacing has been tweaked between icons and content and the sides of the button.
- The `clip-mask` polygon has been updated. I attempted to mimic the layout of the pseudo-element slash in Illustrator, then expanded to a `100px` square grid, then used the point values to determine the percentages of the `polygon`.
- `@supports` is used instead of `-webkit-clip-mask`.
- A `transform` hack is used to force Safari to play a little nicer. I avoided a `translateZ` or `will-change` hack to avoid spinning up the GPU unnecessarily.

This appears to work mostly consistently across the latest versions of Firefox, Chrome, Safari (Mac/iOS) and Edge.

## Screenshots

<img width="1908" alt="Screen Shot 2021-06-11 at 5 04 31 PM" src="https://user-images.githubusercontent.com/69633/121758963-759e7e00-cad8-11eb-9ea6-7ab21ccafa3a.png">

![File](https://user-images.githubusercontent.com/69633/121758942-63bcdb00-cad8-11eb-8c87-00ffe9033775.jpg)

---

/CC @gerardo-rodriguez @Paul-Hebert 
