### PR TITLE
Rename and document npm scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run Preprocess
         run: npm run preprocess
       - name: Run Lint
-        run: npm run check-lint
+        run: npm run lint:check
 
   type:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,16 +5,25 @@ Thanks for contributing to the Cloud Four Pattern Library!
 ## Getting Started
 
 1. `npm ci` — to install dependencies
-1. `npm run storybook` — to run a local instance of Storybook
+1. `npm start` — to run a local instance of Storybook
 
 ## Building
 
 - `npm run build` — Builds CSS+JS for npm package
 - `npm run build-storybook` — Creates a static storybook site build, for example for publishing the pattern library to Netlify
 
-## Testing
+## Validating
 
-Note that tests will fail if you have not built the project. If you see tests failing with errors like "file not found in `dist` folder", try running `npm run build` and then re-run the tests.
+You can run `npm run validate` to run all of the checks that will be run in CI (except for building).
+
+You can also run checks individually:
+
+- **Linters/formatters**: `npm run lint` (runs Prettier, ESLint, and Stylelint)
+- **Tests**: `npm run test` (runs Jest tests)
+  You can also run `npm run test:watch` to run Jest in watch mode
+  Note that tests will fail if you have not built the project. If you see tests failing with errors like "file not found in `dist` folder", try running `npm run build` and then re-run the tests.
+- **Typechecking** `npm run type` (runs TypeScript)
+  You can also run `npm run type:watch` to run TypeScript in watch mode
 
 ## Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudfour/patterns",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudfour/patterns",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "focus-visible": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "webpack": "4.46.0"
   },
   "scripts": {
+    "start": "npm run storybook",
     "storybook": "npm run preprocess && run-p watch start-storybook",
     "start-storybook": "start-storybook -p 6006 -s ./static,./src/assets",
     "build-storybook": "npm run preprocess && build-storybook -s ./static,./src/assets",
@@ -132,16 +133,17 @@
     "clean": "eliminate dist",
     "type": "tsc",
     "type:watch": "tsc --watch",
-    "check-lint": "run-s check-lint:*",
-    "check-lint:prettier": "prettier . --check",
-    "check-lint:css": "stylelint '**/*.scss'",
-    "check-lint:js": "eslint .",
     "lint": "run-s lint:*",
-    "lint:prettier": "prettier . --write",
-    "lint:css": "stylelint --fix '**/*.scss'",
+    "lint:check": "run-s lint:*:check",
     "lint:js": "eslint . --fix",
+    "lint:js:check": "eslint .",
+    "lint:css": "stylelint --fix '**/*.scss'",
+    "lint:css:check": "stylelint '**/*.scss'",
+    "lint:prettier": "prettier . --write",
+    "lint:prettier:check": "prettier . --check",
     "test": "jest",
     "test:watch": "jest --watch",
+    "validate": "run-s test lint:check type",
     "version": "changeset version && prettier --write .",
     "release": "npm run build && changeset publish"
   }


### PR DESCRIPTION
Closes #1294 

- I changed some of the script names to match https://github.com/cloudfour/guides/blob/main/package-json-script-names.md, and I added the `validate` script.
- I added the `start` script, which does the same thing as `npm run storybook` (per @Paul-Hebert's suggestion)
- I reordered some scripts so that Prettier runs after ESLint. This matters because if ESLint makes "fixes" to code, its fixes often do not conform to Prettier formatting. So running Prettier after ESLint makes sure that ESLint's fixes get formatted correctly.
- I documented the most-used npm scripts in contributing.md