### PR TITLE
Add Badge component, pencil icon, demo roles to Comment

### DIFF
--- a/.changeset/kind-beans-fry.md
+++ b/.changeset/kind-beans-fry.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add 'pencil' icon

--- a/.changeset/loud-ligers-remember.md
+++ b/.changeset/loud-ligers-remember.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add Badge component

--- a/src/assets/icons/pencil.svg
+++ b/src/assets/icons/pencil.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <rect x="5.71" y="10.71" width="14" height="5.17" transform="translate(-5.68 12.88) rotate(-45)" />
+  <path d="M9.59,20.07,1.81,22.19l2.12-7.78,12-12a2,2,0,0,1,2.83,0l2.83,2.83a2,2,0,0,1,0,2.83Z" fill="none"
+    stroke-linejoin="round" stroke-width="2" />
+  <rect x="2.22" y="19.78" width="2" height="2" transform="translate(-13.75 8.36) rotate(-45)" />
+  <line x1="19.49" y1="10.17" x2="13.83" y2="4.51" fill="none" stroke-width="2" />
+</svg>

--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -4,6 +4,7 @@
 @use "../../compiled/tokens/scss/size";
 @use '../../mixins/ms';
 @use '../../mixins/theme';
+@use 'sass:math';
 
 .c-badge {
   background: var(--theme-color-background-secondary);
@@ -14,20 +15,20 @@
   font-weight: font-weight.$medium;
   height: ms.step(2);
   line-height: line-height.$tighter;
-  margin-left: 1ch;
-  margin-top: (ms.step(2) / -8);
+  padding: 0 math.div(size.$padding-cell-horizontal, 2);
   vertical-align: middle;
+  white-space: nowrap;
 }
 
 .c-badge__content {
   align-self: center;
 
   &:first-child {
-    padding-left: size.$padding-cell-horizontal;
+    padding-left: math.div(size.$padding-cell-horizontal, 2);
   }
 
   &:last-child {
-    padding-right: size.$padding-cell-horizontal;
+    padding-right: math.div(size.$padding-cell-horizontal, 2);
   }
 }
 

--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -1,28 +1,31 @@
-@use "../../compiled/tokens/scss/color";
 @use "../../compiled/tokens/scss/font-weight";
 @use "../../compiled/tokens/scss/line-height";
 @use "../../compiled/tokens/scss/size";
 @use '../../mixins/ms';
