### PR TITLE
Refine the Dot Leader list code example

### DIFF
--- a/src/components/dot-leader/dot-leader.stories.mdx
+++ b/src/components/dot-leader/dot-leader.stories.mdx
@@ -44,5 +44,29 @@ If `c-dot-leader` is an `<a>` element, it will gain some additional styles.
 Although `c-dot-leader` applies to a single row, the pattern works best as part of [a list object](/docs/objects-list--default-story). The dotted lines clearly associate each column even when content lengths vary.
 
 <Canvas>
-  <Story name="List">{listDemo({ topics })}</Story>
+  <Story
+    name="List"
+    parameters={{
+      docs: {
+        source: {
+          code: `{% embed '@cloudfour/objects/list/list.twig' only %}
+  {% block content %}
+    {% for topic in topics %}
+      <li>
+        {% include '@cloudfour/components/dot-leader/dot-leader.twig' with {
+          label: topic.title,
+          count: topic.count,
+          href: topic.url
+        } only %}
+      </li>
+    {% endfor %}
+  {% endblock %}
+{% endembed %}
+`,
+        },
+      },
+    }}
+  >
+    {listDemo({ topics })}
+  </Story>
 </Canvas>

--- a/src/components/dot-leader/dot-leader.stories.mdx
+++ b/src/components/dot-leader/dot-leader.stories.mdx
@@ -1,5 +1,6 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import listDemo from './demo/list.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import listDemoSource from '!!raw-loader!./demo/list.twig';
 import topics from './demo/topics.json';
 import template from './dot-leader.twig';

--- a/src/components/dot-leader/dot-leader.stories.mdx
+++ b/src/components/dot-leader/dot-leader.stories.mdx
@@ -1,7 +1,14 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
-import listDemo from './demo/list.twig';
+// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
+// See: https://github.com/webpack-contrib/raw-loader#examples
+// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
+// okay with the following Webpack-specific raw loader syntax. It's better to leave
+// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
+// within a Storybook docs page and not within an actual component).
+// This can be revisited in the future if Storybook no longer relies on Webpack.
 // eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import listDemoSource from '!!raw-loader!./demo/list.twig';
+import listDemo from './demo/list.twig';
 import topics from './demo/topics.json';
 import template from './dot-leader.twig';
 const argTypes = {

--- a/src/components/dot-leader/dot-leader.stories.mdx
+++ b/src/components/dot-leader/dot-leader.stories.mdx
@@ -1,5 +1,6 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import listDemo from './demo/list.twig';
+import listDemoSource from '!!raw-loader!./demo/list.twig';
 import topics from './demo/topics.json';
 import template from './dot-leader.twig';
 const argTypes = {
@@ -49,20 +50,7 @@ Although `c-dot-leader` applies to a single row, the pattern works best as part 
     parameters={{
       docs: {
         source: {
-          code: `{% embed '@cloudfour/objects/list/list.twig' only %}
-  {% block content %}
-    {% for topic in topics %}
-      <li>
-        {% include '@cloudfour/components/dot-leader/dot-leader.twig' with {
-          label: topic.title,
-          count: topic.count,
-          href: topic.url
-        } only %}
-      </li>
-    {% endfor %}
-  {% endblock %}
-{% endembed %}
-`,
+          code: listDemoSource,
         },
       },
     }}


### PR DESCRIPTION
## Overview

This PR refines the code example for the Dot Leader list example.

## Screenshots

<img width="951" alt="Screen Shot 2021-06-30 at 1 38 00 PM" src="https://user-images.githubusercontent.com/459757/124028070-6b212700-d9a8-11eb-9007-a011fd975b64.png">

## Testing

Preview: https://deploy-preview-1356--cloudfour-patterns.netlify.app/?path=/docs/components-dot-leader--list

1. Review the Dot Leader list code example for accuracy

---

- See #1289 