### PR TITLE
Move button group source examples to docs code

### DIFF
--- a/src/objects/button-group/button-group.stories.mdx
+++ b/src/objects/button-group/button-group.stories.mdx
@@ -29,17 +29,31 @@ The Button Group layout object can be used for aligning a group of related butto
 
 ## Default
 
-```twig
-{% embed '@cloudfour/objects/button-group/button-group.twig' %}
-  {% block content %}
-    {% include '@cloudfour/components/button/button.twig' with { label: 'Button 1' } %}
-    {% include '@cloudfour/components/button/button.twig' with { label: 'Button 2' } %}
-  {% endblock %}
-{% endembed %}
-```
+<!-- The object demo is not particularly helpful if its source is imported directly,
+so we've provided it manually to the docs add-on via parameters. -->
 
 <Canvas>
-  <Story name="Default">{(args) => demo(args)}</Story>
+  <Story
+    name="Default"
+    parameters={{
+      docs: {
+        source: {
+          code: `{% embed '@cloudfour/objects/button-group/button-group.twig' only %}
+  {% block content %}
+    {% include '@cloudfour/components/button/button.twig' with {
+      label: 'Button 1'
+    } only %}
+    {% include '@cloudfour/components/button/button.twig' with {
+      label: 'Button 2'
+    } only %}
+  {% endblock %}
+{% endembed %}`,
+        },
+      },
+    }}
+  >
+    {(args) => demo(args)}
+  </Story>
 </Canvas>
 
 ## Grow modifer
@@ -47,14 +61,25 @@ The Button Group layout object can be used for aligning a group of related butto
 You can have the buttons grow to fill their horizontal space via
 the template `grow` boolean argument:
 
-```twig
-{% embed '@cloudfour/objects/button-group/button-group.twig' with { grow: true } %}
-  ...
-{% endembed %}
-```
+<!-- The object demo is not particularly helpful if its source is imported directly,
+so we've provided it manually to the docs add-on via parameters. -->
 
 <Canvas>
-  <Story name="Grow" args={{ count: 5, grow: true }}>
+  <Story
+    name="Grow"
+    args={{ count: 5, grow: true }}
+    parameters={{
+      docs: {
+        source: {
+          code: `{% embed '@cloudfour/objects/button-group/button-group.twig' with {
+  grow: true
+} only %}
+  {# buttons #}
+{% endembed %}`,
+        },
+      },
+    }}
+  >
     {(args) => demo(args)}
   </Story>
 </Canvas>


### PR DESCRIPTION
## Overview

See title.

## Screenshots

<img width="634" alt="Screen Shot 2021-07-26 at 3 52 59 PM" src="https://user-images.githubusercontent.com/69633/127069367-0437eecd-4afd-4247-b542-2f3301f5361f.png">

<img width="628" alt="Screen Shot 2021-07-26 at 3 53 05 PM" src="https://user-images.githubusercontent.com/69633/127069371-a0f080b8-c927-4e45-aef8-3040e6bfaeb7.png">

---

- See #1447 