### PR TITLE
Make nested headings inherit font colors

### DIFF
--- a/.changeset/sharp-moles-lick.md
+++ b/.changeset/sharp-moles-lick.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Make nested headings inherit font colors

--- a/src/components/heading/heading.scss
+++ b/src/components/heading/heading.scss
@@ -113,9 +113,10 @@ $max-width-permalink-shift: math.div($min-width-permalink-shift * 16 - 1, 16);
 
 /// For complex headings (those containing a permalink and/or subheading), the
 /// actual `h*` element must be a child element, so we inherit the container's
-/// font styles. It's important the containing element retain the heading font
-/// styles for vertical rhythm to work as intended!
+/// font and color styles. It's important the containing element retain the
+/// heading font styles for vertical rhythm to work as intended!
 .c-heading__content {
+  color: inherit;
   font: inherit;
 }
 

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -50,6 +50,10 @@ import demo from './demo/demo.twig';
         options: ['', 'light'],
       },
     },
+    class: {
+      type: 'string',
+      description: 'If necessary, additional classes can be added to headings.',
+    },
   }}
   parameters={{
     docs: {


### PR DESCRIPTION
This is necessary in Wordpress to be able to apply Gutenberg colors classes to permalinked headings

<img width="1224" alt="Screen Shot 2021-08-27 at 8 43 31 AM" src="https://user-images.githubusercontent.com/5798536/131153888-e54f3328-b3df-4f3d-b2d4-da8d285a6f4f.png">
