### PR TITLE
Refine the Event Log code example

### DIFF
--- a/src/components/event-log/event-log.stories.mdx
+++ b/src/components/event-log/event-log.stories.mdx
@@ -12,7 +12,43 @@ Displays a list of event details in chronological order. Designed to show the pr
 For a less specialized display of tabular data, consider using [Table](/docs/components-table--basic). For simple string/number pairs, consider [Dot Leader](/docs/components-dot-leader--list). To display a single or upcoming date, consider using [Calendar Date](/docs/components-calendar-date--basic) (optionally combined with [Media](/docs/objects-media--event-summary)).
 
 <Canvas>
-  <Story name="Example">{eventsDemoStory.bind({})}</Story>
+  <Story
+    name="Example"
+    parameters={{
+      docs: {
+        source: {
+          code: `{% embed '@cloudfour/components/event-log/event-log.twig' only %}
+  {% block content %}
+    {% for item in items %}
+      {% embed '@cloudfour/components/event-log/item.twig' with item only %}
+        {% block extra %}
+          {%- if item.links -%}
+            {% embed '@cloudfour/objects/list/list.twig' with {
+              class: 'o-list--inline'
+            } only %}
+              {% block content %}
+                {% for link in item.links %}
+                  <li>
+                    <a href="{{link.link}}">
+                      {{link.title}}
+                    </a>
+                  </li>
+                {% endfor %}
+              {% endblock %}
+            {% endembed %}
+          {%- endif -%}
+        {% endblock %}
+      {% endembed %}
+    {% endfor %}
+  {% endblock %}
+{% endembed %}
+`,
+        },
+      },
+    }}
+  >
+    {eventsDemoStory.bind({})}
+  </Story>
 </Canvas>
 
 ## Template Properties

--- a/src/components/event-log/event-log.stories.mdx
+++ b/src/components/event-log/event-log.stories.mdx
@@ -1,5 +1,14 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import events from './demo/events.json';
+// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
+// See: https://github.com/webpack-contrib/raw-loader#examples
+// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
+// okay with the following Webpack-specific raw loader syntax. It's better to leave
+// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
+// within a Storybook docs page and not within an actual component).
+// This can be revisited in the future if Storybook no longer relies on Webpack.
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import eventsDemoSource from '!!raw-loader!./demo/events.twig';
 import eventsDemo from './demo/events.twig';
 const eventsDemoStory = (args) => eventsDemo({ items: events, ...args });
 
@@ -17,32 +26,7 @@ For a less specialized display of tabular data, consider using [Table](/docs/com
     parameters={{
       docs: {
         source: {
-          code: `{% embed '@cloudfour/components/event-log/event-log.twig' only %}
-  {% block content %}
-    {% for item in items %}
-      {% embed '@cloudfour/components/event-log/item.twig' with item only %}
-        {% block extra %}
-          {%- if item.links -%}
-            {% embed '@cloudfour/objects/list/list.twig' with {
-              class: 'o-list--inline'
-            } only %}
-              {% block content %}
-                {% for link in item.links %}
-                  <li>
-                    <a href="{{link.link}}">
-                      {{link.title}}
-                    </a>
-                  </li>
-                {% endfor %}
-              {% endblock %}
-            {% endembed %}
-          {%- endif -%}
-        {% endblock %}
-      {% endembed %}
-    {% endfor %}
-  {% endblock %}
-{% endembed %}
-`,
+          code: eventsDemoSource,
         },
       },
     }}


### PR DESCRIPTION
## Overview

This PR refines the Event Log code example.

## Screenshots

<img width="958" alt="Screen Shot 2021-06-30 at 2 07 00 PM" src="https://user-images.githubusercontent.com/459757/124032139-0caa7780-d9ad-11eb-9506-11919f9bcb01.png">

## Testing

Preview: https://deploy-preview-1357--cloudfour-patterns.netlify.app/?path=/docs/components-event-log--example

1. Review the code example for accuracy

---

- See #1289 