### PR TITLE
Use font-display: swap in font declarations

### DIFF
--- a/.changeset/dirty-seals-cheat.md
+++ b/.changeset/dirty-seals-cheat.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Use `font-display: swap` in font declarations

--- a/src/base/_fonts.scss
+++ b/src/base/_fonts.scss
@@ -3,6 +3,7 @@
     font-family: $name;
     src: url('../src/assets/fonts/#{$path}/#{$parameter}.woff2') format('woff2'),
       url('../src/assets/fonts/#{$path}/#{$parameter}.woff') format('woff');
+    font-display: swap;
 
     @if (type-of($parameter) == 'number') {
       font-weight: $parameter;
@@ -16,6 +17,7 @@
   @font-face {
     font-family: 'Source Sans Pro Variable';
     font-style: $style;
+    font-display: swap;
     font-weight: 100 900;
     src: url('../src/assets/fonts/#{$path}.woff2') format('woff2-variations'),
       url('../src/assets/fonts/#{$path}.woff2') format('woff2');

--- a/src/base/_fonts.scss
+++ b/src/base/_fonts.scss
@@ -1,9 +1,9 @@
 @mixin _non-variable-font-face($name, $path, $parameter) {
   @font-face {
+    font-display: swap;
     font-family: $name;
     src: url('../src/assets/fonts/#{$path}/#{$parameter}.woff2') format('woff2'),
       url('../src/assets/fonts/#{$path}/#{$parameter}.woff') format('woff');
-    font-display: swap;
 
     @if (type-of($parameter) == 'number') {
       font-weight: $parameter;
@@ -15,9 +15,9 @@
 
 @mixin _variable-font-face($name, $path, $style) {
   @font-face {
+    font-display: swap;
     font-family: 'Source Sans Pro Variable';
     font-style: $style;
-    font-display: swap;
     font-weight: 100 900;
     src: url('../src/assets/fonts/#{$path}.woff2') format('woff2-variations'),
       url('../src/assets/fonts/#{$path}.woff2') format('woff2');


### PR DESCRIPTION
## Overview

This is a performance improvement, part of https://github.com/cloudfour/cloudfour.com-wp/issues/511.

`font-display: swap` makes the browser display fallback fonts immediately, until the requested font is loaded. Without this property, the browser displays no text for a short delay, and only displays the fallback font after a timeout, and if the requested font has still not loaded after the timeout.

## Testing

I tested it on cloudfour.com locally by editing the font declarations in the node_modules folder. By repeatedly doing a hard-refresh with caching disabled, I could see that with `font-display: swap` the fallback font gets displayed right away.