### PR TITLE
Fix extra padding on single Gutenberg button

### DIFF
--- a/.changeset/hungry-mirrors-visit.md
+++ b/.changeset/hungry-mirrors-visit.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Remove extra padding on lone Gutenberg button blocks

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -5,13 +5,6 @@
 @use "../../mixins/table";
 
 /**
- * Gutenberg block: Button
- * Applies our pattern library styles to buttons generated via Gutenberg blocks.
- */
-
-$wp-button-gap: size.$spacing-list-inline-gap;
-
-/**
  * Apply to any current or future WordPress block that supports these alignment
  * options (unless they decide to update their class name prefixes!)
  */
@@ -40,39 +33,28 @@ $wp-button-gap: size.$spacing-list-inline-gap;
 }
 
 /**
- * 1. Align buttons with outer parent
- * 2. Complete half-gaps left by buttons
+ * Gutenberg block: Button
+ * Applies our pattern library styles to buttons generated via Gutenberg blocks.
  */
+
+$wp-button-gap: size.$spacing-gap-button-group-default;
+
 .wp-block-buttons {
   display: flex;
   flex-wrap: wrap;
-  margin: $wp-button-gap * -1;
-  padding: math.div($wp-button-gap, 2);
-
-  /**
-   * If this has content before, assume it is prose content and add back
-   * some margin.
-   */
-  &:not(:first-child) {
-    margin-top: size.$rhythm-generous - $wp-button-gap;
-  }
-
-  /**
-   * If this has content after, assume it is prose content and add back
-   * some margin.
-   */
-  &:not(:last-child) {
-    margin-bottom: size.$rhythm-generous - $wp-button-gap;
-  }
+  margin-bottom: $wp-button-gap * -1;
 }
 
 /**
  * 1. Prevent inherited display flex styling from crushing layout
- * 2. Add half-gaps (will add up to full gutters)
  */
 .wp-block-button {
   flex: none; /* 1 */
-  padding: math.div($wp-button-gap, 2); /* 2 */
+
+  .wp-block-buttons & {
+    margin-bottom: $wp-button-gap;
+    margin-right: $wp-button-gap;
+  }
 
   .wp-block-button__link {
     @include button.default;

--- a/src/vendor/wordpress/gutenberg.stories.mdx
+++ b/src/vendor/wordpress/gutenberg.stories.mdx
@@ -70,17 +70,24 @@ class on the `.wp-block-button` element.
 Controls allow each button to have custom text color, background color or gradient,
 and border radius.
 
-<Canvas>
+<Canvas isColumn>
   <Story name="core/button">
+    {`<div class="wp-block-button is-style-fill">
+        <a class="wp-block-button__link" href="#">
+          Single button
+        </a>
+      </div>`}
+  </Story>
+  <Story name="core/buttons">
     {`<div class="wp-block-buttons">
         <div class="wp-block-button is-style-fill">
           <a class="wp-block-button__link" href="#">
-            Button
+            Button 1 (Default/Fill)
           </a>
         </div>
         <div class="wp-block-button is-style-outline">
           <a class="wp-block-button__link" href="#">
-            Outlined button
+            Button 2 (Outline)
           </a>
         </div>
     </div>`}


### PR DESCRIPTION
## Overview

- Simplifies the spacing for `wp-button-blocks`. This is a less sophisticated solution but it doesn't require knowledge of which `o-rhythm` modifier is in use anymore, and I think it's fine for buttons located within prose content.
- Only applies adjacent button spacing to `wp-button-block` when it is nested within `wp-button-blocks`. Before, lone buttons would appear to have extra padding since they expected to always be contained.

## Screenshots

<img width="515" alt="Screen Shot 2021-06-14 at 3 59 33 PM" src="https://user-images.githubusercontent.com/69633/121969621-872a9480-cd29-11eb-887f-016afcd99dc2.png">

## Testing

[Deploy preview](https://deploy-preview-1311--cloudfour-patterns.netlify.app/?path=/docs/vendor-wordpress-gutenberg--core-buttons#button)

---

- Fixes #1310 