-@use '../../mixins/theme';
 @use 'sass:math';
 
 .c-badge {
+  align-items: center;
   background: var(--theme-color-background-secondary);
   border-radius: size.$border-radius-medium;
   color: var(--theme-color-text-muted);
   display: inline-flex;
   font-size: ms.step(-1);
   font-weight: font-weight.$medium;
+  // Because the text in a badge does not wrap, we can avoid icons accidentally
+  // increasing the height as often by setting this here instead of relying on
+  // vertical padding.
   height: ms.step(2);
   line-height: line-height.$tighter;
+  // We only apply half padding because the padding feels too tight around icons
+  // but not around the label content. We'll apply the other half of padding on
+  // the content element itself.
   padding: 0 math.div(size.$padding-cell-horizontal, 2);
   vertical-align: middle;
   white-space: nowrap;
 }
 
 .c-badge__content {
-  align-self: center;
-
   &:first-child {
     padding-left: math.div(size.$padding-cell-horizontal, 2);
   }
@@ -35,6 +38,7 @@
 .c-badge__extra {
   align-items: center;
   display: flex;
+  flex: none;
   justify-content: center;
   min-width: ms.step(2);
 }

--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -1,0 +1,39 @@
+@use "../../compiled/tokens/scss/color";
+@use "../../compiled/tokens/scss/font-weight";
+@use "../../compiled/tokens/scss/line-height";
+@use "../../compiled/tokens/scss/size";
+@use '../../mixins/ms';
+@use '../../mixins/theme';
+
+.c-badge {
+  background: var(--theme-color-background-secondary);
+  border-radius: size.$border-radius-medium;
+  color: var(--theme-color-text-muted);
+  display: inline-flex;
+  font-size: ms.step(-1);
+  font-weight: font-weight.$medium;
+  height: ms.step(2);
+  line-height: line-height.$tighter;
+  margin-left: 1ch;
+  margin-top: (ms.step(2) / -8);
+  vertical-align: middle;
+}
+
+.c-badge__content {
+  align-self: center;
+
+  &:first-child {
+    padding-left: size.$padding-cell-horizontal;
+  }
+
+  &:last-child {
+    padding-right: size.$padding-cell-horizontal;
+  }
+}
+
+.c-badge__extra {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  min-width: ms.step(2);
+}

--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -1,10 +1,46 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import template from './badge.twig';
 
-<Meta title="Components/Badge" />
+<Meta
+  title="Components/Badge"
+  argTypes={{
+    label: { type: { name: 'string' } },
+    icon: {
+      type: { name: 'string' },
+      control: {
+        type: 'select',
+        options: ['', 'check', 'heart', 'pencil'],
+      },
+      defaultValue: '',
+    },
+  }}
+/>
 
 # Badge
 
+Badges help provide just a smidge more context to repetitive or serialized content. For example, a badge can help the reader identify when [a comment on an article is by the author of that article](/docs/components-comment--role-author#role-badges).
+
 <Canvas>
-  <Story name="Basic">{template}</Story>
+  <Story name="Basic" args={{ label: 'Hello' }}>
+    {(args) => template(args)}
+  </Story>
 </Canvas>
+
+## With icon
+
+<Canvas>
+  <Story name="With icon" args={{ icon: 'check', label: 'Verified' }}>
+    {(args) => template(args)}
+  </Story>
+</Canvas>
+
+## Template Properties
+
+- `class` (string)
+- `icon` (string): The name of one of [our icons](/docs/design-icons--page) to display.
+- `message` (string, default `'Label'`)
+
+## Template Blocks
+
+- `content`: The main label content, typically the value of `message`.
+- `extra`: A visual extra preceding the content, typically populated by an icon if `icon` is set.

--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -1,0 +1,10 @@
+import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import template from './badge.twig';
+
+<Meta title="Components/Badge" />
+
+# Badge
+
+<Canvas>
+  <Story name="Example">{template}</Story>
+</Canvas>

--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -6,5 +6,5 @@ import template from './badge.twig';
 # Badge
 
 <Canvas>
-  <Story name="Example">{template}</Story>
+  <Story name="Basic">{template}</Story>
 </Canvas>

--- a/src/components/badge/badge.twig
+++ b/src/components/badge/badge.twig
@@ -1,10 +1,22 @@
-<div class="c-badge">
-  <div class="c-badge__extra">
-    {% include '@cloudfour/assets/brand/logo.svg.twig' with {
-      class: 'c-icon',
-    } only %}
-  </div>
-  <div class="c-badge__content">
-    {{label|default('Team')}}
-  </div>
-</div>
+{% set _extra_content %}
+  {% block extra %}
+    {% if icon %}
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: icon
+      } only %}
+    {% endif %}
+  {% endblock %}
+{% endset %}
+
+<span class="c-badge{% if class %} {{class}}{% endif %}">
+  {% if _extra_content|trim %}
+    <span class="c-badge__extra">
+      {{_extra_content}}
+    </span>
+  {% endif %}
+  <span class="c-badge__content">
+    {% block content %}
+      {{label|default('Label')}}
+    {% endblock %}
+  </span>
+</span>

