### PR TITLE
Refine Heading component story code examples

### DIFF
--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -1,5 +1,16 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
+// See: https://github.com/webpack-contrib/raw-loader#examples
+// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
+// okay with the following Webpack-specific raw loader syntax. It's better to leave
+// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
+// within a Storybook docs page and not within an actual component).
+// This can be revisited in the future if Storybook no longer relies on Webpack.
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import levelsDemoSource from '!!raw-loader!./demo/levels.twig';
 import levelsDemo from './demo/levels.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import permalinksDemoSource from '!!raw-loader!./demo/permalinks.twig';
 import permalinksDemo from './demo/permalinks.twig';
 
 <Meta title="Components/Heading" />
@@ -33,7 +44,12 @@ You can control the appearance of a `c-heading` component by including a `c-head
 | 6     | `<h6>`  | `c-heading--level-6`  |
 
 <Canvas>
-  <Story name="Levels">{levelsDemo}</Story>
+  <Story
+    name="Levels"
+    parameters={{ docs: { source: { code: levelsDemoSource } } }}
+  >
+    {levelsDemo}
+  </Story>
 </Canvas>
 
 ## Permalinks
@@ -52,7 +68,12 @@ behave as expected.
 -->
 
 <Canvas>
-  <Story name="Permalinks" height="300px" inline={false}>
+  <Story
+    name="Permalinks"
+    height="300px"
+    inline={false}
+    parameters={{ docs: { source: { code: permalinksDemoSource } } }}
+  >
     {permalinksDemo}
   </Story>
 </Canvas>

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -46,7 +46,16 @@ You can control the appearance of a `c-heading` component by including a `c-head
 <Canvas>
   <Story
     name="Levels"
-    parameters={{ docs: { source: { code: levelsDemoSource } } }}
+    parameters={{
+      docs: {
+        source: {
+          code: `{% include '@cloudfour/components/heading/heading.twig' with {
+  level: -2,
+  content: 'c-heading--level-n2',
+} only %}`,
+        },
+      },
+    }}
   >
     {levelsDemo}
   </Story>
@@ -72,7 +81,17 @@ behave as expected.
     name="Permalinks"
     height="300px"
     inline={false}
-    parameters={{ docs: { source: { code: permalinksDemoSource } } }}
+    parameters={{
+      docs: {
+        source: {
+          code: `{% include '@cloudfour/components/heading/heading.twig' with {
+  level: 1,
+  content: 'c-heading--level-1',
+  permalink: true
+} only %}`,
+        },
+      },
+    }}
   >
     {permalinksDemo}
   </Story>

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -1,16 +1,5 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
-// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
-// See: https://github.com/webpack-contrib/raw-loader#examples
-// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
-// okay with the following Webpack-specific raw loader syntax. It's better to leave
-// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
-// within a Storybook docs page and not within an actual component).
-// This can be revisited in the future if Storybook no longer relies on Webpack.
-// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
-import levelsDemoSource from '!!raw-loader!./demo/levels.twig';
 import levelsDemo from './demo/levels.twig';
-// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
-import permalinksDemoSource from '!!raw-loader!./demo/permalinks.twig';
 import permalinksDemo from './demo/permalinks.twig';
 
 <Meta title="Components/Heading" />


### PR DESCRIPTION
## Overview

This PR refines the Heading component story code examples.


## Testing

Preview: https://deploy-preview-1367--cloudfour-patterns.netlify.app/?path=/docs/components-heading--levels

1. Review the Heading component code example for accuracy

---

- See #1289 