### PR TITLE
Fix issue with Comment `replies` block not working

### DIFF
--- a/.changeset/large-teachers-roll.md
+++ b/.changeset/large-teachers-roll.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix issue with Comment `replies` block not working

--- a/src/components/comment/comment.stories.mdx
+++ b/src/components/comment/comment.stories.mdx
@@ -109,9 +109,7 @@ It is helpful for context within a discussion to know when a commentor is the or
     {(args) => {
       useEffect(() => initCommentReplyForms());
       return authorDemo({
-        comment: makeComment({
-          replies: 2,
-        }),
+        comment: makeComment(),
         allow_replies: args.allowReplies,
         demo_post_author: true,
         logged_in_user: args.isLoggedIn ? tyler : null,

--- a/src/components/comment/comment.stories.mdx
+++ b/src/components/comment/comment.stories.mdx
@@ -109,7 +109,9 @@ It is helpful for context within a discussion to know when a commentor is the or
     {(args) => {
       useEffect(() => initCommentReplyForms());
       return authorDemo({
-        comment: makeComment(),
+        comment: makeComment({
+          replies: 2,
+        }),
         allow_replies: args.allowReplies,
         demo_post_author: true,
         logged_in_user: args.isLoggedIn ? tyler : null,

--- a/src/components/comment/comment.twig
+++ b/src/components/comment/comment.twig
@@ -113,18 +113,27 @@
       <h{{_section_heading_depth}} class="u-hidden-visually">
         Replies to {{comment.author.name}}
       </h{{_section_heading_depth}}>
+
+      {#
+        This is defined here, so we can pass it into the block of a nested embed.
+        @see https://benfurfie.co.uk/articles/how-to-nest-a-block-in-another-block-in-an-embed-in-twig
+      #}
+      {% set repliesContent %}
+        {% block replies %}
+          {% for child in comment.children %}
+            {% include '@cloudfour/components/comment/comment.twig' with {
+              comment: child,
+              heading_depth: _child_heading_depth,
+            } only %}
+          {% endfor %}
+        {% endblock %}
+      {% endset %}
+
       {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
         class: 'c-comment__replies'
       } %}
         {% block content %}
-          {% block replies %}
-            {% for child in comment.children %}
-              {% include '@cloudfour/components/comment/comment.twig' with {
-                comment: child,
-                heading_depth: _child_heading_depth,
-              } only %}
-            {% endfor %}
-          {% endblock %}
+          {{ repliesContent }}
         {% endblock %}
       {% endembed %}
     {% endif %}


### PR DESCRIPTION
## Overview

The Comment template has a `replies` block allowing devs to customize how replies are output.

This block was not working correctly because it was nested inside another embed.

This PR uses `set` to define the replies outside of the embed and then pass them in.