### PR TITLE
Remove console log from Icon stories

### DIFF
--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -11,7 +11,6 @@ import template from './icon.twig';
 import inlineDemoSource from '!!raw-loader!./demo/inline.twig';
 import inlineDemo from './demo/inline.twig';
 const iconStory = (args) => {
-  console.log(args);
   // Don't bother with the inline option if it is the default
   if (args.inline === false) {
     delete args.inline;


### PR DESCRIPTION
## Overview

This PR removes a `console.log` that was accidentally left in the code.