### PR TITLE
Add "Overview" object for use on the Article Listing page

### DIFF
--- a/.changeset/five-turkeys-double.md
+++ b/.changeset/five-turkeys-double.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': major
+---
+
+Renamed the Heading property from `permalink_id` to `id` and allowed you to use `id` when `permalink` is false.

--- a/.changeset/shaggy-pumpkins-hug.md
+++ b/.changeset/shaggy-pumpkins-hug.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Added Overview object for use in Article Listings

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -2,6 +2,7 @@
 
 .c-button {
   @include button.default;
+  flex-grow: none;
 }
 
 /**

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -2,7 +2,6 @@
 
 .c-button {
   @include button.default;
-  flex-grow: none;
 }
 
 /**

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -76,6 +76,8 @@ The `c-heading` class may include a permalink using [a technique from Marcy Sutt
 - `c-heading__content`: The actual semantic heading element (usually `<h1>` – `<h6>`), including the `id` referenced by `c-heading__permalink`.
 - `c-heading__permalink`: The `<a>` element that exposes the permalink to the user. This element is kept separate from the actual heading so it won't disrupt a user's ability to navigate via headings.
 
+You can specify an ID that will be used for the heading (and therefore the permalink hash) using the `id` property. (The `id` property can also be used without permalinking.)
+
 Note that the layout of this pattern is optimized for [our prose containers](/docs/objects-container--prose#prose) with generous horizontal whitespace.
 
 <!--

--- a/src/components/heading/heading.twig
+++ b/src/components/heading/heading.twig
@@ -47,15 +47,15 @@
 {% endset %}
 
 {#
-  If a `permalink` is desired but no `permalink_id` is specified, we try
-  creating a `permalink_id` from the value of `content`.
+  If a `permalink` is desired but no `id` is specified, we try
+  creating a `id` from the value of `content`.
 
   Since Twig lacks a built-in slugify function, this is pretty fragile and
   should be considered a fallback.
 #}
 
-{% if permalink and not permalink_id and content is not empty %}
-  {% set permalink_id = content|lower|escape('url')|replace({'%20': '-'}) %}
+{% if permalink and not id and content is not empty %}
+  {% set id = content|lower|escape('url')|replace({'%20': '-'}) %}
 {% endif %}
 
 {#
@@ -63,21 +63,21 @@
   Marcy Sutton: http://codepen.io/marcysutton/pen/rLKvgZ
 #}
 
-{% if permalink and permalink_id %}
+{% if permalink and id %}
   <div class="{{ _heading_class }}">
-    <a class="c-heading__permalink" href="#{{ permalink_id }}">
+    <a class="c-heading__permalink" href="#{{ id }}">
       {% include '@cloudfour/components/icon/icon.twig' with {
         name: 'link',
         aria_hidden: 'true'
       } only %}
       <span class="u-hidden-visually">Permalink to {{ _content }}</span>
     </a>
-    <{{ tag_name }} class="c-heading__content" id="{{ permalink_id }}">
+    <{{ tag_name }} class="c-heading__content" id="{{ id }}">
       {{ _content }}
     </{{ tag_name }}>
   </div>
 {% else %}
-  <{{ tag_name }} class="{{ _heading_class }}">
+  <{{ tag_name }} class="{{ _heading_class }}" {% if id %}id="{{id}}"{% endif %}>
     {{ _content }}
   </{{ tag_name }}>
 {% endif %}

--- a/src/objects/overview/demo/advanced.twig
+++ b/src/objects/overview/demo/advanced.twig
@@ -17,12 +17,21 @@
     </label>
   {% endblock %}
   {% block content %}
-    <p>
-      Etiam et egestas lorem. Vivamus sagittis sit amet dolor quis lobortis.
-      Integer sed fermentum arcu, id vulputate lacus. Etiam fermentum sem eu
-      quam hendrerit.
-      Nam risus massa, ullamcorper consectetur eros fermentum, porta aliquet
-      ligula. Sed vel mauris nec enim.
-    </p>
+    {% embed '@cloudfour/objects/list/list.twig' with {
+      "tag_name": "ul",
+      "class": "o-list--2-column@m o-list--3-column@l"
+    } %}
+      {% block content %}
+        {% for topic in topics %}
+          <li class="u-space-block-end-0">
+            {% include '@cloudfour/components/dot-leader/dot-leader.twig' with {
+              label: topic.title,
+              count: topic.count,
+              href: 'https://cloudfour.com/thinks/'
+            } only %}
+          </li>
+        {% endfor %}
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 {% endembed %}

--- a/src/objects/overview/demo/advanced.twig
+++ b/src/objects/overview/demo/advanced.twig
@@ -1,9 +1,12 @@
-{% embed '@cloudfour/objects/overview/overview.twig' %}
+{% embed '@cloudfour/objects/overview/overview.twig' with {
+  labelledby_id: 'more-topics'
+} %}
   {% block header %}
     {% include '@cloudfour/components/heading/heading.twig' with {
       level: -1,
       weight: "light",
       content: 'More Topics',
+      id: 'more-topics'
     } only %}
   {% endblock %}
   {% block actions %}

--- a/src/objects/overview/demo/advanced.twig
+++ b/src/objects/overview/demo/advanced.twig
@@ -1,0 +1,28 @@
+{% embed '@cloudfour/objects/overview/overview.twig' %}
+  {% block header %}
+    {% include '@cloudfour/components/heading/heading.twig' with {
+      level: -1,
+      weight: "light",
+      content: 'More Topics',
+    } only %}
+  {% endblock %}
+  {% block actions %}
+    {#
+      In the future we could swap this out for the Input Group component
+      that's currently in the works.
+    #}
+    <label>
+      <span class="u-hidden-visually">Search</span>
+      {% include '@cloudfour/components/input/input.twig' %}
+    </label>
+  {% endblock %}
+  {% block content %}
+    <p>
+      Etiam et egestas lorem. Vivamus sagittis sit amet dolor quis lobortis.
+      Integer sed fermentum arcu, id vulputate lacus. Etiam fermentum sem eu
+      quam hendrerit.
+      Nam risus massa, ullamcorper consectetur eros fermentum, porta aliquet
+      ligula. Sed vel mauris nec enim.
+    </p>
+  {% endblock %}
+{% endembed %}

--- a/src/objects/overview/demo/basic.twig
+++ b/src/objects/overview/demo/basic.twig
@@ -1,0 +1,11 @@
+{% embed '@cloudfour/objects/overview/overview.twig' %}
+  {% block header %}
+    Header
+  {% endblock %}
+  {% block actions %}
+    Actions
+  {% endblock %}
+  {% block content %}
+    Content
+  {% endblock %}
+{% endembed %}

--- a/src/objects/overview/overview.scss
+++ b/src/objects/overview/overview.scss
@@ -32,7 +32,7 @@
       grid-template-areas:
         'header header actions'
         'content content content';
-      grid-template-columns: repeat(3, minmax(max-content, 1fr));
+      grid-template-columns: repeat(3, 1fr);
       row-gap: ms.step(3);
     }
 

--- a/src/objects/overview/overview.scss
+++ b/src/objects/overview/overview.scss
@@ -17,38 +17,40 @@
   margin-bottom: ms.step(3);
 }
 
-@media (min-width: breakpoint.$l) {
-  .o-overview {
-    @include fluid.column-gap(
-      breakpoint.$s,
-      breakpoint.$xl,
-      size.$spacing-gap-fluid-min,
-      size.$spacing-gap-fluid-max
-    );
+@supports (display: grid) {
+  @media (min-width: breakpoint.$l) {
+    .o-overview {
+      @include fluid.column-gap(
+        breakpoint.$s,
+        breakpoint.$xl,
+        size.$spacing-gap-fluid-min,
+        size.$spacing-gap-fluid-max
+      );
 
-    align-items: center;
-    display: grid;
-    grid-template-areas:
-      'header header actions'
-      'content content content';
-    grid-template-columns: repeat(3, minmax(max-content, 1fr));
-    row-gap: ms.step(3);
-  }
+      align-items: center;
+      display: grid;
+      grid-template-areas:
+        'header header actions'
+        'content content content';
+      grid-template-columns: repeat(3, minmax(max-content, 1fr));
+      row-gap: ms.step(3);
+    }
 
-  .o-overview__header,
-  .o-overview__actions {
-    margin: 0;
-  }
+    .o-overview__header,
+    .o-overview__actions {
+      margin: 0;
+    }
 
-  .o-overview__header {
-    grid-area: header;
-  }
+    .o-overview__header {
+      grid-area: header;
+    }
 
-  .o-overview__actions {
-    grid-area: actions;
-  }
+    .o-overview__actions {
+      grid-area: actions;
+    }
 
-  .o-overview__content {
-    grid-area: content;
+    .o-overview__content {
+      grid-area: content;
+    }
   }
 }

--- a/src/objects/overview/overview.scss
+++ b/src/objects/overview/overview.scss
@@ -3,7 +3,11 @@
 @use "../../compiled/tokens/scss/size";
 @use '../../mixins/fluid';
 
-// TODO: Design tokens?
+/**
+ * The Overview stacks content vertically on small screens.
+ * On large screens the header and actions are stacked horizontally above the content.
+ * The specific spacing values were inferred from the Article Listing prototype.
+ */
 
 .o-overview__header {
   margin-bottom: ms.step(1);

--- a/src/objects/overview/overview.scss
+++ b/src/objects/overview/overview.scss
@@ -1,22 +1,50 @@
 @use "../../compiled/tokens/scss/breakpoint";
 @use '../../mixins/ms';
+@use "../../compiled/tokens/scss/size";
+@use '../../mixins/fluid';
 
 // TODO: Design tokens?
 
 .o-overview__header {
-  padding-bottom: ms.step(1);
+  margin-bottom: ms.step(1);
 }
 
 .o-overview__actions {
-  padding-bottom: ms.step(3);
+  margin-bottom: ms.step(3);
 }
 
 @media (min-width: breakpoint.$l) {
   .o-overview {
+    @include fluid.column-gap(
+      breakpoint.$s,
+      breakpoint.$xl,
+      size.$spacing-gap-fluid-min,
+      size.$spacing-gap-fluid-max
+    );
+
+    align-items: center;
     display: grid;
-    grid-template-areas: "
-      header header actions
-      content content content
-    ";
+    grid-template-areas:
+      'header header actions'
+      'content content content';
+    grid-template-columns: repeat(3, minmax(max-content, 1fr));
+    row-gap: ms.step(3);
+  }
+
+  .o-overview__header,
+  .o-overview__actions {
+    margin: 0;
+  }
+
+  .o-overview__header {
+    grid-area: header;
+  }
+
+  .o-overview__actions {
+    grid-area: actions;
+  }
+
+  .o-overview__content {
+    grid-area: content;
   }
 }

--- a/src/objects/overview/overview.scss
+++ b/src/objects/overview/overview.scss
@@ -1,0 +1,22 @@
+@use "../../compiled/tokens/scss/breakpoint";
+@use '../../mixins/ms';
+
+// TODO: Design tokens?
+
+.o-overview__header {
+  padding-bottom: ms.step(1);
+}
+
+.o-overview__actions {
+  padding-bottom: ms.step(3);
+}
+
+@media (min-width: breakpoint.$l) {
+  .o-overview {
+    display: grid;
+    grid-template-areas: "
+      header header actions
+      content content content
+    ";
+  }
+}

--- a/src/objects/overview/overview.stories.mdx
+++ b/src/objects/overview/overview.stories.mdx
@@ -25,11 +25,11 @@ embedded examples.
 
 # Overview
 
-The Overview object can be used to provide an overview of a site section. For example, the overview is used to provide an index of article categories, as well as a form to search for articles.
+The Overview object can be used to provide an overview of a site section. For example, it is used to provide an index of article categories, as well as a form to search for articles.
 
 It handles the responsive layout of `header`, `actions`, and `content` blocks. On small screens they are stacked vertically. On large screens the `header` and `actions` blocks stack horizontally above the `content` block.
 
-The Overview object should usually be placed in a [Container](/docs/objects-container--basic).
+It should usually be placed in a [Container](/docs/objects-container--basic).
 
 <Canvas>
   <Story

--- a/src/objects/overview/overview.stories.mdx
+++ b/src/objects/overview/overview.stories.mdx
@@ -43,7 +43,7 @@ It should usually be placed in a [Container](/docs/objects-container--basic).
       },
     }}
   >
