### PR TITLE
Add Speaking Listing prototype

### DIFF
--- a/src/prototypes/speaking-listing/data/future.json
+++ b/src/prototypes/speaking-listing/data/future.json
@@ -25,5 +25,12 @@
     "speaker": "Jason",
     "date": "2020-06-14",
     "note": "2 day event"
+  },
+  {
+    "event": "Smashing Conference",
+    "location": "Freiburg, Germany",
+    "speaker": "Jason",
+    "date": "2020-09-12",
+    "note": "2 day event"
   }
 ]

--- a/src/prototypes/speaking-listing/data/future.json
+++ b/src/prototypes/speaking-listing/data/future.json
@@ -1,0 +1,29 @@
+[
+  {
+    "event": "An Event Apart",
+    "location": "Nashville, TN",
+    "speaker": "Jason",
+    "date": "2020-03-14",
+    "note": "3 day event"
+  },
+  {
+    "event": "An Event Apart",
+    "location": "Seattle, WA",
+    "speaker": "Jason",
+    "date": "2020-04-14",
+    "note": "3 day event"
+  },
+  {
+    "event": "Front End PDX",
+    "location": "Portland, OR",
+    "speaker": "Tyler",
+    "date": "2020-04-12"
+  },
+  {
+    "event": "Smashing Conference",
+    "location": "New York, NY",
+    "speaker": "Jason",
+    "date": "2020-06-14",
+    "note": "2 day event"
+  }
+]

--- a/src/prototypes/speaking-listing/data/speaking.json
+++ b/src/prototypes/speaking-listing/data/speaking.json
@@ -33,7 +33,8 @@
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
     "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/10/the-path-forward.jpg",
-    "description": "Presented at An Event Apart, Portland Digital Summit, PADNU + 2 more"
+    "description": "Presented at An Event Apart, Portland Digital Summit, PADNU",
+    "more": "+ 2 more"
   },
   {
     "title": "SVG: So Very Good",
@@ -42,7 +43,8 @@
     "author": "Tyler Sticka",
     "avatar": "https://cloudfour.com/wp-content/uploads/2017/06/tyler-128x128-c-default.png",
     "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/08/svg-slide-1.png",
-    "description": "Presented at Smashing Conference, Open Source Bridge, CascadiaFest + 1 more"
+    "description": "Presented at Smashing Conference, Open Source Bridge, CascadiaFest",
+    "more": "+ 1 more"
   },
   {
     "title": "Responsive images are here. Now what?",
@@ -69,7 +71,8 @@
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
     "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/being-responsive.jpg",
-    "description": "Presented at Federal Reserve UX Summit, Gore UX Summit, Epic Systems + 1 more"
+    "description": "Presented at Federal Reserve UX Summit, Gore UX Summit, Epic Systems",
+    "more": "+ 1 more"
   },
   {
     "title": "The virtuoso generalist",
@@ -87,7 +90,8 @@
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
     "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/adaptive-input.jpg",
-    "description": "Presented at UX Mobile Immersion, Refresh PDX, Beyond the Desktop + 5 more"
+    "description": "Presented at UX Mobile Immersion, Refresh PDX, Beyond the Desktop",
+    "more": "+ 5 more"
   },
   {
     "title": "Mobile First Responsive Design",
@@ -96,7 +100,8 @@
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
     "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/mobile-first.jpg",
-    "description": "Presented at An Event Apart, User Experience Lisbon, Respond + 6 more"
+    "description": "Presented at An Event Apart, User Experience Lisbon, Respond",
+    "more": "+ 6 more"
   },
   {
     "title": "Side Projects That Ships",
@@ -114,7 +119,8 @@
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
     "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/immobile-web-16-9.jpg",
-    "description": "Presented at An Event Apart, UX Mobile Immersion, Breaking Development + 2 more"
+    "description": "Presented at An Event Apart, UX Mobile Immersion, Breaking Development",
+    "more": "+ 2 more"
   },
   {
     "title": "PhoneGap Self Defense for Web Developers",
@@ -150,7 +156,8 @@
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
     "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/desktop-shackles.jpg",
-    "description": "Presented at WebVisions, Talk at HP, BeerMob + 2 more"
+    "description": "Presented at WebVisions, Talk at HP, BeerMob",
+    "more": "+ 2 more"
   },
   {
     "title": "The Essence of Content of the Future Web",
@@ -177,7 +184,8 @@
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
     "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/iStock_000001555960Medium.jpg",
-    "description": "Presented at MIMA Summit, OCCA, Innotech + 7 more"
+    "description": "Presented at MIMA Summit, OCCA, Innotech",
+    "more": "+ 7 more"
   },
   {
     "title": "Cup Noodle Ignite Talk",
@@ -186,6 +194,7 @@
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
     "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/freeze-drying.jpg",
-    "description": "Presented at Google Zeitgeist, Web 2.0 Expo, Gnomedex + 1 more"
+    "description": "Presented at Google Zeitgeist, Web 2.0 Expo, Gnomedex",
+    "more": "+ 1 more"
   }
 ]

