### PR TITLE
Change button default type to the browser's default type

### DIFF
--- a/.changeset/itchy-mangos-count.md
+++ b/.changeset/itchy-mangos-count.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Change button default type to the browser's default

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -191,7 +191,7 @@ You can override the `content_start_icon` value to a different icon.
 - `href` (string): Converts the button to an anchor element and assigns the `href` value. Defaults to `#` if `a` is passed as the `tag_name`.
 - `label` (string, default `'Hello world'`): Sets the button's text content.
 - `tag_name` (string, default `'button'`): The tag for the button. Uses a `button` by default, an `a` when an `href` value is passed.
-- `type` (string, default `'button'`): Sets the button's `type` value.
+- `type` (string): Sets the button's `type` value. If none is passed the browser will default to `submit` or `button` depending on whether the button is in a form.
 
 ## Template Blocks
 

--- a/src/components/button/button.twig
+++ b/src/components/button/button.twig
@@ -26,7 +26,7 @@
   {% if tag_name == 'a' %}
     href="{{ href|default('#') }}"
   {% elseif tag_name == 'button' %}
-    type="{{ type|default('button') }}"
+    {% if type %}type="{{ type }}"{% endif %}
     {% if disabled %}
       disabled
     {% endif %}


### PR DESCRIPTION
## Overview

Closes https://github.com/cloudfour/cloudfour.com-patterns/issues/1428 (the validation stuff is all handled by the markup, and the only part left is hooking up the forms to WP)

Our button component defaults to `type="button"`. In the comment form, we need it to be `type="submit"` so that the browser fires the form submission. Initially I solved this by passing `type="submit"` into the button in the comment form template. Then I decided to change the button component's default behavior, so it matches the browser's default behavior with `<button>` elements: it infers the type from context. If the button is inside a `<form>`, it is `type="submit"`, otherwise it is `type="button"`