### PR TITLE
Improve deck source examples

### DIFF
--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -2,10 +2,35 @@ import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import articles from './demo/articles.json';
 import articlesDemo from './demo/articles.twig';
 const articlesStory = (args) => articlesDemo({ items: articles, ...args });
+// Custom function for generating story source from args given
+const articlesTemplateSource = (_src, storyContext) => {
+  const { args } = storyContext;
+  let twigArgs = '';
+  if (
+    args.columns &&
+    args.columns > 1 &&
+    args.columnsBreakpoint &&
+    args.columnsBreakpoint !== 'none'
+  ) {
+    twigArgs = ` with {
+  class: 'o-deck--${args.columns}-column${args.columnsBreakpoint}'
+}`;
+  }
+  return `{% embed '@cloudfour/objects/deck/deck.twig'${twigArgs} only %}
+  {% block content %}
+    {# cards #}
+  {% endblock %}
+{% endembed %}`;
+};
 
 <Meta
   title="Objects/Deck"
-  parameters={{ docs: { inlineStories: false } }}
+  parameters={{
+    docs: {
+      inlineStories: false,
+      transformSource: articlesTemplateSource,
+    },
+  }}
   argTypes={{
     columns: {
       control: {


### PR DESCRIPTION
## Overview

For this one I used a `transformSource` function because I thought the class names were complex enough that it would be helpful to have them match the `args` for individual stories without all the logic that's in the demo template.

## Screenshots

<img width="1040" alt="Screen Shot 2021-07-28 at 2 59 20 PM" src="https://user-images.githubusercontent.com/69633/127401826-cc6c927e-fa13-432a-9822-c201a486a698.png">

---

- See #1447
