### PR TITLE
[BLOCKED] Toggling Button, JavaScript logic

### DIFF
--- a/.changeset/dry-rabbits-burn.md
+++ b/.changeset/dry-rabbits-burn.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add toggling button JavaScript functionality

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -136,7 +136,7 @@ Pass an `aria_pressed` value (`'true'` or `'false'`) to set up a toggling button
 
 You can override the `content_start_icon` value to a different icon.
 
-<Canvas>
+<Canvas isColumn>
   <Story
     name="Toggling Button"
     args={{

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -143,6 +143,7 @@ You can override the `content_start_icon` value to a different icon.
       class: 'js-toggling-button',
       aria_pressed: 'true',
     }}
+    inline={false}
   >
     {(args) => togglingButtonStory(args)}
   </Story>
@@ -152,6 +153,7 @@ You can override the `content_start_icon` value to a different icon.
       class: 'c-button--secondary js-toggling-button',
       aria_pressed: 'true',
     }}
+    inline={false}
   >
     {(args) => togglingButtonStory(args)}
   </Story>
@@ -161,6 +163,7 @@ You can override the `content_start_icon` value to a different icon.
       class: 'c-button--tertiary js-toggling-button',
       aria_pressed: 'true',
     }}
+    inline={false}
   >
     {(args) => togglingButtonStory(args)}
   </Story>
@@ -171,6 +174,7 @@ You can override the `content_start_icon` value to a different icon.
       aria_pressed: 'true',
       isIconButtonCustomDemo: true,
     }}
+    inline={false}
   >
     {(args) => togglingButtonStory(args)}
   </Story>

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -1,7 +1,9 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import { useEffect } from '@storybook/client-api';
 import stylesDemo from './demo/styles.twig';
 import iconButtonCustomDemo from './demo/icon-button-custom-demo.twig';
 import button from './button.twig';
+import { initTogglingButton } from './toggling-button.ts';
 const iconControlConfig = {
   type: { name: 'string' },
   control: {
@@ -16,6 +18,19 @@ const iconControlConfig = {
     ],
   },
   defaultValue: '',
+};
+// Helper function to initialize toggling button JS
+const togglingButtonStory = (args) => {
+  useEffect(() => {
+    const { destroy } = initTogglingButton(
+      document.querySelector('.js-c-button')
+    );
+    return destroy;
+  }, []);
+  if (args.isIconButtonCustomDemo) {
+    return iconButtonCustomDemo(args);
+  }
+  return button(args);
 };
 
 <Meta
@@ -128,7 +143,7 @@ You can override the `content_start_icon` value to a different icon.
       aria_pressed: 'true',
     }}
   >
-    {(args) => button(args)}
+    {(args) => togglingButtonStory(args)}
   </Story>
   <Story
     name="Secondary Toggling Button"
@@ -137,7 +152,7 @@ You can override the `content_start_icon` value to a different icon.
       aria_pressed: 'true',
     }}
   >
-    {(args) => button(args)}
+    {(args) => togglingButtonStory(args)}
   </Story>
   <Story
     name="Tertiary Toggling Button"
@@ -146,10 +161,13 @@ You can override the `content_start_icon` value to a different icon.
       aria_pressed: 'true',
     }}
   >
-    {(args) => button(args)}
+    {(args) => togglingButtonStory(args)}
   </Story>