-    {basicDemo.bind({})}
+    {basicDemo()}
   </Story>
 </Canvas>
 

--- a/src/objects/overview/overview.stories.mdx
+++ b/src/objects/overview/overview.stories.mdx
@@ -15,7 +15,9 @@ embedded examples.
 
 # Overview
 
-The Overview object can be used to provide an overview of a site section. For example, the overview is used to provide an index of article categories, as well as a form to search for articles. It handles the responsive layout of `header`, `actions`, and `content` blocks.
+The Overview object can be used to provide an overview of a site section. For example, the overview is used to provide an index of article categories, as well as a form to search for articles.
+
+It handles the responsive layout of `header`, `actions`, and `content` blocks. On small screens they are stacked vertically. On large screens the `header` and `actions` blocks stack horizontally above the `content` block.
 
 The Overview object should usually be placed in a [Container](/docs/objects-container--basic).
 

--- a/src/objects/overview/overview.stories.mdx
+++ b/src/objects/overview/overview.stories.mdx
@@ -15,7 +15,9 @@ embedded examples.
 
 # Overview
 
-TODO
+The Overview object can be used to provide an overview of a site section. For example, the overview is used to provide an index of article categories, as well as a form to search for articles. It handles the responsive layout of `header`, `actions`, and `content` blocks.
+
+The Overview object should usually be placed in a [Container](/docs/objects-container--basic).
 
 <Canvas>
   <Story name="Basic" height="300px">
