### PR TITLE
Refine the visual display of the comment reply form help text

### DIFF
--- a/.changeset/cold-melons-boil.md
+++ b/.changeset/cold-melons-boil.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Refine the visual display of the comment reply form help text

--- a/src/components/comment-form/comment-form.scss
+++ b/src/components/comment-form/comment-form.scss
@@ -3,7 +3,8 @@
 
 .c-comment-form {
   display: grid;
-  grid-gap: size.$spacing-gap-comment-form-vertical size.$spacing-gap-comment-form-horizontal;
+  grid-gap: size.$spacing-gap-comment-form-vertical
+    size.$spacing-gap-comment-form-horizontal;
   grid-template-columns: 1fr 1fr;
 }
 

--- a/src/components/comment-form/comment-form.scss
+++ b/src/components/comment-form/comment-form.scss
@@ -3,7 +3,7 @@
 
 .c-comment-form {
   display: grid;
-  grid-gap: ms.step(2, 1rem) ms.step(4, 1rem);
+  grid-gap: size.$spacing-gap-comment-form-vertical size.$spacing-gap-comment-form-horizontal;
   grid-template-columns: 1fr 1fr;
 }
 

--- a/src/components/comment-form/comment-form.stories.mdx
+++ b/src/components/comment-form/comment-form.stories.mdx
@@ -62,7 +62,7 @@ The form used to add a comment to an article. Including the `heading_id` and `he
   </Story>
 </Canvas>
 
-There is also a reply version of this component (`is_reply: true`), used to reply to an existing comment. (You'll also want to modify `heading_tag`, `heading_id`, `heading_class`, `heading_text`, `main_label`, and `wrap_help_text_in_alert`. When using the [Comment pattern](/docs/components-comment--with-reply-button) this will be done automatically.)
+There is also a reply version of this component (`is_reply: true`), used to reply to an existing comment. (You'll also want to modify `heading_tag`, `heading_id`, `heading_class`, `heading_text`, and `main_label`. When using the [Comment pattern](/docs/components-comment--with-reply-button) this will be done automatically.)
 
 <Canvas>
   <Story
@@ -82,7 +82,6 @@ There is also a reply version of this component (`is_reply: true`), used to repl
               heading_text: 'Reply to John Doe',
               heading_class: 'u-hidden-visually',
               main_label: 'Reply',
-              wrap_help_text_in_alert: true,
             }
           ),
         },
@@ -105,7 +104,6 @@ There is also a reply version of this component (`is_reply: true`), used to repl
         heading_text: 'Reply to John Doe',
         heading_class: 'u-hidden-visually',
         main_label: 'Reply',
-        wrap_help_text_in_alert: true,
       });
     }}
   </Story>
@@ -120,7 +118,6 @@ There is also a reply version of this component (`is_reply: true`), used to repl
 - `heading_class`: An optional class for your heading.
 - `heading_id`: A unique ID for your help text. This will be used as the accessible description for the reply textarea.
 - `main_label`: The label for the primary message textarea. Defaults to `message`
-- `wrap_help_text_in_alert`: Wraps the help text in the promo in an [Alert](/docs/components-alert--basic)
 - `logged_in_user`: [user object](https://timber.github.io/docs/reference/timber-user/#properties) of the type:
 
   ```ts

