### PR TITLE
Export tokens as nested JSON

### DIFF
--- a/.changeset/giant-keys-look.md
+++ b/.changeset/giant-keys-look.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add JSON format for compiled design tokens

--- a/.style-dictionary/config.js
+++ b/.style-dictionary/config.js
@@ -115,5 +115,17 @@ module.exports = {
         },
       ],
     },
+    json: {
+      transformGroup: 'custom/transform-group/css',
+      buildPath: 'src/compiled/tokens/json/',
+      files: [
+        // Export all the tokens in a single JSON file. This will be easier to
+        // import for server-side languages like PHP.
+        {
+          destination: 'tokens.json',
+          format: 'json/nested',
+        },
+      ],
+    },
   },
 };


### PR DESCRIPTION
## Overview

We've found a use case for consuming these tokens via PHP. Since PHP, like most server-side languages, has built in [JSON support](https://www.php.net/manual/en/book.json.php), the easiest way to do this is to expose a JSON format of tokens using Style Dictionary's existing format. I chose the [`json/nested`](https://amzn.github.io/style-dictionary/#/formats?id=jsonnested) format so the file would maintain its hierarchy without requiring `.value` calls.

## Testing

Run `npm run build` and confirm that `src/compiled/tokens/json/tokens.json`  is populated with our tokens in JSON format.