@@ -23,12 +25,23 @@ TODO
   </Story>
 </Canvas>
 
-# Advanced Usags
+## Advanced Usage
 
-TODO
+Here's a more complex usage example, showing how the Overview object could be used on the article listing page.
 
 <Canvas>
   <Story name="Advanced Usage" height="300px">
     {advancedDemo({topics})}
   </Story>
 </Canvas>
+
+## Template Properties
+
+- `overview_tag` - defaults to `section` but can be switched out for any HTML tag.
+- `labelledby_id` - an optional ID to use with the `aria-labelledby` attribute.
+
+## Template blocks
+
+- `header` - should generally contain a [Heading](/docs/components-heading--levels)
+- `actions` - could contain a searchbar or other actions
+- `content` the primary overview content. For example, a list of categories.

--- a/src/objects/overview/overview.stories.mdx
+++ b/src/objects/overview/overview.stories.mdx
@@ -33,7 +33,7 @@ Here's a more complex usage example, showing how the Overview object could be us
 
 <Canvas>
   <Story name="Advanced Usage" height="300px">
-    {advancedDemo({topics})}
+    {advancedDemo({ topics })}
   </Story>
 </Canvas>
 

--- a/src/objects/overview/overview.stories.mdx
+++ b/src/objects/overview/overview.stories.mdx
@@ -1,6 +1,16 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import basicDemo from './demo/basic.twig';
-import advancedDemo from './demo/advanced.twig';
+import advancedDemo from './demo/advanced.twig'; // The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
+// See: https://github.com/webpack-contrib/raw-loader#examples
+// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
+// okay with the following Webpack-specific raw loader syntax. It's better to leave
+// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
+// within a Storybook docs page and not within an actual component).
+// This can be revisited in the future if Storybook no longer relies on Webpack.
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import basicDemoSource from '!!raw-loader!./demo/basic.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import advancedDemoSource from '!!raw-loader!./demo/advanced.twig';
 import topics from '../../components/dot-leader/demo/topics.json';
 
 <!--
