### PR TITLE
Slightly refactor Rhythm, support Jetpack Markdown Block

### DIFF
--- a/.changeset/stupid-walls-sip.md
+++ b/.changeset/stupid-walls-sip.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add support for Jetpack Markdown Block

--- a/.changeset/tender-wasps-type.md
+++ b/.changeset/tender-wasps-type.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Use custom properties for Rhythm spacing to support inheritance

--- a/src/mixins/_adjacent.scss
+++ b/src/mixins/_adjacent.scss
@@ -1,0 +1,29 @@
+@use "../compiled/tokens/scss/size";
+
+/// Applies styles for a vertical rhythm layout object. Used by the `o-rhythm`
+/// pattern and for relevant Gutenberg blocks. Makes heavy use of Heydon
+/// Pickering's "lobotomized owl" selectors: By adding `margin-top` to adjacent
+/// elements, we avoid impacting the layout of the container itself (which would
+/// complicate alignment of adjacent columns).
+/// @link https://alistapart.com/article/axiomatic-css-and-lobotomized-owls/
+/// @param {Number} $space - The default space between.
+@mixin rhythm($space: size.$rhythm-default) {
+  & > * + * {
+    margin-top: $space;
+    // Allow space to be overridden using custom properties
+    margin-top: var(--rhythm);
+  }
+
+  // Where custom properties are supported, also allow headings to receive their
+  // own rhythm.
+  @supports (--custom: properties) {
+    & > * + h1,
+    & > * + h2,
+    & > * + h3,
+    & > * + h4,
+    & > * + h5,
+    & > * + h6 {
+      margin-top: var(--rhythm-headings);
+    }
+  }
+}

--- a/src/mixins/_spacing.scss
+++ b/src/mixins/_spacing.scss
@@ -7,7 +7,7 @@
 /// complicate alignment of adjacent columns).
 /// @link https://alistapart.com/article/axiomatic-css-and-lobotomized-owls/
 /// @param {Number} $space - The default space between.
