### PR TITLE
Only run CI on PRs and pushes to v-next/main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+    - v-next
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
   push:
     branches:
-    - main
-    - v-next
+      - main
+      - v-next
 
 jobs:
   lint:


### PR DESCRIPTION
Closes #1421, see #1421 for reasons

[here's the docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on)