### PR TITLE
Refine Cloud Cover component story code examples

### DIFF
--- a/src/components/cloud-cover/cloud-cover.stories.mdx
+++ b/src/components/cloud-cover/cloud-cover.stories.mdx
@@ -20,9 +20,9 @@ A containing element for introductory page content, for example a heading and su
 
 <Canvas>
   <Story
-  name="Content"
-  height="400px"
-  parameters={{
+    name="Content"
+    height="400px"
+    parameters={{
       docs: {
         source: {
           code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
@@ -58,12 +58,12 @@ The cloud cover may optionally contain a "scene" containing a visual object, mos
 
 <Canvas>
   <Story
-  name="Scene"
-  height="400px"
-  parameters={{
-    docs: {
-      source: {
-        code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
+    name="Scene"
+    height="400px"
+    parameters={{
+      docs: {
+        source: {
+          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
   {% block content %}
     {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
       class: 'o-rhythm--condensed'
@@ -104,9 +104,9 @@ The `c-cloud-cover--horizon-scene` modifier applies an alternate composition ide
     name="Horizon Scene"
     height="400px"
     parameters={{
-    docs: {
-      source: {
-        code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' with {
+      docs: {
+        source: {
+          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' with {
   class: 'c-cloud-cover--horizon-scene'
 } only %}
   {% block content %}
@@ -151,9 +151,9 @@ You can also include supporting elements like newsletter sign-up forms, notifica
     name="Extra Content"
     height="400px"
     parameters={{
-    docs: {
-      source: {
-        code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
+      docs: {
+        source: {
+          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
   {% block content %}
     {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
       class: 'o-rhythm--condensed'

--- a/src/components/cloud-cover/cloud-cover.stories.mdx
+++ b/src/components/cloud-cover/cloud-cover.stories.mdx
@@ -100,7 +100,44 @@ The cloud cover may optionally contain a "scene" containing a visual object, mos
 The `c-cloud-cover--horizon-scene` modifier applies an alternate composition ideal for scenes intended to intersect the "horizon line" (bottom) of the cloud cover.
 
 <Canvas>
-  <Story name="Horizon Scene" height="400px">
+  <Story
+    name="Horizon Scene"
+    height="400px"
+    parameters={{
+    docs: {
+      source: {
+        code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' with {
+  class: 'c-cloud-cover--horizon-scene'
+} only %}
+  {% block content %}
+    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
+      class: 'o-rhythm--condensed'
+    } only %}
+      {% block content %}
+        {% include '@cloudfour/components/heading/heading.twig' with {
+          level: -2,
+          content: 'What We Do'
+        } only %}
+        <p>
+          We
+          {% include '@cloudfour/components/icon/icon.twig' with {
+            name: 'heart',
+            inline: true
+          } only %}
+          <span class="u-hidden-visually">love</span>
+          solving tough puzzles through design and&nbsp;code.
+        </p>
+      {% endblock %}
+    {% endembed %}
+  {% endblock %}
+  {% block scene %}
+    <img class="c-cloud-cover__scene-object" src="./path/flag.svg" alt="">
+  {% endblock %}
+{% endembed %}`,
+        },
+      },
+    }}
+  >
     {sceneDemo({ class: 'c-cloud-cover--horizon-scene', image: flagImage })}
   </Story>
 </Canvas>

--- a/src/components/cloud-cover/cloud-cover.stories.mdx
+++ b/src/components/cloud-cover/cloud-cover.stories.mdx
@@ -57,7 +57,42 @@ A containing element for introductory page content, for example a heading and su
 The cloud cover may optionally contain a "scene" containing a visual object, most likely an `img` or `svg` element. By default, the scene will float in the sky.
 
 <Canvas>
-  <Story name="Scene" height="400px">
+  <Story
+  name="Scene"
+  height="400px"
+  parameters={{
+    docs: {
+      source: {
+        code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
+  {% block content %}
+    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
+      class: 'o-rhythm--condensed'
+    } only %}
+      {% block content %}
+        {% include '@cloudfour/components/heading/heading.twig' with {
+          level: -2,
+          content: 'What We Do'
+        } only %}
+        <p>
+          We
+          {% include '@cloudfour/components/icon/icon.twig' with {
+            name: 'heart',
+            inline: true
+          } only %}
+          <span class="u-hidden-visually">love</span>
+          solving tough puzzles through design and&nbsp;code.
+        </p>
+      {% endblock %}
+    {% endembed %}
+  {% endblock %}
+  {% block scene %}
+    <img class="c-cloud-cover__scene-object" src="./path/robot.svg" alt="">
+  {% endblock %}
+{% endembed %}`,
+        },
+      },
+    }}
+  >
     {sceneDemo({ image: robotImage })}
   </Story>
 </Canvas>

--- a/src/components/cloud-cover/cloud-cover.stories.mdx
+++ b/src/components/cloud-cover/cloud-cover.stories.mdx
@@ -19,7 +19,35 @@ import robotImage from './demo/robot.svg';
 A containing element for introductory page content, for example a heading and subtitle. The clouds offer a whimsical, illustrative element to help transition from the page title and [Sky Nav](/docs/components-sky-nav--dark) to the main body content.
 
 <Canvas>
-  <Story name="Content" height="400px">
+  <Story
+  name="Content"
+  height="400px"
+  parameters={{
+      docs: {
+        source: {
+          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
+  {% block content %}
+    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
+      class: 'o-rhythm--condensed'
+    } only %}
+      {% block content %}
+        {% include '@cloudfour/components/heading/heading.twig' with {
+          level: -2,
+          content: 'Our Team'
+        } only %}
+        <p>
+          We are a small, versatile team who care passionately about the web.
+          We’re full of what our industry considers unicorns. Our designers
+          code. Our developers went to art school.
+        </p>
+      {% endblock %}
+    {% endembed %}
+  {% endblock %}
+{% endembed %}`,
+        },
+      },
+    }}
+  >
     {contentDemo()}
   </Story>
 </Canvas>

--- a/src/components/cloud-cover/cloud-cover.stories.mdx
+++ b/src/components/cloud-cover/cloud-cover.stories.mdx
@@ -147,7 +147,42 @@ The `c-cloud-cover--horizon-scene` modifier applies an alternate composition ide
 You can also include supporting elements like newsletter sign-up forms, notification opt-ins or other calls to action in an adjacent cell. Note that it is not possible to show extra content _and_ a scene at the same time.
 
 <Canvas>
-  <Story name="Extra Content" height="400px">
+  <Story
+    name="Extra Content"
+    height="400px"
+    parameters={{
+    docs: {
+      source: {
+        code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
+  {% block content %}
+    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
+      class: 'o-rhythm--condensed'
+    } only %}
+      {% block content %}
+        {% include '@cloudfour/components/heading/heading.twig' with {
+          level: -2,
+          content: 'What We Do'
+        } only %}
+        <p>
+          We
+          {% include '@cloudfour/components/icon/icon.twig' with {
+            name: 'heart',
+            inline: true
+          } only %}
+          <span class="u-hidden-visually">love</span>
+          solving tough puzzles through design and&nbsp;code.
+        </p>
+      {% endblock %}
+    {% endembed %}
+  {% endblock %}
+  {% block extra %}
+    <p>(Imagine a nifty newsletter signup form here 👀)</p>
+  {% endblock %}
+{% endembed %}`,
+        },
+      },
+    }}
+  >
     {extraDemo()}
   </Story>
 </Canvas>


### PR DESCRIPTION
## Overview

This PR refines the code examples for the Cloud Cover stories.

## Screenshots

<img width="1392" alt="Screen Shot 2021-06-29 at 1 08 47 PM" src="https://user-images.githubusercontent.com/459757/123860781-372c0000-d8db-11eb-8f96-587a1f917aa8.png">

## Testing

Cloud Cover stories: https://deploy-preview-1350--cloudfour-patterns.netlify.app/?path=/docs/components-cloud-cover--content

1. Review each of the story code examples for accuracy

---

- See #1289 