@@ -22,7 +32,17 @@ It handles the responsive layout of `header`, `actions`, and `content` blocks. O
 The Overview object should usually be placed in a [Container](/docs/objects-container--basic).
 
 <Canvas>
-  <Story name="Basic" height="300px">
+  <Story
+    name="Basic"
+    height="300px"
+    parameters={{
+      docs: {
+        source: {
+          code: basicDemoSource,
+        },
+      },
+    }}
+  >
     {basicDemo.bind({})}
   </Story>
 </Canvas>
@@ -32,7 +52,17 @@ The Overview object should usually be placed in a [Container](/docs/objects-cont
 Here's a more complex usage example, showing how the Overview object could be used on the article listing page.
 
 <Canvas>
-  <Story name="Advanced Usage" height="300px">
+  <Story
+    name="Advanced Usage"
+    height="300px"
+    parameters={{
+      docs: {
+        source: {
+          code: advancedDemoSource,
+        },
+      },
+    }}
+  >
     {advancedDemo({ topics })}
   </Story>
 </Canvas>

--- a/src/objects/overview/overview.stories.mdx
+++ b/src/objects/overview/overview.stories.mdx
@@ -1,0 +1,33 @@
+import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import basicDemo from './demo/basic.twig';
+import advancedDemo from './demo/advanced.twig';
+
+<!--
+Inline stories disabled so media queries will behave as expected within
+embedded examples.
+-->
+
+<Meta
+  title="Objects/Overview"
+  parameters={{ docs: { inlineStories: false } }}
+/>
+
+# Overview
+
+TODO
+
+<Canvas>
+  <Story name="Basic" height="300px">
+    {basicDemo.bind({})}
+  </Story>
+</Canvas>
+
+# Advanced Usags
+
+TODO
+
+<Canvas>
+  <Story name="Advanced Usage" height="300px">
+    {advancedDemo.bind({})}
+  </Story>
+</Canvas>

--- a/src/objects/overview/overview.stories.mdx
+++ b/src/objects/overview/overview.stories.mdx
@@ -1,6 +1,7 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import basicDemo from './demo/basic.twig';
 import advancedDemo from './demo/advanced.twig';
+import topics from '../../components/dot-leader/demo/topics.json';
 
 <!--
 Inline stories disabled so media queries will behave as expected within
@@ -28,6 +29,6 @@ TODO
 
 <Canvas>
   <Story name="Advanced Usage" height="300px">
-    {advancedDemo.bind({})}
+    {advancedDemo({topics})}
   </Story>
 </Canvas>

--- a/src/objects/overview/overview.twig
+++ b/src/objects/overview/overview.twig
@@ -1,14 +1,13 @@
-{# TODO: More semantic elements #}
 {# TODO: aria-labelledby? #}
 
-<section class="o-overview">
-  <div class="o-overview__header">
+<{{overview_tag|default('section')}} class="o-overview">
+  <header class="o-overview__header">
     {% block header %}{% endblock %}
-  </div>
+  </header>
   <div class="o-overview__actions">
     {% block actions %}{% endblock %}
   </div>
   <div class="o-overview__content">
     {% block content %}{% endblock %}
   </div>
-</section>
+</{{overview_tag|default('section')}}>

--- a/src/objects/overview/overview.twig
+++ b/src/objects/overview/overview.twig
@@ -1,0 +1,14 @@
+{# TODO: More semantic elements #}
+{# TODO: aria-labelledby? #}
+
+<section class="o-overview">
+  <div class="o-overview__header">
+    {% block header %}{% endblock %}
+  </div>
+  <div class="o-overview__actions">
+    {% block actions %}{% endblock %}
+  </div>
+  <div class="o-overview__content">
+    {% block content %}{% endblock %}
+  </div>
+</section>

--- a/src/objects/overview/overview.twig
+++ b/src/objects/overview/overview.twig
@@ -1,6 +1,7 @@
-{# TODO: aria-labelledby? #}
-
-<{{overview_tag|default('section')}} class="o-overview">
+<{{overview_tag|default('section')}}
+  class="o-overview"
+  {% if labelledby_id %}aria-labelledby="{{labelledby_id}}"{% endif %}
+>
   <header class="o-overview__header">
     {% block header %}{% endblock %}
   </header>

--- a/src/prototypes/article-listing/example/example.scss
+++ b/src/prototypes/article-listing/example/example.scss
@@ -94,11 +94,6 @@
     align-items: center;
     display: flex;
     grid-column: 3 / -1;
-    padding-top: ms.step(1);
-
-    @media (min-width: breakpoint.$l) {
-      padding-top: 0;
-    }
   }
 
   .search-input {

--- a/src/prototypes/article-listing/example/example.scss
+++ b/src/prototypes/article-listing/example/example.scss
@@ -74,26 +74,8 @@
     }
   }
 
-  .topics-header {
-    padding-bottom: ms.step(3);
-
-    @media (min-width: breakpoint.$l) {
-      display: grid;
-      @include fluid.grid-gap(
-        breakpoint.$s,
-        breakpoint.$xl,
-        size.$spacing-gap-fluid-min,
-        size.$spacing-gap-fluid-max
-      );
-      grid-template-columns: repeat(3, minmax(max-content, 1fr));
-      padding-bottom: ms.step(3);
-    }
-  }
-
   .search-content {
-    align-items: center;
     display: flex;
-    grid-column: 3 / -1;
   }
 
   .search-input {
@@ -109,25 +91,5 @@
 
   .search-btn .c-icon {
     font-size: ms.step(1);
-  }
-
-  .topics-content {
-    @media (min-width: breakpoint.$m) {
-      columns: 2;
-      @include fluid.grid-gap(
-        breakpoint.$s,
-        breakpoint.$xl,
-        size.$spacing-gap-fluid-min,
-        size.$spacing-gap-fluid-max
-      );
-    }
-
-    @media (min-width: breakpoint.$l) {
-      columns: 3;
-    }
-  }
-
-  .topics-content li {
-    margin-bottom: ms.step(0);
   }
 }

--- a/src/prototypes/article-listing/example/example.twig
+++ b/src/prototypes/article-listing/example/example.twig
@@ -168,12 +168,15 @@
   {% endfor %}
   <div class="o-container o-container--pad">
     <div class="o-container__content">
-      {% embed '@cloudfour/objects/overview/overview.twig' %}
+      {% embed '@cloudfour/objects/overview/overview.twig' with {
+        labelledby_id: 'more-topics'
+      }  %}
         {% block header %}
           {% include '@cloudfour/components/heading/heading.twig' with {
             level: -1,
             weight: "light",
             content: 'More Topics',
+            id: 'more-topics'
           } only %}
         {% endblock %}
         {% block actions %}

--- a/src/prototypes/article-listing/example/example.twig
+++ b/src/prototypes/article-listing/example/example.twig
@@ -168,41 +168,47 @@
   {% endfor %}
   <div class="o-container o-container--pad">
     <div class="o-container__content">
-      <div class="topics-header">
-        {% include '@cloudfour/components/heading/heading.twig' with {
-          level: -1,
-          tag_name: 'h2',
-          weight: 'light',
-          content: 'More Topics',
-        } only %}
-        <div class="search-content">
-          {% include '@cloudfour/components/input/input.twig' with {
-            class: 'search-input'
-          }  %}
-          {% embed '@cloudfour/components/button/button.twig' with {
-            class: 'search-btn'
-          }  %}
+      {% embed '@cloudfour/objects/overview/overview.twig' %}
+        {% block header %}
+          {% include '@cloudfour/components/heading/heading.twig' with {
+            level: -1,
+            weight: "light",
+            content: 'More Topics',
+          } only %}
+        {% endblock %}
+        {% block actions %}
+          <div class="search-content">
+            {% include '@cloudfour/components/input/input.twig' with {
+              class: 'search-input'
+            }  %}
+            {% embed '@cloudfour/components/button/button.twig' with {
+              class: 'search-btn'
+            }  %}
+              {% block content %}
+                {% include '@cloudfour/components/icon/icon.twig' with {
+                  name: 'magnifying-glass'
+                } %}
+              {% endblock %}
+            {% endembed %}
+          </div>
+        {% endblock %}
+        {% block content %}
+          {% embed '@cloudfour/objects/list/list.twig' with {
+            "tag_name": "ul",
+            "class": "o-list--2-column@m o-list--3-column@l"
+          } %}
             {% block content %}
-              {% include '@cloudfour/components/icon/icon.twig' with {
-                name: 'magnifying-glass'
-              } %}
+              {% for topic in topics %}
+                <li class="u-space-block-end-0">
+                  {% include '@cloudfour/components/dot-leader/dot-leader.twig' with {
+                    label: topic.title,
+                    count: topic.count,
+                    href: 'https://cloudfour.com/thinks/'
+                  } only %}
+                </li>
+              {% endfor %}
             {% endblock %}
           {% endembed %}
-        </div>
-      </div>
-      {% embed '@cloudfour/objects/list/list.twig' with {
-        class: 'topics-content'
-      } %}
-        {% block content %}
-          {% for topic in topics %}
-            <li>
-              {% include '@cloudfour/components/dot-leader/dot-leader.twig' with {
-                label: topic.title,
-                count: topic.count,
-                href: 'https://cloudfour.com/thinks/'
-              } only %}
-            </li>
-          {% endfor %}
         {% endblock %}
       {% endembed %}
     </div>


### PR DESCRIPTION
## Overview

This PR adds an "Overview" object which is used on the Article Listing pages to show a full list of topics and a search bar. The Article Listings prototype was updated to use this component

## Screenshots

<img width="1440" alt="Screen Shot 2021-07-16 at 12 32 02 PM" src="https://user-images.githubusercontent.com/5798536/125999615-8f66c41f-1a3b-414b-ac55-ebec9734d34b.png">
<img width="1092" alt="Screen Shot 2021-07-16 at 12 32 08 PM" src="https://user-images.githubusercontent.com/5798536/125999619-dc175f52-d3f3-4b91-b003-90e88c8a0ee4.png">

## Testing

1. Compare the Article Listings prototype on the [current site](https://v-next--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-article-listing--example&args=&viewMode=story) and the [preview deploy](https://deploy-preview-1406--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-article-listing--example). They should look pretty much identical
2. Confirm on the [preview deploy](https://deploy-preview-1406--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-article-listing--example)you can [use the VoiceOver rotor in Safari](https://support.apple.com/guide/voiceover/with-the-voiceover-rotor-mchlp2719/mac) and see there is a "More Topics region" listed in the Landmarks section.  (enable VoiceOver. press Option, Command, U. If necessary, use the arrow keys to navigate to the Landmarks section)
3. Confirm there are no regressions with [heading permalinks.](https://deploy-preview-1406--cloudfour-patterns.netlify.app/?path=/story/components-heading--permalinks)

---

- Fixes #1376

/CC @dromo77 