--- a/src/components/badge/badge.twig
+++ b/src/components/badge/badge.twig
@@ -1,0 +1,48 @@
+<h3>
+  <span style="font-weight: 600;">Danielle Romo</span>
+  <div class="c-badge">
+    <div class="c-badge__extra">
+      {# {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'bell',
+      } only %} #}
+      ✏️
+    </div>
+    <div class="c-badge__content">
+      {{label|default('Author')}}
+    </div>
+  </div>
+</h3>
+
+<h3 style="margin-top: 2em;">
+  <span style="font-weight: 600;">Paul Hebert</span>
+  <div class="c-badge">
+    <div class="c-badge__extra">
+      {# {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'bell',
+      } only %} #}
+      {% include '@cloudfour/assets/brand/logo.svg.twig' with {
+        class: 'c-icon',
+      } only %}
+    </div>
+    <div class="c-badge__content">
+      {{label|default('Team')}}
+    </div>
+  </div>
+</h3>
+
+<h3 style="margin-top: 2em;">
+  <span style="font-weight: 600;">Sara Lohr</span>
+  <div class="c-badge">
+    <div class="c-badge__extra">
+      {# {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'bell',
+      } only %} #}
+      {% include '@cloudfour/assets/brand/logo.svg.twig' with {
+        class: 'c-icon',
+      } only %}
+    </div>
+    <div class="c-badge__content">
+      {{label|default('Alumni')}}
+    </div>
+  </div>
+</h3>

--- a/src/components/badge/badge.twig
+++ b/src/components/badge/badge.twig
@@ -1,48 +1,10 @@
-<h3>
-  <span style="font-weight: 600;">Danielle Romo</span>
-  <div class="c-badge">
-    <div class="c-badge__extra">
-      {# {% include '@cloudfour/components/icon/icon.twig' with {
-        name: 'bell',
-      } only %} #}
-      ✏️
-    </div>
-    <div class="c-badge__content">
-      {{label|default('Author')}}
-    </div>
+<div class="c-badge">
+  <div class="c-badge__extra">
+    {% include '@cloudfour/assets/brand/logo.svg.twig' with {
+      class: 'c-icon',
+    } only %}
   </div>
-</h3>
-
-<h3 style="margin-top: 2em;">
-  <span style="font-weight: 600;">Paul Hebert</span>
-  <div class="c-badge">
-    <div class="c-badge__extra">
-      {# {% include '@cloudfour/components/icon/icon.twig' with {
-        name: 'bell',
-      } only %} #}
-      {% include '@cloudfour/assets/brand/logo.svg.twig' with {
-        class: 'c-icon',
-      } only %}
-    </div>
-    <div class="c-badge__content">
-      {{label|default('Team')}}
-    </div>
+  <div class="c-badge__content">
+    {{label|default('Team')}}
   </div>
-</h3>
-
-<h3 style="margin-top: 2em;">
-  <span style="font-weight: 600;">Sara Lohr</span>
-  <div class="c-badge">
-    <div class="c-badge__extra">
-      {# {% include '@cloudfour/components/icon/icon.twig' with {
-        name: 'bell',
-      } only %} #}
-      {% include '@cloudfour/assets/brand/logo.svg.twig' with {
-        class: 'c-icon',
-      } only %}
-    </div>
-    <div class="c-badge__content">
-      {{label|default('Alumni')}}
-    </div>
-  </div>
-</h3>
+</div>

--- a/src/components/badge/badge.twig
+++ b/src/components/badge/badge.twig
@@ -2,7 +2,8 @@
   {% block extra %}
     {% if icon %}
       {% include '@cloudfour/components/icon/icon.twig' with {
-        name: icon
+        name: icon,
+        aria_hidden: 'true',
       } only %}
     {% endif %}
   {% endblock %}

--- a/src/components/comment/comment.stories.mdx
+++ b/src/components/comment/comment.stories.mdx
@@ -12,9 +12,8 @@ Displays a single comment in a comment thread, optionally with replies. Multiple
 
 This component is still a work in progress. The following features are still in development:
 
-- Indicating when a comment's author is a Cloud Four team member.
 - Integrating the comment reply form.