--- a/src/prototypes/speaking-listing/data/speaking.json
+++ b/src/prototypes/speaking-listing/data/speaking.json
@@ -1,0 +1,191 @@
+[
+  {
+    "title": "Designing Progressive Web Apps",
+    "pubDate": "2020-11-19 17:28:54",
+    "link": "https://cloudfour.com/presents/designing-progressive-web-apps/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2018/10/background-black-blank-733857.jpg",
+    "description": "Presented at Artifact Conference, Smashing Conference, An Event Apart"
+  },
+  {
+    "title": "Web Forms: Now You See Them, Now You Don’t!",
+    "pubDate": "2020-11-17 08:30:14",
+    "link": "https://cloudfour.com/presents/web-forms-now-you-see-them-now-you-dont/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2019/12/webforms-title-page.png",
+    "description": "Presented at An Event Apart"
+  },
+  {
+    "title": "What is Modular Css",
+    "pubDate": "2020-10-30 08:00:21",
+    "link": "https://cloudfour.com/thinks/perfectly-broken-code/",
+    "author": "Scott Vandehey",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2019/03/scott.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2019/02/legos.png",
+    "description": "Presented at pdxFLIT, Devsigner 2016"
+  },
+  {
+    "title": "The Case for Progressive Web Apps",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/why-you-should-build-a-progressive-web-app-now/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/10/the-path-forward.jpg",
+    "description": "Presented at An Event Apart, Portland Digital Summit, PADNU + 2 more"
+  },
+  {
+    "title": "SVG: So Very Good",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/svg-so-very-good/",
+    "author": "Tyler Sticka",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2017/06/tyler-128x128-c-default.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/08/svg-slide-1.png",
+    "description": "Presented at Smashing Conference, Open Source Bridge, CascadiaFest + 1 more"
+  },
+  {
+    "title": "Responsive images are here. Now what?",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/responsive-images-are-here-now-what",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/responsive-images-here.jpg",
+    "description": "Presented at Imagecon, An Event Apart, Responsive Day Out"
+  },
+  {
+    "title": "Adapting to Input",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/adapting-to-input/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/adapting-to-input.jpg",
+    "description": "Presented at An Event Apart, Smashing Conference"
+  },
+  {
+    "title": "Being Responsive",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/being-responsive/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/being-responsive.jpg",
+    "description": "Presented at Federal Reserve UX Summit, Gore UX Summit, Epic Systems + 1 more"
+  },
+  {
+    "title": "The virtuoso generalist",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/the-virtuoso-generalist/",
+    "author": "Lyza Gardner",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2019/02/cloudfour-avatar-default-blue.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/virtuoso-generalist.jpg",
+    "description": "Presented at Responsive Day Out, Web Design Day"
+  },
+  {
+    "title": "Adaptive Input",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/adaptive-input/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/adaptive-input.jpg",
+    "description": "Presented at UX Mobile Immersion, Refresh PDX, Beyond the Desktop + 5 more"
+  },
+  {
+    "title": "Mobile First Responsive Design",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/mobile-first-responsive-design/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/mobile-first.jpg",
+    "description": "Presented at An Event Apart, User Experience Lisbon, Respond + 6 more"
+  },
+  {
+    "title": "Side Projects That Ships",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/side-projects-that-ship/",
+    "author": "Tyler Sticka",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2017/06/tyler-128x128-c-default.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/feature-image-side-projects-that-ship.png",
+    "description": "Presented at Refresh Portland, WebVisions"
+  },
+  {
+    "title": "The Immobile Web",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/the-immobile-web/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/immobile-web-16-9.jpg",
+    "description": "Presented at An Event Apart, UX Mobile Immersion, Breaking Development + 2 more"
+  },
+  {
+    "title": "PhoneGap Self Defense for Web Developers",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/phonegap-self-defense-for-web-developers/",
+    "author": "Lyza Gardner",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2019/02/cloudfour-avatar-default-blue.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/joyleap.jpg",
+    "description": "Presented at PhoneGap Day US"
+  },
+  {
+    "title": "Mobile Media Panel",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/mobile-media-images-video-audio-and-webrtc/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/mobile-media.jpg",
+    "description": "Presented at Google I/O"
+  },
+  {
+    "title": "The Most Common Denominator",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/the-most-common-denominator-supporting-more-sucking-less/",
+    "author": "Lyza Gardner",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2019/02/cloudfour-avatar-default-blue.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/common-denominator.jpg",
+    "description": "Presented at Breaking Development"
+  },
+  {
+    "title": "Casting Off Our Desktop Shackles",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/casting-off-our-desktop-shackles/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/desktop-shackles.jpg",
+    "description": "Presented at WebVisions, Talk at HP, BeerMob + 2 more"
+  },
+  {
+    "title": "The Essence of Content of the Future Web",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/performance-implications-of-responsive-design/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/performance-responsive.jpg",
+    "description": "Presented at Velocity"
+  },
+  {
+    "title": "Responsive Design Performance",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/cutting-through-the-crap-the-essence-of-content-on-the-future-web/",
+    "author": "Lyza Gardner",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2019/02/cloudfour-avatar-default-blue.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/cutting-crap.jpg",
+    "description": "Presented at Mobilism"
+  },
+  {
+    "title": "DOs and DONTs of Mobile Strategy",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/get-me-a-mobile-strategy-of-youre-fired/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/iStock_000001555960Medium.jpg",
+    "description": "Presented at MIMA Summit, OCCA, Innotech + 7 more"
+  },
+  {
+    "title": "Cup Noodle Ignite Talk",
+    "pubDate": "2020-10-19 15:44:36",
+    "link": "https://cloudfour.com/presents/cup-noodle-innovation-inspiration-and-manga/",
+    "author": "Jason Grigsby",
+    "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
+    "thumbnail": "https://cloudfour.com/wp-content/uploads/2016/07/freeze-drying.jpg",
+    "description": "Presented at Google Zeitgeist, Web 2.0 Expo, Gnomedex + 1 more"
+  }
+]

