### PR TITLE
Refine Icon component story code examples

### DIFF
--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -1,6 +1,23 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import template from './icon.twig';
+// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
+// See: https://github.com/webpack-contrib/raw-loader#examples
+// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
+// okay with the following Webpack-specific raw loader syntax. It's better to leave
+// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
+// within a Storybook docs page and not within an actual component).
+// This can be revisited in the future if Storybook no longer relies on Webpack.
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import inlineDemoSource from '!!raw-loader!./demo/inline.twig';
 import inlineDemo from './demo/inline.twig';
+const iconStory = (args) => {
+  console.log(args);
+  // Don't bother with the inline option if it is the default
+  if (args.inline === false) {
+    delete args.inline;
+  }
+  return template(args);
+};
 
 <Meta title="Components/Icon" />
 
@@ -20,7 +37,7 @@ For a list of available icons, visit [the Icons page](/docs/design-icons--page).
       class: { type: { name: 'string' } },
     }}
   >
-    {(args) => template(args)}
+    {(args) => iconStory(args)}
   </Story>
 </Canvas>
 
@@ -29,7 +46,12 @@ For a list of available icons, visit [the Icons page](/docs/design-icons--page).
 Icons without a flex or grid container may appear [slightly low in comparison to adjacent text](https://cloudfour.com/thinks/some-imaginary-css/#align-to-typeface-median). The `c-icon--inline` modifier applies a slight positioning adjustment to account for this.
 
 <Canvas>
-  <Story name="Inline">{inlineDemo}</Story>
+  <Story
+    name="Inline"
+    parameters={{ docs: { source: { code: inlineDemoSource } } }}
+  >
+    {inlineDemo}
+  </Story>
 </Canvas>
 
 ## Template Properties


### PR DESCRIPTION
## Overview

This PR refines the Icon component story code examples.

## Testing

Preview: https://deploy-preview-1368--cloudfour-patterns.netlify.app/?path=/docs/components-icon--basic

1. Review the Icon component story code examples for accuracy

---

- See #1289 