-- Adding blocks to the template to allow for more customization.
+- Finalizing this pattern's blocks and properties for theme integration.
 
 ## Single
 
@@ -30,6 +29,22 @@ This information may be passed to the component as a `comment` object matching t
 
 <Canvas>
   <Story name="Single">{template({ comment: makeComment() })}</Story>
+</Canvas>
+
+## Role badges
+
+It is helpful for context within a discussion to know when a commentor is the original post author or a Cloud Four team member. The mechanics of this feature are still in development, but these stories show how these roles should appear using [the Badge component](/docs/components-badge--basic).
+
+<Canvas>
+  <Story name="Role: Author">
+    {template({ comment: makeComment(), demo_post_author: true })}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name="Role: Cloud Four">
+    {template({ comment: makeComment(), demo_cloud_four_member: true })}
+  </Story>
 </Canvas>
 
 ## Unapproved

--- a/src/components/comment/comment.twig
+++ b/src/components/comment/comment.twig
@@ -25,7 +25,7 @@
           {% block extra %}
             {% include '@cloudfour/assets/brand/logo.svg.twig' with {
               class: 'c-icon',
-              role: 'presentation',
+              aria_hidden: 'true',
             } only %}
           {% endblock %}
         {% endembed %}

--- a/src/components/comment/comment.twig
+++ b/src/components/comment/comment.twig
@@ -4,6 +4,33 @@
   <header class="c-comment__header">
     <h{{_heading_depth}} class="c-comment__heading">
       {{comment.author.name}}
+      {#
+        TODO: Replace `demo_post_author` and `demo_cloud_four_member` with
+        more meaningful blocks or properties once we have a better idea of how
+        we'll integrate role badging based on actual comment data.
+      #}
+      {% if demo_post_author %}
+        <span class="u-hidden-visually">(Article</span>
+        {% embed '@cloudfour/components/badge/badge.twig' with {
+          label: 'Author',
+          icon: 'pencil',
+        } only %}
+        {% endembed %}
+        <span class="u-hidden-visually">)</span>
+      {% elseif demo_cloud_four_member %}
+        <span class="u-hidden-visually">(Cloud Four</span>
+        {% embed '@cloudfour/components/badge/badge.twig' with {
+          label: 'Team'
+        } only %}
+          {% block extra %}
+            {% include '@cloudfour/assets/brand/logo.svg.twig' with {
+              class: 'c-icon',
+              role: 'presentation',
+            } only %}
+          {% endblock %}
+        {% endembed %}
+        <span class="u-hidden-visually">Member)</span>
+      {% endif %}
       <span class="u-hidden-visually">
         {% if comment.is_child %}replied{% else %}said{% endif %}:
       </span>


### PR DESCRIPTION
## Overview

- Adds a Badge component (see docs for details)
- Adds demo role badges to Comment component
- Adds `pencil` icon for "author" role badge in comments

## Screenshots

<img width="1098" alt="Screen Shot 2021-07-09 at 3 38 18 PM" src="https://user-images.githubusercontent.com/69633/125142357-60fbd880-e0cc-11eb-8fd9-0532ec0a2f02.png">

<img width="1076" alt="Screen Shot 2021-07-09 at 3 38 33 PM" src="https://user-images.githubusercontent.com/69633/125142366-65c08c80-e0cc-11eb-978f-781708e268c0.png">

## Testing

On the deploy preview…

- [Icons](https://deploy-preview-1379--cloudfour-patterns.netlify.app/?path=/docs/design-icons--page)
- [Components ▸ Badge](https://deploy-preview-1379--cloudfour-patterns.netlify.app/?path=/docs/components-badge--basic)
- [Components ▸ Comment ▸ Role badges](https://deploy-preview-1379--cloudfour-patterns.netlify.app/?path=/docs/components-comment--role-author#role-badges)

---

- See #1238 