### PR TITLE
Remove withPaddings decorator

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,4 @@
 import { Parser } from 'html-to-react';
-import { withPaddings } from 'storybook-addon-paddings';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import ReactSyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
 import twig from 'react-syntax-highlighter/dist/esm/languages/prism/twig';
@@ -116,4 +115,4 @@ export const globalTypes = {
   },
 };
 
-export const decorators = [withPaddings, withTheme];
+export const decorators = [withTheme];


### PR DESCRIPTION
## Overview

One of our Storybook add-ons published a minor version release, which Renovate automatically updated: #1328

This version of the add-on streamlined its implementation, no longer requiring a decorator function. Unfortunately because the decorator was removed entirely, every single story after this update showed a `fn is undefined` error.

This PR removes the decorator, resolving the error.

## Testing

1. Review [deploy preview](https://deploy-preview-1332--cloudfour-patterns.netlify.app/), confirm that stories are once again visible.
2. In Canvas view, confirm that the paddings dropdown still functions.