### PR TITLE
Ensure button content is centered

### DIFF
--- a/.changeset/heavy-plums-swim.md
+++ b/.changeset/heavy-plums-swim.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix bug where button content was not centered

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -59,8 +59,8 @@
   font-style: normal;
   font-weight: font-weight.$semibold;
   height: size.$height-control-default; /* 3 */
-  line-height: normal;
   justify-content: center;
+  line-height: normal;
   padding: size.$padding-control-vertical size.$padding-control-horizontal;
   position: relative;
   text-align: center;

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -60,6 +60,7 @@
   font-weight: font-weight.$semibold;
   height: size.$height-control-default; /* 3 */
   line-height: normal;
+  justify-content: center;
   padding: size.$padding-control-vertical size.$padding-control-horizontal;
   position: relative;
   text-align: center;


### PR DESCRIPTION
## Overview

This PR resolves a bug where the Button component content was not centered when the button width was larger than it's default width.

## Screenshots

### Before


![before](https://user-images.githubusercontent.com/459757/123875847-3ef59f80-d8ef-11eb-81cc-57e54ccf9159.gif)


### After

![after](https://user-images.githubusercontent.com/459757/125698556-4df80bcc-d741-417a-82d1-7336c3395fad.gif)


## Testing

1. Confirm the Button content is horizontally centered on the **Comment Form** component ([before](https://v-next--cloudfour-patterns.netlify.app/?path=/docs/components-comment-form--default-story) / [after](https://deploy-preview-1398--cloudfour-patterns.netlify.app/?path=/docs/components-comment-form--default-story))
1. Confirm no regressions on the **Button** component ([before](https://v-next--cloudfour-patterns.netlify.app/?path=/docs/components-button--button-element) / [after](https://deploy-preview-1398--cloudfour-patterns.netlify.app/?path=/docs/components-button--button-element))

---

- Fixes #1352 