### PR TITLE
Introduces an "alternate" theme

### DIFF
--- a/src/base/_themes.scss
+++ b/src/base/_themes.scss
@@ -44,6 +44,10 @@
 
 /**
  * Alternate theme
+ *
+ * An alternate, or secondary, theme that can offset a section of content visually
+ * from its surroundings. This may be helpful for distinguishing rows of content
+ * from one another in a subtle way.
  */
 
 @include theme.props(alternate) {

--- a/src/base/_themes.scss
+++ b/src/base/_themes.scss
@@ -43,10 +43,19 @@
 }
 
 /**
+ * Alternate theme
+ */
+
+@include theme.props(alternate) {
+  --theme-color-background-base: var(--theme-color-background-secondary);
+}
+
+/**
  * Container styles
  */
 
 .t-light,
-.t-dark {
+.t-dark,
+.t-alternate {
   @include theme.rules();
 }

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -83,10 +83,6 @@ $_ground-nav-border-color: color.$base-gray-light;
   }
 }
 
-.c-ground-nav__content {
-  background-color: color.$base-gray-lighter;
-}
-
 /**
  * Creates vertical space between elements when grid isn't supported.
  */

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -43,7 +43,7 @@
   </div>
   {% endwith %}
 
-  <div class="c-ground-nav__content o-container o-container--pad">
+  <div class="c-ground-nav__content o-container o-container--pad t-alternate">
     <div class="c-ground-nav__content-inner o-container__content">
       <h2 class="u-hidden-visually">
         Contact info

--- a/src/design/demo/theme-alternate.twig
+++ b/src/design/demo/theme-alternate.twig
@@ -1,0 +1,18 @@
+{% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
+  class: 'o-rhythm--generous o-container--pad'
+} %}
+  {% block content %}
+    <h1>t-{{theme}}</h1>
+    {% include '@cloudfour/design/typography/demo/inline-elements.twig' only %}
+    {% include '@cloudfour/components/button/demo/styles.twig' only %}
+  {% endblock %}
+{% endembed %}
+{% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
+  class: 'o-rhythm--generous o-container--pad t-alternate'
+} %}
+  {% block content %}
+    <h2>t-alternate within t-{{theme}}</h2>
+    {% include '@cloudfour/design/typography/demo/inline-elements.twig' only %}
+    {% include '@cloudfour/components/button/demo/styles.twig' only %}
+  {% endblock %}
+{% endembed %}

--- a/src/design/themes.stories.mdx
+++ b/src/design/themes.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import demo from './demo/theme.twig';
+import alternateDemo from './demo/theme-alternate.twig';
 const demoStory = (args) => demo(args);
 
 <Meta title="Design/Themes" />
@@ -29,6 +30,30 @@ Optimized for page intros and headings.
 <Canvas>
   <Story name="Dark" parameters={{ theme: 't-dark' }} args={{ theme: 'dark' }}>
     {demoStory.bind({})}
+  </Story>
+</Canvas>
+
+## Alternate
+
+An alternate, or secondary, theme that can be applied to sections.
+
+<Canvas>
+  <Story
+    name="Alternate with Light"
+    parameters={{ theme: 't-light' }}
+    args={{ theme: 'light' }}
+  >
+    {(args) => alternateDemo(args)}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Alternate with Dark"
+    parameters={{ theme: 't-dark' }}
+    args={{ theme: 'dark' }}
+  >
+    {(args) => alternateDemo(args)}
   </Story>
 </Canvas>
 

--- a/src/design/themes.stories.mdx
+++ b/src/design/themes.stories.mdx
@@ -35,7 +35,7 @@ Optimized for page intros and headings.
 
 ## Alternate
 
-An alternate, or secondary, theme that can be applied to sections.
+An alternate, or secondary, theme that can offset a section of content visually from its surroundings. This may be helpful for distinguishing rows of content from one another in a subtle way.
 
 <Canvas>
   <Story

--- a/src/prototypes/case-study-listings/example/example.scss
+++ b/src/prototypes/case-study-listings/example/example.scss
@@ -1,9 +1,5 @@
 #case-study-listings {
 
-  .book-wrapper {
-    background-color: #f2f5f7;
-  }
-
   .top-wrapper {
     padding-top: 4em;
     padding-bottom: 4em;

--- a/src/prototypes/case-study-listings/example/example.twig
+++ b/src/prototypes/case-study-listings/example/example.twig
@@ -112,7 +112,7 @@
     </div>
   </div>
 
-  <div class="wrapper book-wrapper">
+  <div class="wrapper t-alternate">
     <div class="o-container o-container--pad">
       <div class="o-container__content">
         <div class="grid-wrapper">


### PR DESCRIPTION
## Overview

This PR introduces an "alternate" theme. Closes #1380. 

## Screenshots

<img width="949" alt="Screen Shot 2021-07-29 at 11 50 51 AM" src="https://user-images.githubusercontent.com/459757/127549463-6dfa853b-40a0-4bc1-99ef-8b3c921424bf.png">
<img width="945" alt="Screen Shot 2021-07-29 at 11 50 59 AM" src="https://user-images.githubusercontent.com/459757/127549469-5c7a75ea-26c4-49f6-92a3-d2b5c311e456.png">


## Testing

Preview: https://deploy-preview-1458--cloudfour-patterns.netlify.app/?path=/docs/design-themes--alternate-with-light