-  <Story name="Custom Icon Toggling Button" args={{ aria_pressed: 'true' }}>
-    {(args) => iconButtonCustomDemo(args)}
+  <Story
+    name="Custom Icon Toggling Button"
+    args={{ aria_pressed: 'true', isIconButtonCustomDemo: true }}
+  >
+    {(args) => togglingButtonStory(args)}
   </Story>
 </Canvas>
 

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -23,7 +23,7 @@ const iconControlConfig = {
 const togglingButtonStory = (args) => {
   useEffect(() => {
     const { destroy } = initTogglingButton(
-      document.querySelector('.js-c-button')
+      document.querySelector('.js-toggling-button')
     );
     return destroy;
   }, []);
@@ -132,7 +132,7 @@ The `content_start`/`content_end` blocks override the
 
 ## Toggling button
 
-Pass an `aria_pressed` value (`'true'` or `'false'`) to enable a toggling button. If no `content_start_icon`/`content_end_icon` or `content_start`/`content_end` block content is passed in, the `'notifications'` icon will be used by default as the `content_start_icon` value.
+Pass an `aria_pressed` value (`'true'` or `'false'`) to set up a toggling button. If no `content_start_icon`/`content_end_icon` or `content_start`/`content_end` block content is passed in, the `'notifications'` icon will be used by default as the `content_start_icon` value.
 
 You can override the `content_start_icon` value to a different icon.
 
@@ -140,6 +140,7 @@ You can override the `content_start_icon` value to a different icon.
   <Story
     name="Toggling Button"
     args={{
+      class: 'js-toggling-button',
       aria_pressed: 'true',
     }}
   >
@@ -148,7 +149,7 @@ You can override the `content_start_icon` value to a different icon.
   <Story
     name="Secondary Toggling Button"
     args={{
-      class: 'c-button--secondary',
+      class: 'c-button--secondary js-toggling-button',
       aria_pressed: 'true',
     }}
   >
@@ -157,7 +158,7 @@ You can override the `content_start_icon` value to a different icon.
   <Story
     name="Tertiary Toggling Button"
     args={{
-      class: 'c-button--tertiary',
+      class: 'c-button--tertiary js-toggling-button',
       aria_pressed: 'true',
     }}
   >
@@ -165,11 +166,39 @@ You can override the `content_start_icon` value to a different icon.
   </Story>
   <Story
     name="Custom Icon Toggling Button"
-    args={{ aria_pressed: 'true', isIconButtonCustomDemo: true }}
+    args={{
+      class: 'js-toggling-button',
+      aria_pressed: 'true',
+      isIconButtonCustomDemo: true,
+    }}
   >
     {(args) => togglingButtonStory(args)}
   </Story>
 </Canvas>
+
+### JavaScript Instructions
+
+You'll need to use JavaScript to select and initialize the toggling button.
+
+> As a best practice, [you should avoid binding your CSS and JS onto the same class in your HTML](https://cssguidelin.es/#javascript-hooks). As a result, we recommend adding an additional JS-specific class. It could be anything, but we're using `js-toggling-button` for this example.
+
+Once you have added the `js-toggling-button` class to the `button` element, you'll also need to add some JavaScript that runs after the page loads, like so:
+
+```js
+// Initialize a toggle button
+const togglingButton = initTogglingButton(
+  document.querySelector('.js-toggling-button')
+);
+```
+
+The `initTogglingButton` function adds an event listener to the toggling button, updating the `aria-pressed` value.
+
+It also returns an object containing a `destroy()` method, if you need to remove the event listener.
+
+```js
+// Remove toggle button click event listener
+togglingButton.destroy();
+```
 
 ## Template Properties
 

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -4,6 +4,7 @@ import { withBrowser } from 'pleasantest';
 import { loadTwigTemplate } from '../../../test-utils';
 
 const buttonMarkup = loadTwigTemplate(path.join(__dirname, './button.twig'));
+// Helper to test the JS-driven toggling button
 const initTogglingButtonJS = (
   utils: PleasantestUtils,
   togglingButton: ElementHandle
@@ -39,7 +40,7 @@ test(
 );
 
 test(
-  'should be a button when aria_pressed is set',
+  'should render a button when aria_pressed is set',
   withBrowser(async ({ utils, screen }) => {
     await utils.injectHTML(
       await buttonMarkup({ tag_name: 'a', aria_pressed: 'false' })

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -25,7 +25,7 @@ test(
     await utils.injectHTML(await buttonMarkup({}));
 
     const button = await screen.getByRole('button');
-    await expect(button).toBeVisible();
+    await expect(button).toHaveTextContent(/^hello world$/i);
   })
 );
 
@@ -35,7 +35,7 @@ test(
     await utils.injectHTML(await buttonMarkup({ href: '#' }));
 
     const linkButton = await screen.getByRole('link');
-    await expect(linkButton).toBeVisible();
+    await expect(linkButton).toHaveTextContent(/^hello world$/i);
   })
 );
 
@@ -45,11 +45,15 @@ test(
     await utils.injectHTML(
       // The `aria_pressed` value should override the `tag_name` value and always
       // render a button element. This test verifies that expecation.
-      await buttonMarkup({ tag_name: 'a', aria_pressed: 'false' })
+      await buttonMarkup({
+        tag_name: 'a',
+        aria_pressed: 'false',
+        label: 'I am a button',
+      })
     );
 
     const button = await screen.getByRole('button');
-    await expect(button).toBeVisible();
+    await expect(button).toHaveTextContent(/^i am a button$/i);
   })
 );
 

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -1,0 +1,64 @@
+import path from 'path';
+import type { ElementHandle, PleasantestUtils } from 'pleasantest';
+import { withBrowser } from 'pleasantest';
+import { loadTwigTemplate } from '../../../test-utils';
+
+const buttonMarkup = loadTwigTemplate(path.join(__dirname, './button.twig'));
+const initTogglingButtonJS = (
+  utils: PleasantestUtils,
+  togglingButton: ElementHandle
+) =>
+  utils.runJS(
+    `
+    import { initTogglingButton } from './toggling-button'
+    export default (togglingButton) => initTogglingButton(togglingButton)
+    `,
+    [togglingButton]
+  );
+
+test(
+  'should render a button element by default',
+  withBrowser(async ({ utils, screen }) => {
+    // If I don't pass _something_ to buttonMarkup(), I get an error.
+    // To get around that, I pass an empty object.
+    await utils.injectHTML(await buttonMarkup({}));
+
+    const button = await screen.getByRole('button');
+    await expect(button).toBeVisible();
+  })
+);
+
+test(
+  'should render an anchor element when href is provided',
+  withBrowser(async ({ utils, screen }) => {
+    await utils.injectHTML(await buttonMarkup({ href: '#' }));
+
+    const linkButton = await screen.getByRole('link');
+    await expect(linkButton).toBeVisible();
+  })
+);
+
+test(
+  'should be a button when aria_pressed is set',
+  withBrowser(async ({ utils, screen }) => {
+    await utils.injectHTML(
+      await buttonMarkup({ tag_name: 'a', aria_pressed: 'false' })
+    );
+
+    const button = await screen.getByRole('button');
+    await expect(button).toBeVisible();
+  })
+);
+
+test(
+  'should toggle aria-pressed state',
+  withBrowser(async ({ utils, screen }) => {
+    await utils.injectHTML(await buttonMarkup({ aria_pressed: 'false' }));
+    // await utils.loadCSS('../../../dist/standalone.css');
+
+    const togglingButton = await screen.getByRole('button');
+    await initTogglingButtonJS(utils, togglingButton);
+
+    await expect(togglingButton).toBeVisible();
+  })
+);

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -52,13 +52,15 @@ test(
 
 test(
   'should toggle aria-pressed state',
-  withBrowser(async ({ utils, screen }) => {
+  withBrowser(async ({ utils, screen, user }) => {
     await utils.injectHTML(await buttonMarkup({ aria_pressed: 'false' }));
-    // await utils.loadCSS('../../../dist/standalone.css');
-
     const togglingButton = await screen.getByRole('button');
     await initTogglingButtonJS(utils, togglingButton);
 
-    await expect(togglingButton).toBeVisible();
+    await expect(togglingButton).toHaveAttribute('aria-pressed', 'false');
+    await user.click(togglingButton);
+    await expect(togglingButton).toHaveAttribute('aria-pressed', 'true');
+    await user.click(togglingButton);
+    await expect(togglingButton).toHaveAttribute('aria-pressed', 'false');
   })
 );

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -59,8 +59,10 @@ test(
     await initTogglingButtonJS(utils, togglingButton);
 
     await expect(togglingButton).toHaveAttribute('aria-pressed', 'false');
+
     await user.click(togglingButton);
     await expect(togglingButton).toHaveAttribute('aria-pressed', 'true');
+
     await user.click(togglingButton);
     await expect(togglingButton).toHaveAttribute('aria-pressed', 'false');
   })

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -20,9 +20,7 @@ const initTogglingButtonJS = (
 test(
   'should render a button element by default',
   withBrowser(async ({ utils, screen }) => {
-    // If I don't pass _something_ to buttonMarkup(), I get an error.
-    // To get around that, I pass an empty object.
-    await utils.injectHTML(await buttonMarkup({}));
+    await utils.injectHTML(await buttonMarkup());
 
     const button = await screen.getByRole('button');
     await expect(button).toHaveTextContent(/^hello world$/i);

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -43,6 +43,8 @@ test(
   'should render a button when aria_pressed is set',
   withBrowser(async ({ utils, screen }) => {
     await utils.injectHTML(
+      // The `aria_pressed` value should override the `tag_name` value and always
+      // render a button element. This test verifies that expecation.
       await buttonMarkup({ tag_name: 'a', aria_pressed: 'false' })
     );
 

--- a/src/components/button/button.test.ts
+++ b/src/components/button/button.test.ts
@@ -55,6 +55,7 @@ test(
   'should toggle aria-pressed state',
   withBrowser(async ({ utils, screen, user }) => {
     await utils.injectHTML(await buttonMarkup({ aria_pressed: 'false' }));
+
     const togglingButton = await screen.getByRole('button');
     await initTogglingButtonJS(utils, togglingButton);
 

--- a/src/components/button/button.twig
+++ b/src/components/button/button.twig
@@ -1,7 +1,7 @@
 {% set tag_name = tag_name|default(href ? 'a' : 'button') %}
 {# aria_pressed only accepts 'true' or 'false' (string) values #}
 {% set is_aria_pressed_valid = aria_pressed == 'true' or aria_pressed == 'false' %}
-{# When aria_pressed is set, ensure a button is rendered #}
+{# When aria_pressed is set, ensure a button element is rendered #}
 {% if is_aria_pressed_valid %}
   {% set tag_name = 'button' %}
 {% endif %}

--- a/src/components/button/button.twig
+++ b/src/components/button/button.twig
@@ -1,6 +1,10 @@
 {% set tag_name = tag_name|default(href ? 'a' : 'button') %}
 {# aria_pressed only accepts 'true' or 'false' (string) values #}
 {% set is_aria_pressed_valid = aria_pressed == 'true' or aria_pressed == 'false' %}
+{# When aria_pressed is set, ensure a button is rendered #}
+{% if is_aria_pressed_valid %}
+  {% set tag_name = 'button' %}
+{% endif %}
 {# Check for 'content_start' and 'content_end' content #}
 {% set _content_start = block('content_start') %}
 {% set _content_end = block('content_end') %}

--- a/src/components/button/button.twig
+++ b/src/components/button/button.twig
@@ -20,9 +20,7 @@
 {% endif %}
 
 <{{ tag_name }}
-  class="c-button
-  {% if class %}{{ class }}{% endif %}
-  {% if is_aria_pressed_valid %}js-c-button{% endif %}"
+  class="c-button{% if class %} {{ class }}{% endif %}"
   {% if aria_expanded %}
     aria-expanded="{{ aria_expanded }}"
   {% endif %}

--- a/src/components/button/button.twig
+++ b/src/components/button/button.twig
@@ -20,7 +20,9 @@
 {% endif %}
 
 <{{ tag_name }}
-  class="c-button{% if class %} {{ class }}{% endif %}"
+  class="c-button
+  {% if class %}{{ class }}{% endif %}
+  {% if is_aria_pressed_valid %}js-c-button{% endif %}"
   {% if aria_expanded %}
     aria-expanded="{{ aria_expanded }}"
   {% endif %}

--- a/src/components/button/toggling-button.ts
+++ b/src/components/button/toggling-button.ts
@@ -7,12 +7,11 @@
 export const initTogglingButton = (togglingButton: HTMLButtonElement) => {
   // Handler for when a toggling button is clicked
   const onTogglingButtonClick = () => {
-    // Get the current aria-pressed state and toggle it
-    const isAriaPressed = !(
-      togglingButton.getAttribute('aria-pressed') === 'true'
-    );
-    // Update the UI state
-    togglingButton.setAttribute('aria-pressed', String(isAriaPressed));
+    // Get the current aria-pressed state
+    const isAriaPressed =
+      togglingButton.getAttribute('aria-pressed') === 'true';
+    // Update the UI state (making sure to toggle the state as well)
+    togglingButton.setAttribute('aria-pressed', String(!isAriaPressed));
   };
 
   // Clean up event listeners

--- a/src/components/button/toggling-button.ts
+++ b/src/components/button/toggling-button.ts
@@ -1,5 +1,3 @@
-import tokens from '../../compiled/tokens/js/tokens';
-
 /**
  * Create Toggling Button
  *
@@ -14,21 +12,27 @@ import tokens from '../../compiled/tokens/js/tokens';
  * @param togglingButton - The button to apply the toggling functionality
  */
 export const initTogglingButton = (togglingButton: HTMLButtonElement) => {
-  // Trigger event to relay state of button
-
-  const togglePressedState = () => {
-    const isAriaPressed =
-      togglingButton.getAttribute('aria-pressed') === 'true';
-
-    togglingButton.setAttribute('aria-pressed', String(!isAriaPressed));
+  // Handler for when a toggling button is clicked
+  const onTogglingButtonClick = () => {
+    // Get the current aria-pressed state and toggle it
+    const isAriaPressed = !(
+      togglingButton.getAttribute('aria-pressed') === 'true'
+    );
+    // Update the UI state
+    togglingButton.setAttribute('aria-pressed', String(isAriaPressed));
   };
-
-  togglingButton.addEventListener('click', togglePressedState);
 
   // Clean up event listeners
   const destroy = () => {
-    togglingButton.removeEventListener('click', togglePressedState);
+    togglingButton.removeEventListener('click', onTogglingButtonClick);
   };
+
+  // Intialize
+  const init = () => {
+    togglingButton.addEventListener('click', onTogglingButtonClick);
+  };
+
+  init();
 
   // Return a public API for consumers of this component
   return { destroy };

--- a/src/components/button/toggling-button.ts
+++ b/src/components/button/toggling-button.ts
@@ -1,0 +1,35 @@
+import tokens from '../../compiled/tokens/js/tokens';
+
+/**
+ * Create Toggling Button
+ *
+ * Adds an event listener to the toggle button of a Sky Nav component for click
+ * events, which runs the toggle command to show or hide the menu with animation.
+ * Responds to breakpoint changes to show or hide the nav for large and small
+ * screens. Returns an object containing a `destroy()` method to remove the
+ * event listener.
+ *
+ * TODO...
+ *
+ * @param togglingButton - The button to apply the toggling functionality
+ */
+export const initTogglingButton = (togglingButton: HTMLButtonElement) => {
+  // Trigger event to relay state of button
+
+  const togglePressedState = () => {
+    const isAriaPressed =
+      togglingButton.getAttribute('aria-pressed') === 'true';
+
+    togglingButton.setAttribute('aria-pressed', String(!isAriaPressed));
+  };
+
+  togglingButton.addEventListener('click', togglePressedState);
+
+  // Clean up event listeners
+  const destroy = () => {
+    togglingButton.removeEventListener('click', togglePressedState);
+  };
+
+  // Return a public API for consumers of this component
+  return { destroy };
+};

--- a/src/components/button/toggling-button.ts
+++ b/src/components/button/toggling-button.ts
@@ -21,11 +21,7 @@ export const initTogglingButton = (togglingButton: HTMLButtonElement) => {
   };
 
   // Intialize
-  const init = () => {
-    togglingButton.addEventListener('click', onTogglingButtonClick);
-  };
-
-  init();
+  togglingButton.addEventListener('click', onTogglingButtonClick);
 
   // Return a public API for consumers of this component
   return { destroy };

--- a/src/components/button/toggling-button.ts
+++ b/src/components/button/toggling-button.ts
@@ -1,15 +1,8 @@
 /**
  * Create Toggling Button
+ * Adds an event listener to toggle the `aria-pressed` value
  *
- * Adds an event listener to the toggle button of a Sky Nav component for click
- * events, which runs the toggle command to show or hide the menu with animation.
- * Responds to breakpoint changes to show or hide the nav for large and small
- * screens. Returns an object containing a `destroy()` method to remove the
- * event listener.
- *
- * TODO...
- *
- * @param togglingButton - The button to apply the toggling functionality
+ * @param togglingButton - The button to apply the toggling functionality to
  */
 export const initTogglingButton = (togglingButton: HTMLButtonElement) => {
   // Handler for when a toggling button is clicked

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -15,5 +15,5 @@ export const loadTwigTemplate = (templatePath: string) => {
   );
   // Using "await" here because next version of twing returns promises
   // eslint-disable-next-line @cloudfour/typescript-eslint/await-thenable
-  return async (data: any) => (await templatePromise).render(data);
+  return async (data: any = {}) => (await templatePromise).render(data);
 };


### PR DESCRIPTION
## Overview

This PR adds JavaScript logic to the Toggling Button pattern so that the `aria-pressed` attribute updates when clicking the butotn.

## Screenshots

![toggling](https://user-images.githubusercontent.com/459757/122478659-a8d08980-cf7e-11eb-9c4e-0a72d3660089.gif)


## Testing

Preview: https://deploy-preview-1318--cloudfour-patterns.netlify.app/?path=/story/components-button--toggling-button

1. Review the toggling button stories and confirm they toggle.
2. Review the updated documentation.

---

- Closes #1094 