### PR TITLE
Refine Badge component code examples

### DIFF
--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -1,5 +1,12 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import template from './badge.twig';
+const badgeStory = (args) => {
+  // Don't bother with the inline options if they don't exist or are defaults
+  if (args.icon === '') {
+    delete args.icon;
+  }
+  return template(args);
+};
 
 <Meta
   title="Components/Badge"
@@ -22,7 +29,7 @@ Badges help provide just a smidge more context to repetitive or serialized conte
 
 <Canvas>
   <Story name="Basic" args={{ label: 'Hello' }}>
-    {(args) => template(args)}
+    {(args) => badgeStory(args)}
   </Story>
 </Canvas>
 
@@ -30,14 +37,14 @@ Badges help provide just a smidge more context to repetitive or serialized conte
 
 <Canvas>
   <Story name="With icon" args={{ icon: 'check', label: 'Verified' }}>
-    {(args) => template(args)}
+    {(args) => badgeStory(args)}
   </Story>
 </Canvas>
 
 ## Template Properties
 
 - `class` (string)
-- `icon` (string): The name of one of [our icons](/docs/design-icons--page) to display.
+- `icon` (string, optional): The name of one of [our icons](/docs/design-icons--page) to display.
 - `message` (string, default `'Label'`)
 
 ## Template Blocks


### PR DESCRIPTION
## Overview

This PR refines the Badge component code examples.

## Testing

Preview: https://deploy-preview-1414--cloudfour-patterns.netlify.app/?path=/docs/components-badge--basic

1. Review the Badge component story code examples for accuracy

---

- See #1289 