--- a/src/prototypes/speaking-listing/data/speaking.json
+++ b/src/prototypes/speaking-listing/data/speaking.json
@@ -1,7 +1,6 @@
 [
   {
     "title": "Designing Progressive Web Apps",
-    "pubDate": "2020-11-19 17:28:54",
     "link": "https://cloudfour.com/presents/designing-progressive-web-apps/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -10,7 +9,6 @@
   },
   {
     "title": "Web Forms: Now You See Them, Now You Don’t!",
-    "pubDate": "2020-11-17 08:30:14",
     "link": "https://cloudfour.com/presents/web-forms-now-you-see-them-now-you-dont/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -19,7 +17,6 @@
   },
   {
     "title": "What is Modular CSS",
-    "pubDate": "2020-10-30 08:00:21",
     "link": "https://cloudfour.com/thinks/perfectly-broken-code/",
     "author": "Scott Vandehey",
     "avatar": "https://cloudfour.com/wp-content/uploads/2019/03/scott.png",
@@ -28,7 +25,6 @@
   },
   {
     "title": "The Case for Progressive Web Apps",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/why-you-should-build-a-progressive-web-app-now/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -38,7 +34,6 @@
   },
   {
     "title": "SVG: So Very Good",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/svg-so-very-good/",
     "author": "Tyler Sticka",
     "avatar": "https://cloudfour.com/wp-content/uploads/2017/06/tyler-128x128-c-default.png",
@@ -48,7 +43,6 @@
   },
   {
     "title": "Responsive images are here. Now what?",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/responsive-images-are-here-now-what",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -57,7 +51,6 @@
   },
   {
     "title": "Adapting to Input",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/adapting-to-input/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -66,7 +59,6 @@
   },
   {
     "title": "Being Responsive",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/being-responsive/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -76,7 +68,6 @@
   },
   {
     "title": "The virtuoso generalist",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/the-virtuoso-generalist/",
     "author": "Lyza Gardner",
     "avatar": "https://cloudfour.com/wp-content/uploads/2019/02/cloudfour-avatar-default-blue.png",
@@ -85,7 +76,6 @@
   },
   {
     "title": "Adaptive Input",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/adaptive-input/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -95,7 +85,6 @@
   },
   {
     "title": "Mobile First Responsive Design",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/mobile-first-responsive-design/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -105,7 +94,6 @@
   },
   {
     "title": "Side Projects That Ships",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/side-projects-that-ship/",
     "author": "Tyler Sticka",
     "avatar": "https://cloudfour.com/wp-content/uploads/2017/06/tyler-128x128-c-default.png",
@@ -114,7 +102,6 @@
   },
   {
     "title": "The Immobile Web",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/the-immobile-web/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -124,7 +111,6 @@
   },
   {
     "title": "PhoneGap Self Defense for Web Developers",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/phonegap-self-defense-for-web-developers/",
     "author": "Lyza Gardner",
     "avatar": "https://cloudfour.com/wp-content/uploads/2019/02/cloudfour-avatar-default-blue.png",
@@ -133,7 +119,6 @@
   },
   {
     "title": "Mobile Media Panel",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/mobile-media-images-video-audio-and-webrtc/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -142,7 +127,6 @@
   },
   {
     "title": "The Most Common Denominator",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/the-most-common-denominator-supporting-more-sucking-less/",
     "author": "Lyza Gardner",
     "avatar": "https://cloudfour.com/wp-content/uploads/2019/02/cloudfour-avatar-default-blue.png",
@@ -151,7 +135,6 @@
   },
   {
     "title": "Casting Off Our Desktop Shackles",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/casting-off-our-desktop-shackles/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -161,7 +144,6 @@
   },
   {
     "title": "The Essence of Content of the Future Web",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/performance-implications-of-responsive-design/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -170,7 +152,6 @@
   },
   {
     "title": "Responsive Design Performance",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/cutting-through-the-crap-the-essence-of-content-on-the-future-web/",
     "author": "Lyza Gardner",
     "avatar": "https://cloudfour.com/wp-content/uploads/2019/02/cloudfour-avatar-default-blue.png",
@@ -179,7 +160,6 @@
   },
   {
     "title": "DOs and DONTs of Mobile Strategy",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/get-me-a-mobile-strategy-of-youre-fired/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",
@@ -189,7 +169,6 @@
   },
   {
     "title": "Cup Noodle Ignite Talk",
-    "pubDate": "2020-10-19 15:44:36",
     "link": "https://cloudfour.com/presents/cup-noodle-innovation-inspiration-and-manga/",
     "author": "Jason Grigsby",
     "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/jason.png",

--- a/src/prototypes/speaking-listing/data/speaking.json
+++ b/src/prototypes/speaking-listing/data/speaking.json
@@ -18,7 +18,7 @@
     "description": "Presented at An Event Apart"
   },
   {
-    "title": "What is Modular Css",
+    "title": "What is Modular CSS",
     "pubDate": "2020-10-30 08:00:21",
     "link": "https://cloudfour.com/thinks/perfectly-broken-code/",
     "author": "Scott Vandehey",

--- a/src/prototypes/speaking-listing/example/example.scss
+++ b/src/prototypes/speaking-listing/example/example.scss
@@ -1,8 +1,35 @@
 @use "../../../compiled/tokens/scss/color";
+@use "../../../compiled/tokens/scss/ease";
+@use "../../../compiled/tokens/scss/scale";
+@use "../../../compiled/tokens/scss/transition";
 
 #speaking-listing {
   .more-text {
     color: #{color.$brand-primary};
     white-space: nowrap;
+  }
+
+  .media-link {
+    text-decoration: none;
+  }
+
+  .media-link {
+    color: #{color.$text-dark};
+  }
+
+  .media-link h3 {
+    color: #{color.$brand-primary};
+  }
+
+  .media-link:hover h3 {
+    text-decoration: underline;
+  }
+
+  .media-link .o-media__object {
+    transition: transform transition.$quick ease.$out;
+  }
+
+  .media-link:hover .o-media__object {
+    transform: scale(scale.$effect-grow);
   }
 }

--- a/src/prototypes/speaking-listing/example/example.scss
+++ b/src/prototypes/speaking-listing/example/example.scss
@@ -1,0 +1,10 @@
+@use "../../../compiled/tokens/scss/color";
+@use "../../../compiled/tokens/scss/breakpoint";
+@use "../../../compiled/tokens/scss/size";
+@use '../../../mixins/fluid';
+@use '../../../mixins/media-query';
+@use "../../../mixins/ms";
+
+#speaking-listing {
+
+}

