### PR TITLE
Initialize sky nav JS for all prototypes that use the sky nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudfour/patterns",
-  "version": "3.1.1",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudfour/patterns",
-      "version": "3.1.1",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "focus-visible": "5.2.0",

--- a/src/prototypes/single-article/single-article.stories.js
+++ b/src/prototypes/single-article/single-article.stories.js
@@ -1,4 +1,5 @@
 import singleArticlePrototype from './example/example.twig';
+import { useSkyNav } from '../use-sky-nav.ts';
 
 export default {
   title: 'Prototypes/Single Article',
@@ -7,4 +8,7 @@ export default {
   },
 };
 
-export const Example = () => singleArticlePrototype({});
+export const Example = () => {
+  useSkyNav();
+  return singleArticlePrototype({});
+};

--- a/src/prototypes/single-page/single-page.stories.js
+++ b/src/prototypes/single-page/single-page.stories.js
@@ -1,6 +1,7 @@
 import singlePagePrototype from './example/example.twig';
 import './example/example.scss';
 import devices from './data/devices.json';
+import { useSkyNav } from '../use-sky-nav.ts';
 
 export default {
   title: 'Prototypes/Single Page',
@@ -9,7 +10,9 @@ export default {
   },
 };
 
-export const Example = () =>
-  singlePagePrototype({
+export const Example = () => {
+  useSkyNav();
+  return singlePagePrototype({
     devices,
   });
+};

--- a/src/prototypes/team/team.stories.js
+++ b/src/prototypes/team/team.stories.js
@@ -3,6 +3,7 @@ import teamIndividualPrototype from './example/team-individual.twig';
 import teamArticlePage2 from './example/team-articles-page2.twig';
 import avatars from './data/avatars.json';
 import './example/team-individual.scss';
+import { useSkyNav } from '../use-sky-nav.ts';
 
 export default {
   title: 'Prototypes/Team Page',
@@ -12,14 +13,21 @@ export default {
   },
 };
 
-export const List = () =>
-  teamListPrototype({
+export const List = () => {
+  useSkyNav();
+  return teamListPrototype({
     avatars,
   });
+};
 
-export const IndividualBio = () =>
-  teamIndividualPrototype({
+export const IndividualBio = () => {
+  useSkyNav();
+  return teamIndividualPrototype({
     avatars,
   });
+};
 
-export const ArticlesPage2 = () => teamArticlePage2({});
+export const ArticlesPage2 = () => {
+  useSkyNav();
+  return teamArticlePage2({});
+};

--- a/src/prototypes/use-sky-nav.ts
+++ b/src/prototypes/use-sky-nav.ts
@@ -1,0 +1,11 @@
+import { useEffect } from '@storybook/client-api';
+import { initSkyNav } from '../components/sky-nav/sky-nav';
+
+export const useSkyNav = () => {
+  useEffect(() => {
+    const { destroy } = initSkyNav(
+      document.querySelector('.js-sky-nav-menu-toggle')
+    );
+    return destroy;
+  }, []);
+}


### PR DESCRIPTION
## Overview

Closes https://github.com/cloudfour/cloudfour.com-patterns/issues/1473

I made a custom hook `useSkyNav` that initializes the sky nav. In prototypes that have the sky nav, the hook needs to be called:

```js
export const SomePrototypeStory = () => {
  useSkyNav()
  return someTwigFile()
}
```

## Testing

Make sure that all the prototypes that use the sky nav initialize the JS correctly for small screens