-@mixin rhythm($space: size.$rhythm-default) {
+@mixin vertical-rhythm($space: size.$rhythm-default) {
   & > * + * {
     margin-top: $space;
     // Allow space to be overridden using custom properties

--- a/src/objects/rhythm/rhythm.scss
+++ b/src/objects/rhythm/rhythm.scss
@@ -1,45 +1,31 @@
 @use "../../compiled/tokens/scss/size";
+@use "../../mixins/adjacent";
 
-/**
- * This pattern makes heavy use of Heydon Pickering's "lobotomized owl"
- * selectors. By adding `margin-top` to adjacent elements, we avoid impacting
- * the layout of the container itself (which would complicate alignment of
- * adjacent columns).
- *
- * @see https://alistapart.com/article/axiomatic-css-and-lobotomized-owls/
- */
-
-.o-rhythm > * + * {
-  margin-top: size.$rhythm-default;
+:root {
+  --rhythm: #{size.$rhythm-default};
+  --rhythm-headings: var(--rhythm);
 }
 
-/**
- * General spacing modifiers
- */
-
-.o-rhythm--compact > * + * {
-  margin-top: size.$rhythm-compact;
+.o-rhythm {
+  @include adjacent.rhythm(size.$rhythm-default);
 }
 
-.o-rhythm--condensed > * + * {
-  margin-top: size.$rhythm-condensed;
+// General spacing modifiers
+
+.o-rhythm--compact {
+  --rhythm: #{size.$rhythm-compact};
 }
 
-.o-rhythm--generous > * + * {
-  margin-top: size.$rhythm-generous;
+.o-rhythm--condensed {
+  --rhythm: #{size.$rhythm-condensed};
 }
 
-/**
- * Heading modifiers
- */
+.o-rhythm--generous {
+  --rhythm: #{size.$rhythm-generous};
+}
+
+// Heading modifiers
 
 .o-rhythm--generous-headings {
-  & > * + h1,
-  & > * + h2,
-  & > * + h3,
-  & > * + h4,
-  & > * + h5,
-  & > * + h6 {
-    margin-top: size.$rhythm-generous;
-  }
+  --rhythm-headings: #{size.$rhythm-generous};
 }

--- a/src/objects/rhythm/rhythm.scss
+++ b/src/objects/rhythm/rhythm.scss
@@ -1,5 +1,5 @@
 @use "../../compiled/tokens/scss/size";
-@use "../../mixins/adjacent";
+@use "../../mixins/spacing";
 
 :root {
   --rhythm: #{size.$rhythm-default};
@@ -7,7 +7,7 @@
 }
 
 .o-rhythm {
-  @include adjacent.rhythm(size.$rhythm-default);
+  @include spacing.vertical-rhythm(size.$rhythm-default);
 }
 
 // General spacing modifiers

--- a/src/objects/rhythm/rhythm.stories.mdx
+++ b/src/objects/rhythm/rhythm.stories.mdx
@@ -51,3 +51,38 @@ behave as expected.
     {articleDemo}
   </Story>
 </Canvas>
+
+## Inheriting Rhythm
+
+The vertical spacing applied by the Rhythm object only applies to direct children. In some cases, you may want elements below to inherit rhythm. This can be accomplished in two main ways.
+
+### Via HTML
+
+If you have access to the markup, you can add the `o-rhythm` class to the child element:
+
+```html
+<div class="o-rhythm o-rhythm--condensed">
+  <!-- ... -->
+  <div class="o-rhythm">
+    <!-- will also be condensed -->
+  </div>
+  <!-- ... -->
+</div>
+```
+
+### Via Sass
+
+Our project includes an `adjacent.rhythm` mixin that will apply the basic object rules to any selector:
+
+```scss
+@use 'path/to/mixins/adjacent';
+
+.unchangeable-vendor-selector {
+  @include adjacent.rhythm();
+}
+```
+
+## Custom Properties
+
+- `--rhythm`: Amount of vertical space between adjacent elements. Defaults to our `$rhythm-default` [size token](/docs/design-tokens-size--page#rhythm).
+- `--rhythm-headings`: Extra space to precede headings that follow another element. Defaults to the value of `--rhythm`.

--- a/src/objects/rhythm/rhythm.stories.mdx
+++ b/src/objects/rhythm/rhythm.stories.mdx
@@ -72,13 +72,13 @@ If you have access to the markup, you can add the `o-rhythm` class to the child 
 
 ### Via Sass
 
-Our project includes an `adjacent.rhythm` mixin that will apply the basic object rules to any selector:
+Our project includes a `spacing.vertical-rhythm` mixin that will apply the basic object rules to any selector:
 
 ```scss
-@use 'path/to/mixins/adjacent';
+@use 'path/to/mixins/spacing';
 
 .unchangeable-vendor-selector {
-  @include adjacent.rhythm();
+  @include spacing.vertical-rhythm();
 }
 ```
 

--- a/src/vendor/wordpress/_wordpress.scss
+++ b/src/vendor/wordpress/_wordpress.scss
@@ -1,2 +1,3 @@
 @use 'styles/core-blocks';
+@use 'styles/jetpack-blocks';
 @use 'styles/utilities';

--- a/src/vendor/wordpress/jetpack-blocks.stories.mdx
+++ b/src/vendor/wordpress/jetpack-blocks.stories.mdx
@@ -8,7 +8,7 @@ WordPress developer Automattic provides a [Jetpack](https://jetpack.com/) plugin
 
 ## Markdown Block
 
-Reenforces the containing element's rhythm. If contained within a [Rhythm object](/docs/objects-rhythm--default-story), its children will inherit the same spacing.
+The markdown block applies vertical rhythm between its children. If contained within a [Rhythm object](/docs/objects-rhythm--default-story), the markdown block will inherit the same spacing. For example, if the Rhythm object uses the `o-rhythm--generous` modifier, the markdown block will inherit the generous spacing.
 
 See also: [Markdown Block documentation](https://jetpack.com/support/markdown/)
 

--- a/src/vendor/wordpress/jetpack-blocks.stories.mdx
+++ b/src/vendor/wordpress/jetpack-blocks.stories.mdx
@@ -1,0 +1,29 @@
+import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Vendor/WordPress/Jetpack Blocks" />
+
+# Jetpack Blocks
+
+WordPress developer Automattic provides a [Jetpack](https://jetpack.com/) plugin that includes additional blocks. We support a selection of these.
+
+## Markdown Block
+
+Reenforces the containing element's rhythm. If contained within a [Rhythm object](/docs/objects-rhythm--default-story), its children will inherit the same spacing.
+
+See also: [Markdown Block documentation](https://jetpack.com/support/markdown/)
+
+<Canvas>
+  <Story name="Markdown">
+    {`<div class="wp-block-jetpack-markdown">
+      <p>
+        <b>Lorem</b> <i>ipsum</i> dolor sit amet, consectetur adipiscing elit. Quisque eu ex
+        enim. Nunc efficitur scelerisque dolor et sollicitudin.
+      </p>
+      <p>
+        Donec finibus lorem elit, eu consectetur quam pellentesque sed.
+        Pellentesque habitant morbi tristique senectus et netus et malesuada
+        fames ac turpis egestas.
+      </p>
+    </div>`}
+  </Story>
+</Canvas>

--- a/src/vendor/wordpress/styles/_jetpack-blocks.scss
+++ b/src/vendor/wordpress/styles/_jetpack-blocks.scss
@@ -1,0 +1,5 @@
+@use '../../../mixins/adjacent';
+
+.wp-block-jetpack-markdown {
+  @include adjacent.rhythm();
+}

--- a/src/vendor/wordpress/styles/_jetpack-blocks.scss
+++ b/src/vendor/wordpress/styles/_jetpack-blocks.scss
@@ -1,5 +1,5 @@
-@use '../../../mixins/adjacent';
+@use '../../../mixins/spacing';
 
 .wp-block-jetpack-markdown {
-  @include adjacent.rhythm();
+  @include spacing.vertical-rhythm();
 }


### PR DESCRIPTION
## Overview

See changelog and docs for details.

## Screenshots

<img width="1090" alt="Screen Shot 2021-06-29 at 1 38 55 PM" src="https://user-images.githubusercontent.com/69633/123864343-84aa6c00-d8df-11eb-9654-f3a207796e72.png">

<img width="950" alt="Screen Shot 2021-06-29 at 1 38 42 PM" src="https://user-images.githubusercontent.com/69633/123864347-85db9900-d8df-11eb-87ab-e7888ccfcac9.png">

## Testing

[On the deploy preview](https://deploy-preview-1351--cloudfour-patterns.netlify.app/):

- Review Rhythm Object docs for regressions
- Review Vendor WordPress Jetpack Markdown story

---

- Fixes #1314 