### PR TITLE
Add small size of avatar

### DIFF
--- a/.changeset/angry-wasps-sip.md
+++ b/.changeset/angry-wasps-sip.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add small size modifier and design token to Avatar

--- a/src/components/avatar/avatar.scss
+++ b/src/components/avatar/avatar.scss
@@ -36,8 +36,12 @@
 }
 
 /**
- * Full-width modifier
+ * Size modifiers
  */
+
+.c-avatar--small {
+  width: size.$square-avatar-small;
+}
 
 .c-avatar--full {
   width: size.$square-avatar-full;

--- a/src/components/avatar/avatar.stories.mdx
+++ b/src/components/avatar/avatar.stories.mdx
@@ -47,9 +47,35 @@ The size is fixed to the value of [our `sizes.$avatar-medium` token by default](
   </Story>
 </Canvas>
 
+## Small
+
+The `c-avatar--small` modifier sizes the avatar down to the value of our `sizes.$avatar-small` token. This may be useful when accompanying a single line of text or showing many avatars in a condensed space.
+
+<Canvas>
+  <Story
+    name="Small (Empty)"
+    args={{
+      size: 'small',
+    }}
+  >
+    {avatarStory.bind({})}
+  </Story>
+  <Story
+    name="Small (With Image)"
+    args={{
+      size: 'small',
+      src: demoImageSmall,
+      srcset: demoImageSrcset,
+      sizes: '38px',
+    }}
+  >
+    {avatarStory.bind({})}
+  </Story>
+</Canvas>
+
 ## Full Width
 
-The `c-avatar--full` modifier sizes the component to `100%` of its container.
+The `c-avatar--full` modifier sizes the component to `100%` of its container width.
 
 <Canvas>
   <Story
@@ -76,7 +102,7 @@ The `c-avatar--full` modifier sizes the component to `100%` of its container.
 - `src`: Value for the inner `img` element's `src` attribute. If omitted, no `img` will be output.
 - `srcset`: Value for the inner `img` element's `srcset` attribute.
 
-## See Also
+## See also…
 
 To display multiple avatars in a visual cluster, see [the Bunch object](/docs/objects-bunch--of-avatars).
 

--- a/src/tokens/size/sizing.js
+++ b/src/tokens/size/sizing.js
@@ -32,6 +32,7 @@ module.exports = {
     },
     square: {
       avatar: {
+        small: { value: modularEm(3) },
         medium: { value: modularEm(5) },
         full: { value: '100%' },
       },


### PR DESCRIPTION
## Overview

See title and accompanying docs. Required for #1238.

## Screenshots

<img width="1032" alt="Screen Shot 2021-06-30 at 2 23 33 PM" src="https://user-images.githubusercontent.com/69633/124033487-da017e80-d9ae-11eb-9b6a-7b91ee6f697f.png">

## Testing

[Deploy preview](https://deploy-preview-1358--cloudfour-patterns.netlify.app/?path=/docs/components-avatar--small-empty#small)