### PR TITLE
Update article listing headings, fix lint warning

### DIFF
--- a/src/objects/feature-group/feature-group.scss
+++ b/src/objects/feature-group/feature-group.scss
@@ -6,17 +6,17 @@
 
 .o-feature-group {
   display: grid;
+  grid-template-areas:
+    'intro'
+    'content'
+    'action';
+  grid-template-rows: repeat(3, minmax(0, auto));
   @include fluid.grid-gap(
     breakpoint.$s,
     breakpoint.$xl,
     size.$spacing-gap-fluid-min,
     size.$spacing-gap-fluid-max
   );
-  grid-template-areas:
-    'intro'
-    'content'
-    'action';
-  grid-template-rows: repeat(3, minmax(0, auto));
 
   @media (min-width: breakpoint.$l) {
     grid-row-gap: 0;

--- a/src/prototypes/article-listing/example/example.scss
+++ b/src/prototypes/article-listing/example/example.scss
@@ -74,16 +74,6 @@
     }
   }
 
-  .section-title {
-    font-weight: 300;
-    @include fluid.font-size(
-      breakpoint.$xs,
-      breakpoint.$xl,
-      ms.step(4, 1rem),
-      ms.step(5, 1rem)
-    );
-  }
-
   .topics-header {
     padding-bottom: ms.step(3);
 

--- a/src/prototypes/article-listing/example/example.twig
+++ b/src/prototypes/article-listing/example/example.twig
@@ -110,7 +110,12 @@
       <div class="o-container__content">
         <div class="section">
             <div class="section-title-wrapper">
-              <h2 class="section-title">{{topic.title}}</h2>
+              {% include '@cloudfour/components/heading/heading.twig' with {
+                level: -1,
+                tag_name: 'h2',
+                weight: 'light',
+                content: topic.title,
+              } only %}
             </div>
             {% for article in topic.articles %}
               <div class="section-card-wrapper">
@@ -164,7 +169,12 @@
   <div class="o-container o-container--pad">
     <div class="o-container__content">
       <div class="topics-header">
-        <h2 class="section-title">More Topics</h2>
+        {% include '@cloudfour/components/heading/heading.twig' with {
+          level: -1,
+          tag_name: 'h2',
+          weight: 'light',
+          content: 'More Topics',
+        } only %}
         <div class="search-content">
           {% include '@cloudfour/components/input/input.twig' with {
             class: 'search-input'


### PR DESCRIPTION
## Overview

Issue #1401 suggests that new heading sizes and/or a means of adjusting heading sizes is necessary. But upon viewing the prototype in question, it looked like there was very little difference between those headings and our heading component with the following settings:

```json
{
  "level": -1,
  "tag_name": "h2",
  "weight": "light",
}
```

This PR updates that prototype to leverage the existing heading component. While there are subtle differences, they do not appear meaningful to my eye.

After making this change, running `npm run lint` also caught a CSS ordering issue that slipped by somehow. So that is also fixed to make sure this PR passes our tests.

## Screenshots

![Screenshot 2021-07-16 at 08-39-38 Storybook](https://user-images.githubusercontent.com/69633/125973727-1ad2931d-a454-4037-a396-7026b6338d56.png)

## Testing

Compare the article listing prototype headings:

- [On `v-next` (before this change)](https://v-next--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-article-listing--example&args=)
- [In this PR (deploy preview)](https://deploy-preview-1404--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-article-listing--example&args=)

---

- Fixes #1401

/CC @dromo77 @Paul-Hebert 