--- a/src/prototypes/speaking-listing/example/example.scss
+++ b/src/prototypes/speaking-listing/example/example.scss
@@ -6,5 +6,8 @@
 @use "../../../mixins/ms";
 
 #speaking-listing {
-
+  .more-text {
+    color: #{color.$brand-primary};
+    white-space: nowrap;
+  }
 }

--- a/src/prototypes/speaking-listing/example/example.scss
+++ b/src/prototypes/speaking-listing/example/example.scss
@@ -1,9 +1,4 @@
 @use "../../../compiled/tokens/scss/color";
-@use "../../../compiled/tokens/scss/breakpoint";
-@use "../../../compiled/tokens/scss/size";
-@use '../../../mixins/fluid';
-@use '../../../mixins/media-query';
-@use "../../../mixins/ms";
 
 #speaking-listing {
   .more-text {

--- a/src/prototypes/speaking-listing/example/example.twig
+++ b/src/prototypes/speaking-listing/example/example.twig
@@ -35,11 +35,7 @@
               {% endblock %}
               {% block content %}
                 <p>
-                  {% if article.description|length > 140 %}
-                    {{item.description|slice(0, 140)|trim}}…
-                  {% else %}
-                    {{item.description}}
-                  {% endif %}
+                  {{item.description}} {% if item.more %}<span class="more-text">{{item.more}}</span>{% endif %}
                 </p>
               {% endblock %}
               {% block footer %}

--- a/src/prototypes/speaking-listing/example/example.twig
+++ b/src/prototypes/speaking-listing/example/example.twig
@@ -1,0 +1,152 @@
+<div id="speaking-listing">
+  {% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
+    {% block content %}
+      {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
+        class: 'o-rhythm--condensed'
+      } only %}
+        {% block content %}
+          {% include '@cloudfour/components/heading/heading.twig' with {
+            level: -2,
+            content: 'Speaking'
+          } only %}
+          <p>
+            Saying what we mean, meaning what we say
+          </p>
+        {% endblock %}
+      {% endembed %}
+    {% endblock %}
+  {% endembed %}
+  <div class="o-container o-container--pad">
+    <div class="o-container__content">
+      {% embed '@cloudfour/objects/deck/deck.twig' with {
+        class: 'o-deck--3-column@l'
+      } %}
+        {% block content %}
+          {% for item in speaking %}
+            {% embed '@cloudfour/components/card/card.twig' with {
+              class: _card_class,
+              href: item.link
+            } %}
+              {% block heading %}
+                {{item.title}}
+              {% endblock %}
+              {% block cover %}
+                <img src="{{item.thumbnail}}" alt="">
+              {% endblock %}
+              {% block content %}
+                <p>
+                  {% if article.description|length > 140 %}
+                    {{item.description|slice(0, 140)|trim}}…
+                  {% else %}
+                    {{item.description}}
+                  {% endif %}
+                </p>
+              {% endblock %}
+              {% block footer %}
+                <div class="c-author o-media">
+                  <div class="o-media__object">
+                    {% include '@cloudfour/components/avatar/avatar.twig' with { src: item.avatar } only %}
+                  </div>
+                  <div class="o-media__content">
+                    <p<a href="#">{{item.author}}</a></p>
+                  </div>
+                </div>
+              {% endblock %}
+            {% endembed %}
+          {% endfor %}
+        {% endblock %}
+      {% endembed %}
+    </div>
+  </div>
+  {% include '@cloudfour/components/ground-nav/ground-nav.twig' with {
+    "menu": {
+      "items": [
+        {
+          "link": "/does",
+          "title": "What We Do",
+          "current": true
+        },
+        {
+          "link": "/believes",
+          "title": "Our Approach"
+        },
+        {
+          "link": "/made",
+          "title": "Our Work"
+        },
+        {
+          "link": "/thinks",
+          "title": "Articles"
+        },
+        {
+          "link": "/presents",
+          "title": "Speaking"
+        },
+        {
+          "link": "/contributes",
+          "title": "Labs"
+        },
+        {
+          "link": "/is",
+          "title": "Team"
+        },
+        {
+          "link": "/portland-device-lab",
+          "title": "Device Lab"
+        },
+        {
+          "link": "https://cloudfour-patterns.netlify.app/",
+          "title": "Patterns"
+        },
+        {
+          "link": "https://www.responsivefieldday.com/",
+          "title": "Responsive Field Day"
+        }
+      ]
+    },
+    "social": {
+      "items": [
+        {
+          "link": "https://twitter.com/cloudfour",
+          "title": "Follow us on Twitter",
+          "icon": "brands/twitter"
+        },
+        {
+          "link": "https://github.com/cloudfour",
+          "title": "Find us on GitHub",
+          "icon": "brands/github"
+        },
+        {
+          "link": "https://www.instagram.com/cloudfourpdx/",
+          "title": "Follow us on Instagram",
+          "icon": "brands/instagram"
+        },
+        {
+          "link": "https://www.linkedin.com/company/cloud-four",
+          "title": "Follow us on LinkedIn",
+          "icon": "brands/linkedin"
+        }
+      ]
+    },
+    "action": {
+      "lead_in": "Let’s discuss your project!",
+      "title": "Email us",
+      "link": "mailto:info@cloudfour.com",
+      "icon": "envelope"
+    },
+    "organization": {
+      "name": "Cloud Four, Inc.",
+      "address": {
+        "street_address": "510 SW 3rd Ave, Suite 420",
+        "address_locality": "Portland",
+        "address_region": "Oregon",
+        "postal_code": "97204",
+        "address_country": "USA"
+      },
+      "email": "info@cloudfour.com",
+      "telephone": "+1 (503) 290-1090",
+      "url": "https://cloudfour.com/",
+      "founding_date": "2007-12-13"
+    }
+  } only %}
+</div>

--- a/src/prototypes/speaking-listing/example/example.twig
+++ b/src/prototypes/speaking-listing/example/example.twig
@@ -18,7 +18,9 @@
   {% endembed %}
   <div class="o-container o-container--pad">
     <div class="o-container__content">
-      {% embed '@cloudfour/objects/rhythm/rhythm.twig' %}
+      {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
+        class: 'o-rhythm--generous'
+      } %}
         {% block content %}
           {% include '@cloudfour/components/heading/heading.twig' with {
             level: -1,

--- a/src/prototypes/speaking-listing/example/example.twig
+++ b/src/prototypes/speaking-listing/example/example.twig
@@ -18,38 +18,75 @@
   {% endembed %}
   <div class="o-container o-container--pad">
     <div class="o-container__content">
-      {% embed '@cloudfour/objects/deck/deck.twig' with {
-        class: 'o-deck--3-column@l'
-      } %}
+      {% embed '@cloudfour/objects/rhythm/rhythm.twig' %}
         {% block content %}
-          {% for item in speaking %}
-            {% embed '@cloudfour/components/card/card.twig' with {
-              class: _card_class,
-              href: item.link
-            } %}
-              {% block heading %}
-                {{item.title}}
-              {% endblock %}
-              {% block cover %}
-                <img src="{{item.thumbnail}}" alt="">
-              {% endblock %}
-              {% block content %}
-                <p>
-                  {{item.description}} {% if item.more %}<span class="more-text">{{item.more}}</span>{% endif %}
-                </p>
-              {% endblock %}
-              {% block footer %}
-                <div class="c-author o-media">
-                  <div class="o-media__object">
-                    {% include '@cloudfour/components/avatar/avatar.twig' with { src: item.avatar } only %}
-                  </div>
-                  <div class="o-media__content">
-                    <p<a href="#">{{item.author}}</a></p>
-                  </div>
-                </div>
-              {% endblock %}
-            {% endembed %}
-          {% endfor %}
+          {% include '@cloudfour/components/heading/heading.twig' with {
+            level: -1,
+            tag_name: 'h2',
+            content: 'Future Events',
+          } only %}
+          {% embed '@cloudfour/objects/deck/deck.twig' with {
+            class: 'o-deck--3-column@l'
+          } %}
+            {% block content %}
+              {% for item in future %}
+                <a href="#" class="media-link">
+                {% embed '@cloudfour/objects/media/media.twig' with { reverse_markup: true } %}
+                  {% block object %}
+                    {% include '@cloudfour/components/calendar-date/calendar-date.twig' with {
+                      datetime: item.date,
+                      note: item.note
+                    } only %}
+                  {% endblock %}
+                  {% block content %}
+                    <h3>{{item.event}}</h3>
+                    <p>{{item.location}}</p>
+                    <p>Speaker: {{item.speaker}}</p>
+                  {% endblock %}
+                {% endembed %}
+                </a>
+              {% endfor %}
+            {% endblock %}
+          {% endembed %}
+          {% include '@cloudfour/components/heading/heading.twig' with {
+            level: -1,
+            tag_name: 'h2',
+            content: 'Our Talks',
+          } only %}
+          {% embed '@cloudfour/objects/deck/deck.twig' with {
+            class: 'o-deck--3-column@l'
+          } %}
+            {% block content %}
+              {% for item in speaking %}
+                {% embed '@cloudfour/components/card/card.twig' with {
+                  class: _card_class,
+                  href: item.link
+                } %}
+                  {% block heading %}
+                    {{item.title}}
+                  {% endblock %}
+                  {% block cover %}
+                    <img src="{{item.thumbnail}}" alt="">
+                  {% endblock %}
+                  {% block content %}
+                    <p>
+                      {{item.description}} {% if item.more %}<span class="more-text">{{item.more}}</span>{% endif %}
+                    </p>
+                  {% endblock %}
+                  {% block footer %}
+                    <div class="c-author o-media">
+                      <div class="o-media__object">
+                        {% include '@cloudfour/components/avatar/avatar.twig' with { src: item.avatar } only %}
+                      </div>
+                      <div class="o-media__content">
+                        <p<a href="#">{{item.author}}</a></p>
+                      </div>
+                    </div>
+                  {% endblock %}
+                {% endembed %}
+              {% endfor %}
+            {% endblock %}
+          {% endembed %}
         {% endblock %}
       {% endembed %}
     </div>

--- a/src/prototypes/speaking-listing/speaking.stories.js
+++ b/src/prototypes/speaking-listing/speaking.stories.js
@@ -1,4 +1,5 @@
 import speaking from './data/speaking.json';
+import future from './data/future.json';
 import examplePrototype from './example/example.twig';
 import './example/example.scss';
 
@@ -10,4 +11,4 @@ export default {
   },
 };
 
-export const Example = () => examplePrototype({ speaking });
+export const Example = () => examplePrototype({ speaking, future });

--- a/src/prototypes/speaking-listing/speaking.stories.js
+++ b/src/prototypes/speaking-listing/speaking.stories.js
@@ -1,0 +1,13 @@
+import speaking from './data/speaking.json';
+import examplePrototype from './example/example.twig';
+import './example/example.scss';
+
+export default {
+  title: 'Prototypes/Speaking Listing',
+  parameters: {
+    docs: { page: null },
+    paddings: { disable: true },
+  },
+};
+
+export const Example = () => examplePrototype({ speaking });


### PR DESCRIPTION
## Overview

This PR adds a prototype of the speaking page. It's an overview of talks Cloud Four has given. The design similar to the [current page](https://cloudfour.com/presents/), but uses our new patterns.

## Screenshots

![Screen Shot 2021-07-21 at 3 11 12 PM](https://user-images.githubusercontent.com/42841342/126568184-b880bddd-e08a-466c-81b5-b62b9cbd2fa1.png)

---

- This is 1/2 of issue #1417. The other part will involve prototyping the individual pages.
