### PR TITLE
Refine Calendar Date Seasons code example

### DIFF
--- a/src/components/calendar-date/calendar-date.stories.mdx
+++ b/src/components/calendar-date/calendar-date.stories.mdx
@@ -1,5 +1,4 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
-import { makeTwigInclude } from '../../make-twig-include';
 import template from './calendar-date.twig';
 import seasonsDemo from './demo/seasons.twig';
 import './demo/styles.scss';

--- a/src/components/calendar-date/calendar-date.stories.mdx
+++ b/src/components/calendar-date/calendar-date.stories.mdx
@@ -38,10 +38,18 @@ To add some fun and visual variety, each season has its own header color. These 
     parameters={{
       docs: {
         source: {
-          code: makeTwigInclude(
-            '@cloudfour/components/calendar-date/calendar-date.twig',
-            { datetime: '2020-04-01' }
-          ),
+          code: `{% include '@cloudfour/components/calendar-date/calendar-date.twig' with {
+  datetime: '2020-04-01'
+} only %}
+{% include '@cloudfour/components/calendar-date/calendar-date.twig' with {
+  datetime: '2020-07-04'
+} only %}
+{% include '@cloudfour/components/calendar-date/calendar-date.twig' with {
+  datetime: '2020-10-31'
+} only %}
+{% include '@cloudfour/components/calendar-date/calendar-date.twig' with {
+  datetime: '2020-12-31'
+} only %}`,
         },
       },
     }}


### PR DESCRIPTION
## Overview

This PR refines the code example for the Calendar Date component Seasons example.

## Screenshots

Left: Before
Right: After

<img width="2332" alt="Screen Shot 2021-06-17 at 4 25 58 PM" src="https://user-images.githubusercontent.com/459757/122484061-c145a180-cf88-11eb-8697-944b01ae86bd.png">


## Testing

1. Review the Calendar Date Seasons code example

---

- See #1289 