### PR TITLE
Add missing `name` attribute to Comment Form email input

### DIFF
--- a/.changeset/few-ducks-shake.md
+++ b/.changeset/few-ducks-shake.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Add missing `name` attribute to Comment Form email input

--- a/src/components/comment-form/comment-form.twig
+++ b/src/components/comment-form/comment-form.twig
@@ -25,6 +25,13 @@
       {% endblock %}
     {% endembed %}
   {% endblock %}
+
+  {#
+    Can be used to include `<input type="hidden">` elements, which systems like
+    Wordpress use to provide additional context during form submission.
+  #}
+  {% block hidden_inputs %}{% endblock %}
+
   {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: main_label|default('Message') } %}
     {% block control %}
       {% include '@cloudfour/components/input/input.twig' with {

--- a/src/components/comment-form/comment-form.twig
+++ b/src/components/comment-form/comment-form.twig
@@ -25,13 +25,6 @@
       {% endblock %}
     {% endembed %}
   {% endblock %}
-
-  {#
-    Can be used to include `<input type="hidden">` elements, which systems like
-    Wordpress use to provide additional context during form submission.
-  #}
-  {% block hidden_inputs %}{% endblock %}
-
   {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: main_label|default('Message') } %}
     {% block control %}
       {% include '@cloudfour/components/input/input.twig' with {
@@ -53,7 +46,7 @@
     {% endembed %}
     {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Email', class: 'c-comment-form__email' } only %}
       {% block control %}
-        {% include '@cloudfour/components/input/input.twig' with { type: 'email', autocomplete: 'home email', required: true } only %}
+        {% include '@cloudfour/components/input/input.twig' with { name: 'email', type: 'email', autocomplete: 'home email', required: true } only %}
       {% endblock %}
     {% endembed %}
   {% endif %}


### PR DESCRIPTION
While testing https://github.com/cloudfour/cloudfour.com-wp/pull/592 Tyler noticed that the email input was missing a name attribute and breaking comment submission. This fixes that.