### PR TITLE
Refine Input component code examples & simplify stories

### DIFF
--- a/src/components/input/demo/example.twig
+++ b/src/components/input/demo/example.twig
@@ -1,7 +1,0 @@
-<demo class="demo-input-basic{% if type != 'textarea' %} demo-input-basic--single-line{% endif %}">
-  <label for="{{id}}">Label</label>
-  {% block element %}
-    {% include '@cloudfour/components/input/input.twig' %}
-  {% endblock %}
-  {% include '@cloudfour/components/button/button.twig' with { label: 'Button' } only %}
-</demo>

--- a/src/components/input/demo/select.twig
+++ b/src/components/input/demo/select.twig
@@ -1,5 +1,8 @@
-{% embed '@cloudfour/components/input/demo/example.twig' %}
-  {% block element %}
-    {% include '@cloudfour/components/input/select.twig' %}
+{% embed '@cloudfour/components/input/select.twig' only %}
+  {% block options %}
+    <option value="this">This</option>
+    <option value="that">That</option>
+    <option value="other">Other</option>
+    <option value="none">None</option>
   {% endblock %}
 {% endembed %}

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -1,9 +1,28 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import { useEffect } from '@storybook/client-api';
-import textDemo from './demo/example.twig';
+import { makeTwigInclude } from '../../make-twig-include';
+// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
+// See: https://github.com/webpack-contrib/raw-loader#examples
+// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
+// okay with the following Webpack-specific raw loader syntax. It's better to leave
+// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
+// within a Storybook docs page and not within an actual component).
+// This can be revisited in the future if Storybook no longer relies on Webpack.
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import selectDemoSource from '!!raw-loader!./demo/select.twig';
 import selectDemo from './demo/select.twig';
+import input from './input.twig';
 import './demo/styles.scss';
 import { createElasticTextArea } from './elastic-textarea.ts';
+const elasticTextAreaConfig = {
+  type: 'textarea',
+  value:
+    'We are a small, versatile team who care passionately about the web. We’re full of what our industry considers unicorns. Our designers code. Our developers went to art school.',
+  placeholder: 'Placeholder text…',
+  id: 'demo-elastic',
+  rows: 2,
+  class: 'c-input--elastic js-elastic-textarea',
+};
 
 <!--
 Inline stories disabled because when the same input element is rendered with
@@ -22,7 +41,6 @@ The `c-input` class styles text and text-like form elements in a consistent way.
 <Canvas>
   <Story
     name="Text Elements"
-    height="200px"
     argTypes={{
       type: {
         type: { name: 'enum' },
@@ -42,7 +60,7 @@ The `c-input` class styles text and text-like form elements in a consistent way.
       disabled: { type: { name: 'boolean' }, defaultValue: false },
     }}
   >
-    {(args) => textDemo(args)}
+    {(args) => input(args)}
   </Story>
 </Canvas>
 
@@ -51,11 +69,11 @@ You can also add `c-input` to `<select>` elements, in which case you’ll get a 
 <Canvas>
   <Story
     name="Select Element"
-    height="200px"
     argTypes={{
       id: { type: { name: 'string' }, defaultValue: 'demo-input' },
       disabled: { type: { name: 'boolean' }, defaultValue: false },
     }}
+    parameters={{ docs: { source: { code: selectDemoSource } } }}
   >
     {(args) => selectDemo(args)}
   </Story>
@@ -70,12 +88,23 @@ If the `rows` attribute is set, it will be used as the minimum height.
 <Canvas>
   <Story
     name="Elastic Textarea"
-    height="350px"
+    height="250px"
     argTypes={{
       rows: { type: { name: 'number' }, defaultValue: 2 },
       class: {
         type: { name: 'string' },
         defaultValue: 'c-input--elastic js-elastic-textarea',
+      },
+    }}
+    args={elasticTextAreaConfig}
+    parameters={{
+      docs: {
+        source: {
+          code: makeTwigInclude(
+            '@cloudfour/components/input/input.twig',
+            elasticTextAreaConfig
+          ),
+        },
       },
     }}
   >
@@ -85,15 +114,7 @@ If the `rows` attribute is set, it will be used as the minimum height.
       useEffect(() => {
         createElasticTextArea(document.querySelector('.js-elastic-textarea'));
       }, []);
-      return textDemo({
-        type: 'textarea',
-        value:
-          'We are a small, versatile team who care passionately about the web. We’re full of what our industry considers unicorns. Our designers code. Our developers went to art school.',
-        placeholder: 'Placeholder text…',
-        id: 'demo-elastic',
-        rows: args.rows,
-        class: args.class,
-      });
+      return input(args);
     }}
   </Story>
 </Canvas>


### PR DESCRIPTION
## Overview

This PR refines the Input component code examples and simplifies a couple of the stories as well.

## Screenshots

<img width="1048" alt="Screen Shot 2021-07-20 at 12 06 37 PM" src="https://user-images.githubusercontent.com/459757/126381332-7cc1a0d7-70f0-4be7-93a0-5985c7bdf056.png">

<img width="1035" alt="Screen Shot 2021-07-20 at 12 07 03 PM" src="https://user-images.githubusercontent.com/459757/126381400-2971f8f4-1085-4e27-9b2b-1a616ac510f8.png">


## Testing

Preview: https://deploy-preview-1419--cloudfour-patterns.netlify.app/?path=/docs/components-input--elastic-textarea

1. Review the Input component story code examples for accuracy

---

- See #1289 