### PR TITLE
Add Calendar Date code example + template props/block docs

### DIFF
--- a/src/components/calendar-date/calendar-date.stories.mdx
+++ b/src/components/calendar-date/calendar-date.stories.mdx
@@ -1,4 +1,5 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { makeTwigInclude } from '../../make-twig-include';
 import template from './calendar-date.twig';
 import seasonsDemo from './demo/seasons.twig';
 import './demo/styles.scss';
@@ -32,5 +33,19 @@ A short note may be included, for example the event length ("3-day event"), type
 To add some fun and visual variety, each season has its own header color. These are applied using a modifier class based on the month, for example `c-calendar-date--january`.
 
 <Canvas>
-  <Story name="Seasons">{seasonsDemo()}</Story>
+  <Story
+    name="Seasons"
+    parameters={{
+      docs: {
+        source: {
+          code: makeTwigInclude(
+            '@cloudfour/components/calendar-date/calendar-date.twig',
+            { datetime: '2020-04-01' }
+          ),
+        },
+      },
+    }}
+  >
+    {seasonsDemo()}
+  </Story>
 </Canvas>

--- a/src/components/calendar-date/calendar-date.stories.mdx
+++ b/src/components/calendar-date/calendar-date.stories.mdx
@@ -49,3 +49,12 @@ To add some fun and visual variety, each season has its own header color. These 
     {seasonsDemo()}
   </Story>
 </Canvas>
+
+## Template Properties
+
+- `datetime` (string): The display date. (e.g. `'2020-04-01'`)
+- `class` (string): Append a class to the root element.
+
+## Template Blocks
+
+- `note`: A short note. (e.g. '3-day event')


### PR DESCRIPTION
## Overview

This PR updates one of the code examples + adds documentation of the template props and block.

## Screenshots

Left: Before
Right: After

<img width="2560" alt="Screen Shot 2021-06-15 at 10 48 26 AM" src="https://user-images.githubusercontent.com/459757/122099892-61ec6380-cdc7-11eb-85ca-61ee47079252.png">


## Testing

1. Review https://deploy-preview-1313--cloudfour-patterns.netlify.app/?path=/docs/components-calendar-date--basic

---

- See #1289 