--- a/src/components/comment-form/comment-form.stories.mdx
+++ b/src/components/comment-form/comment-form.stories.mdx
@@ -62,7 +62,7 @@ The form used to add a comment to an article. Including the `heading_id` and `he
   </Story>
 </Canvas>
 
-There is also a reply version of this component (`is_reply: true`), used to reply to an existing comment. (You'll also want to modify `heading_tag`, `heading_id`, `heading_class`, and `heading_text`. When using the [Comment pattern](/docs/components-comment--with-reply-button) this will be done automatically.)
+There is also a reply version of this component (`is_reply: true`), used to reply to an existing comment. (You'll also want to modify `heading_tag`, `heading_id`, `heading_class`, `heading_text`, `main_label`, and `wrap_help_text_in_alert`. When using the [Comment pattern](/docs/components-comment--with-reply-button) this will be done automatically.)
 
 <Canvas>
   <Story
@@ -82,6 +82,7 @@ There is also a reply version of this component (`is_reply: true`), used to repl
               heading_text: 'Reply to John Doe',
               heading_class: 'u-hidden-visually',
               main_label: 'Reply',
+              wrap_help_text_in_alert: true,
             }
           ),
         },
@@ -104,6 +105,7 @@ There is also a reply version of this component (`is_reply: true`), used to repl
         heading_text: 'Reply to John Doe',
         heading_class: 'u-hidden-visually',
         main_label: 'Reply',
+        wrap_help_text_in_alert: true,
       });
     }}
   </Story>

--- a/src/components/comment-form/comment-form.stories.mdx
+++ b/src/components/comment-form/comment-form.stories.mdx
@@ -120,6 +120,7 @@ There is also a reply version of this component (`is_reply: true`), used to repl
 - `heading_class`: An optional class for your heading.
 - `heading_id`: A unique ID for your help text. This will be used as the accessible description for the reply textarea.
 - `main_label`: The label for the primary message textarea. Defaults to `message`
+- `wrap_help_text_in_alert`: Wraps the help text in the promo in an [Alert](/docs/components-alert--basic)
 - `logged_in_user`: [user object](https://timber.github.io/docs/reference/timber-user/#properties) of the type:
 
   ```ts

--- a/src/components/comment-form/comment-form.twig
+++ b/src/components/comment-form/comment-form.twig
@@ -1,13 +1,3 @@
-{% set help_text %}
-  <p {% if help_text_id %}id="{{ help_text_id }}"{% endif %}>
-      Please be kind, courteous and constructive.
-      You may use simple HTML or
-      <a href="https://en.support.wordpress.com/markdown-quick-reference">Markdown</a>
-      in your comments.
-      All fields are required.
-  </p>
-{% endset %}
-
 <form
   class="c-comment-form{% if class %} {{class}}{% endif %}"
   {% if heading_id %}aria-labelledby="{{ heading_id }}"{% endif %}
@@ -23,15 +13,17 @@
       {{ heading_text|default("Leave a Comment") }}
     </{{_heading_tag}}>
 
-    {% if wrap_help_text_in_alert %}
-      {% embed '@cloudfour/components/alert/alert.twig' %}
-        {% block content %}
-          {{help_text}}
-        {% endblock %}
-      {% endembed %}
-    {% else %}
-      {{help_text}}
-    {% endif %}
+    {% embed '@cloudfour/components/alert/alert.twig' %}
+      {% block content %}
+        <p {% if help_text_id %}id="{{ help_text_id }}"{% endif %}>
+          Please be kind, courteous and constructive.
+          You may use simple HTML or
+          <a href="https://en.support.wordpress.com/markdown-quick-reference">Markdown</a>
+          in your comments.
+          All fields are required.
+        </p>
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
   {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: main_label|default('Message') } %}
     {% block control %}

--- a/src/components/comment-form/comment-form.twig
+++ b/src/components/comment-form/comment-form.twig
@@ -1,3 +1,13 @@
+{% set help_text %}
+  <p {% if help_text_id %}id="{{ help_text_id }}"{% endif %}>
+      Please be kind, courteous and constructive.
+      You may use simple HTML or
+      <a href="https://en.support.wordpress.com/markdown-quick-reference">Markdown</a>
+      in your comments.
+      All fields are required.
+  </p>
+{% endset %}
+
 <form
   class="c-comment-form{% if class %} {{class}}{% endif %}"
   {% if heading_id %}aria-labelledby="{{ heading_id }}"{% endif %}
@@ -12,13 +22,16 @@
     >
       {{ heading_text|default("Leave a Comment") }}
     </{{_heading_tag}}>
-    <p {% if help_text_id %}id="{{ help_text_id }}"{% endif %}>
-      Please be kind, courteous and constructive.
-      You may use simple HTML or
-      <a href="https://en.support.wordpress.com/markdown-quick-reference">Markdown</a>
-      in your comments.
-      All fields are required.
-    </p>
+
+    {% if wrap_help_text_in_alert %}
+      {% embed '@cloudfour/components/alert/alert.twig' %}
+        {% block content %}
+          {{help_text}}
+        {% endblock %}
+      {% endembed %}
+    {% else %}
+      {{help_text}}
+    {% endif %}
   {% endblock %}
   {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: main_label|default('Message') } %}
     {% block control %}

