### PR TITLE
Comment Form code example + docs + template updates

### DIFF
--- a/.changeset/poor-planes-retire.md
+++ b/.changeset/poor-planes-retire.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Remove function call from logged_in_user object in template
+Remove function call from logged_in_user object properties in Comment Form template

--- a/.changeset/poor-planes-retire.md
+++ b/.changeset/poor-planes-retire.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Remove function call from logged_in_user object in template

--- a/src/components/comment-form/comment-form.stories.mdx
+++ b/src/components/comment-form/comment-form.stories.mdx
@@ -1,6 +1,7 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import { useEffect } from '@storybook/client-api';
 import { createElasticTextArea } from '../input/elastic-textarea.ts';
+import { makeTwigInclude } from '../../make-twig-include';
 import template from './comment-form.twig';
 const tyler = {
   name: 'Tyler Sticka',
@@ -32,7 +33,9 @@ The form used to add a comment to an article.
     parameters={{
       docs: {
         source: {
-          code: `{% include '@cloudfour/components/comment-form/comment-form.twig' only %}`,
+          code: makeTwigInclude(
+            '@cloudfour/components/comment-form/comment-form.twig'
+          ),
         },
       },
     }}
@@ -62,14 +65,10 @@ There is also a reply version of this component (`is_reply: true`), used to repl
     parameters={{
       docs: {
         source: {
-          code: `{% include '@cloudfour/components/comment-form/comment-form.twig' with {
-  logged_in_user: {
-    name: 'Tyler Sticka',
-    link: 'https://cloudfour.com/is/tyler',
-  },
-  log_out_url: '/logout',
-  is_reply: true
-} only %}`,
+          code: makeTwigInclude(
+            '@cloudfour/components/comment-form/comment-form.twig',
+            { logged_in_user: tyler, log_out_url: '/logout', is_reply: true }
+          ),
         },
       },
     }}

--- a/src/components/comment-form/comment-form.stories.mdx
+++ b/src/components/comment-form/comment-form.stories.mdx
@@ -26,7 +26,17 @@ const tyler = {
 The form used to add a comment to an article.
 
 <Canvas>
-  <Story name="Default" args={{ isReply: false }}>
+  <Story
+    name="Default"
+    args={{ isReply: false }}
+    parameters={{
+      docs: {
+        source: {
+          code: `{% include '@cloudfour/components/comment-form/comment-form.twig' only %}`,
+        },
+      },
+    }}
+  >
     {({ isLoggedIn, isReply }) => {
       useEffect(() => {
         const { destroy } = createElasticTextArea(
@@ -46,7 +56,24 @@ The form used to add a comment to an article.
 There is also a reply version of this component (`is_reply: true`), used to reply to an existing comment:
 
 <Canvas>
-  <Story name="Reply" args={{ isReply: true }}>
+  <Story
+    name="Reply"
+    args={{ isReply: true, isLoggedIn: true }}
+    parameters={{
+      docs: {
+        source: {
+          code: `{% include '@cloudfour/components/comment-form/comment-form.twig' with {
+  logged_in_user: {
+    name: 'Tyler Sticka',
+    link: 'https://cloudfour.com/is/tyler',
+  },
+  log_out_url: '/logout',
+  is_reply: true
+} only %}`,
+        },
+      },
+    }}
+  >
     {({ isLoggedIn, isReply }) => {
       useEffect(() => {
         const { destroy } = createElasticTextArea(

--- a/src/components/comment-form/comment-form.stories.mdx
+++ b/src/components/comment-form/comment-form.stories.mdx
@@ -97,11 +97,15 @@ There is also a reply version of this component (`is_reply: true`), used to repl
 
   ```ts
   {
-    name: () => string;
-    link: () => string;
+    name: string | () => string;
+    link: string | () => string;
   }
   ```
 
 - `log_out_url`: URL used for log out link.
 - `is_reply`: Whether the comment is a reply to another comment.
 - `prompt` (block): The text that is displayed above the messge box.
+
+## JavaScript
+
+The Comment Form component includes the [Elastic Textarea component](http://localhost:6006/?path=/docs/components-input--elastic-textarea). See the Elastic Textarea component for JavaScript setup details.

--- a/src/components/comment-form/comment-form.stories.mdx
+++ b/src/components/comment-form/comment-form.stories.mdx
@@ -3,8 +3,8 @@ import { useEffect } from '@storybook/client-api';
 import { createElasticTextArea } from '../input/elastic-textarea.ts';
 import template from './comment-form.twig';
 const tyler = {
-  name: () => 'Tyler Sticka',
-  link: () => 'https://cloudfour.com/is/tyler',
+  name: 'Tyler Sticka',
+  link: 'https://cloudfour.com/is/tyler',
 };
 
 <Meta

--- a/src/components/comment-form/comment-form.twig
+++ b/src/components/comment-form/comment-form.twig
@@ -13,7 +13,7 @@
     {% endblock %}
   {% endembed %}
   {% if logged_in_user and log_out_url %}
-    <p>Logged in as <a href="{{ logged_in_user.link() }}">{{ logged_in_user.name() }}</a>. <a href="{{ log_out_url }}">Log out?</a></p>
+    <p>Logged in as <a href="{{ logged_in_user.link }}">{{ logged_in_user.name }}</a>. <a href="{{ log_out_url }}">Log out?</a></p>
   {% else %}
     {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Name', class: 'c-comment-form__name' } only %}
       {% block control %}

--- a/src/make-twig-include.js
+++ b/src/make-twig-include.js
@@ -4,7 +4,7 @@
  * @param {string} path
  * @param {any} args
  */
-export const makeTwigInclude = (path, args) => {
+export const makeTwigInclude = (path, args = {}) => {
   const argsString =
     Object.keys(args).length > 0
       ? ` with ${JSON.stringify(args, null, 2)}`


### PR DESCRIPTION
## Overview

Refine Comment Form component code examples and docs.

I also updated the template by dropping the parenthesis on the `logged_in_user` object property calls, following what I did for [PR 1300](https://github.com/cloudfour/cloudfour.com-patterns/pull/1300#discussion_r652121442).


## Screenshots

<img width="1392" alt="Screen Shot 2021-06-29 at 4 42 29 PM" src="https://user-images.githubusercontent.com/459757/123881377-5d609880-d8f9-11eb-835a-72dc6cb3598f.png">

## Testing

Preview: https://deploy-preview-1353--cloudfour-patterns.netlify.app/?path=/docs/components-comment-form--default-story

1. Review code examples for accuracy
1. Review template changes

---

- See #1289 