### PR TITLE
Improve embed source examples

### DIFF
--- a/src/objects/embed/embed.stories.mdx
+++ b/src/objects/embed/embed.stories.mdx
@@ -1,7 +1,7 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
 import tokens from '../../compiled/tokens/js/tokens';
 import imageDemo from './demo/image.twig';
-import imageDemoSrc from './demo/design-system-navigation.png';
+import imageDemoImgSrc from './demo/design-system-navigation.png';
 import penDemo from './demo/pen.twig';
 import pictureDemo from './demo/picture.twig';
 import pictureDemoJpgSrc from './demo/twilight.jpg';
@@ -21,8 +21,24 @@ const defaultArgTypes = {
   },
   aspect_ratio: { type: { name: 'string' } },
 };
+// Custom embed source function to preserve args in source code examples
+const embedTransformSource = (_src, storyContext) => {
+  const { args } = storyContext;
+  const argsString =
+    Object.keys(args).length > 0
+      ? ` with ${JSON.stringify(args, null, 2)}`
+      : '';
+  return `{% embed '@cloudfour/objects/embed/embed.twig'${argsString} only %}
+  {% block content %}
+    {# image, video or embed #}
+  {% endblock %}
+{% endembed %}`;
+};
 
-<Meta title="Objects/Embed" />
+<Meta
+  title="Objects/Embed"
+  parameters={{ docs: { transformSource: embedTransformSource } }}
+/>
 
 # Embed
 
@@ -39,7 +55,7 @@ Embed objects support two methods for specifying the desired aspect ratio:
 
 <Canvas>
   <Story name="Image" argTypes={defaultArgTypes}>
-    {(args) => imageDemo({ ...args, src: imageDemoSrc })}
+    {(args) => imageDemo({ ...args, src: imageDemoImgSrc })}
   </Story>
 </Canvas>
 
@@ -70,12 +86,19 @@ Embed objects support two methods for specifying the desired aspect ratio:
 Embeds may be combined with [rounded corner utilities](/docs/utilities-rounded-corners--sizes). In this example, a square embed becomes circular thanks to `u-rounded-full`.
 
 <Canvas>
-  <Story name="Rounded">
-    {imageDemo({
+  <Story
+    name="Rounded"
+    args={{
       class: 'u-rounded-full',
       style: 'max-width: 10em',
-      src: roundedDemoSrc,
-    })}
+    }}
+  >
+    {(args) =>
+      imageDemo({
+        ...args,
+        src: roundedDemoSrc,
+      })
+    }
   </Story>
 </Canvas>
 


### PR DESCRIPTION
## Overview

See title. As with #1452, this uses a `transformSource` function to dynamically update a source code example per story.

## Screenshots

<img width="1048" alt="Screen Shot 2021-07-28 at 4 10 50 PM" src="https://user-images.githubusercontent.com/69633/127407930-47df0fdd-5bd7-4f31-97c0-d20edf89b9e6.png">

---

- See #1447 