--- a/src/components/comment/comment.scss
+++ b/src/components/comment/comment.scss
@@ -4,6 +4,7 @@
 @use '../../compiled/tokens/scss/size';
 @use '../../mixins/headings';
 @use '../../mixins/theme';
+@use "../../mixins/ms";
 
 .c-comment {
   display: grid;
@@ -50,6 +51,10 @@
 
 .c-comment.is-replying .c-comment__reply-form {
   display: block;
+  /// The top margin matches the grid gap spacing applied to the comment form.
+  /// Otherwise, the form's help text appears visually closer to the comment
+  /// you're responding to than to the form.
+  margin-top: ms.step(2, 1rem);
 }
 
 /// Named object for consistency with the Media component.
@@ -134,10 +139,6 @@
   // Visually centers the child avatars with the indentation of the parent
   // comment. Without this, the replies feel nested too far to the right.
   margin-left: math.div(size.$square-avatar-small, -2);
-}
-
-.c-comment__replies,
-.c-comment__reply-form {
   // Since the replies are likely wrapped in a Rhythm object intended to inherit
   // the parent rhythm, we can use that custom property to inherit that same
   // spacing between the meta and replies.

--- a/src/components/comment/comment.scss
+++ b/src/components/comment/comment.scss
@@ -54,7 +54,7 @@
   /// The top margin matches the grid gap spacing applied to the comment form.
   /// Otherwise, the form's help text appears visually closer to the comment
   /// you're responding to than to the form.
-  margin-top: ms.step(2, 1rem);
+  margin-top: size.$spacing-gap-comment-form-vertical;
 }
 
 /// Named object for consistency with the Media component.

--- a/src/components/comment/comment.scss
+++ b/src/components/comment/comment.scss
@@ -4,7 +4,6 @@
 @use '../../compiled/tokens/scss/size';
 @use '../../mixins/headings';
 @use '../../mixins/theme';
-@use "../../mixins/ms";
 
 .c-comment {
   display: grid;

--- a/src/components/comment/comment.twig
+++ b/src/components/comment/comment.twig
@@ -125,7 +125,6 @@
           heading_text: "Reply to #{comment.author.name}",
           heading_class: 'u-hidden-visually',
           main_label: 'Reply',
-          wrap_help_text_in_alert: true,
         } only %}
       </div>
     {% endif %}

--- a/src/components/comment/comment.twig
+++ b/src/components/comment/comment.twig
@@ -125,6 +125,7 @@
           heading_text: "Reply to #{comment.author.name}",
           heading_class: 'u-hidden-visually',
           main_label: 'Reply',
+          wrap_help_text_in_alert: true,
         } only %}
       </div>
     {% endif %}

--- a/src/tokens/size/spacing.js
+++ b/src/tokens/size/spacing.js
@@ -1,4 +1,4 @@
-const { modularEm } = require('../../scripts/modular-scale');
+const { modularEm, modularRem } = require('../../scripts/modular-scale');
 
 module.exports = {
   size: {
@@ -49,6 +49,10 @@ module.exports = {
         logo_group: {
           value: modularEm(3),
         },
+        comment_form: {
+          horizontal: { value: modularRem(4) },
+          vertical: { value: modularRem(2) },
+        }
       },
       control: {
         text_inset: { value: modularEm(-1) },

--- a/src/tokens/size/spacing.js
+++ b/src/tokens/size/spacing.js
@@ -52,7 +52,7 @@ module.exports = {
         comment_form: {
           horizontal: { value: modularRem(4) },
           vertical: { value: modularRem(2) },
-        }
+        },
       },
       control: {
         text_inset: { value: modularEm(-1) },


### PR DESCRIPTION
## Overview

This PR wraps the help text in and alert, and adjust the spacing between the reply form and the comment above.

The goal is to more clearly distinguish the reply form from the comment, and make it clear that the help text is connected to the reply form, not the comment above.|

## Screenshots

<img width="606" alt="Screen Shot 2021-07-22 at 12 48 33 PM" src="https://user-images.githubusercontent.com/5798536/126700674-8f668c5f-950c-49aa-857b-c2c4f95231cc.png">

## Testing

1. Review the [preview deploy](https://deploy-preview-1434--cloudfour-patterns.netlify.app/?path=/story/components-comment--with-reply-button)

---

Fixes #1427

/CC @tylersticka 
