### PR TITLE
Improve media source examples

### DIFF
--- a/src/objects/media/demo/calendar-date.twig
+++ b/src/objects/media/demo/calendar-date.twig
@@ -1,4 +1,6 @@
-{% embed '@cloudfour/objects/media/media.twig' with { reverse_markup: true } %}
+{% embed '@cloudfour/objects/media/media.twig' with {
+  reverse_markup: true
+} only %}
   {% block object %}
     {% include '@cloudfour/components/calendar-date/calendar-date.twig' with {
       datetime: '2020-08-17',

--- a/src/objects/media/demo/checkbox.twig
+++ b/src/objects/media/demo/checkbox.twig
@@ -1,4 +1,7 @@
-{% embed '@cloudfour/objects/media/media.twig' with { tag_name: 'label', inner_tag_name: 'span' } %}
+{% embed '@cloudfour/objects/media/media.twig' with {
+  tag_name: 'label',
+  inner_tag_name: 'span'
+} only %}
   {% block object %}
     {% include '@cloudfour/components/checkbox/checkbox.twig' with {
       class: 'o-media__object'

--- a/src/objects/media/media.stories.mdx
+++ b/src/objects/media/media.stories.mdx
@@ -1,15 +1,41 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs/blocks';
+// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
+// See: https://github.com/webpack-contrib/raw-loader#examples
+// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we
+// are okay with the following Webpack-specific raw loader syntax. It's better
+// to leave the ESLint rule enabled globally, and only thoughtfully disable as
+// needed (e.g. within a Storybook docs page and not within an actual
+// component). This can be revisited in the future if Storybook no longer relies
+// on Webpack.
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import calendarDateDemoSource from '!!raw-loader!./demo/calendar-date.twig';
 import calendarDateDemo from './demo/calendar-date.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import checkboxDemoSource from '!!raw-loader!./demo/checkbox.twig';
 import checkboxDemo from './demo/checkbox.twig';
 import imageDemo from './demo/image.twig';
 import meganProfileImage from './demo/megan.png';
 const exampleText =
   'One of the things that is really clear to us (and that we hear often from our clients) is that the way we engage with our clients is unique. In fact, bringing clients in early and often to our process is one of our specialties at Cloud Four.';
-const imgSizeOptions = {
-  type: 'range',
-  min: 24,
-  max: 256,
-  step: 1,
+// We define a transformSource function for the image demo since it needs to
+// respond to args more dynamically than other demos.
+const imageDemoTransformSource = (_src, storyContext) => {
+  const { args } = storyContext;
+  const withStr = args.reverse
+    ? ` with {
+  reverse: true
+}`
+    : '';
+  return `{% embed '@cloudfour/objects/media/media.twig'${withStr} only %}
+  {% block object %}
+    {% include '@cloudfour/components/avatar/avatar.twig' with {
+      src: '${args.imgSrc}'
+    } only %}
+  {% endblock %}
+  {% block content %}
+    <p>${args.text}</p>
+  {% endblock %}
+{% endembed %}`;
 };
 
 <Meta
@@ -20,11 +46,6 @@ const imgSizeOptions = {
       defaultValue: meganProfileImage,
     },
     text: { type: { name: 'string' }, defaultValue: exampleText },
-    imgSize: {
-      type: { name: 'number' },
-      control: imgSizeOptions,
-      defaultValue: 64,
-    },
     reverse: { type: { name: 'boolean' }, defaultValue: false },
   }}
 />
@@ -40,7 +61,16 @@ This pattern is composed of three elements:
 - `o-media__content` for the wrapping content (typically text). This content will appear middle-aligned with the object until it exceeds the object's height, at which point it will appear top-aligned.
 
 <Canvas>
-  <Story name="Image">{(args) => imageDemo(args)}</Story>
+  <Story
+    name="Image"
+    parameters={{
+      docs: {
+        transformSource: imageDemoTransformSource,
+      },
+    }}
+  >
+    {(args) => imageDemo(args)}
+  </Story>
 </Canvas>
 
 ## Reverse Order
@@ -48,7 +78,15 @@ This pattern is composed of three elements:
 The order of `o-media__object` and `o-media__content` will not affect this pattern's visual appearance. To display the object on the right, use the `o-media--reverse` modifier.
 
 <Canvas>
-  <Story name="Image Reversed" args={{ reverse: true }}>
+  <Story
+    name="Image Reversed"
+    args={{ reverse: true }}
+    parameters={{
+      docs: {
+        transformSource: imageDemoTransformSource,
+      },
+    }}
+  >
     {(args) => imageDemo(args)}
   </Story>
 </Canvas>
@@ -58,7 +96,12 @@ The order of `o-media__object` and `o-media__content` will not affect this patte
 In this example, `o-media` is applied to a `<label>` element, `o-media__object` to [a Checkbox component](/docs/components-checkbox--enabled), and `o-media__content` to a `<span>`.
 
 <Canvas>
-  <Story name="Checkbox Label">{checkboxDemo}</Story>
+  <Story
+    name="Checkbox Label"
+    parameters={{ docs: { source: { code: checkboxDemoSource } } }}
+  >
+    {checkboxDemo}
+  </Story>
 </Canvas>
 
 ## Event Summary
@@ -66,5 +109,10 @@ In this example, `o-media` is applied to a `<label>` element, `o-media__object` 
 In this example, the object is [a Calendar Date component](/docs/components-calendar-date--basic). Even though it's included _after_ the heading to promote a sensible document outline, it still visually precedes the content.
 
 <Canvas>
-  <Story name="Event Summary">{calendarDateDemo}</Story>
+  <Story
+    name="Event Summary"
+    parameters={{ docs: { source: { code: calendarDateDemoSource } } }}
+  >
+    {calendarDateDemo}
+  </Story>
 </Canvas>


### PR DESCRIPTION
## Overview

This one uses a `transformSource` function for the examples that respond to `args` and `raw-loader` for the examples that are static. The static examples were updated slightly to improve the copy-ability of the source code.

## Screenshots

<img width="1040" alt="Screen Shot 2021-07-29 at 7 51 57 AM" src="https://user-images.githubusercontent.com/69633/127514353-275752f2-1897-48c7-9227-b14ddb40dd97.png">

---

- See #1447 
