### PR TITLE
Introduce Button 'is-slashed' CSS state class, remove aria-pressed logic

### DIFF
--- a/.changeset/famous-peaches-punch.md
+++ b/.changeset/famous-peaches-punch.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Introduce `c-button--slashed` modifier, remove `aria-pressed` logic

--- a/.changeset/famous-peaches-punch.md
+++ b/.changeset/famous-peaches-punch.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Introduce `c-button--slashed` modifier, remove `aria-pressed` logic
+Introduce `is-slashed` CSS state class, remove `aria-pressed` logic

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -142,40 +142,45 @@ The `content_start`/`content_end` blocks override the
   </Story>
 </Canvas>
 
-## Toggling button
+## Icon with slash
 
-Pass an `aria_pressed` value (`'true'` or `'false'`) to enable a toggling button. If no `content_start_icon`/`content_end_icon` or `content_start`/`content_end` block content is passed in, the `'bell'` icon will be used by default as the `content_start_icon` value.
+To add a slash across the icon(s), use the `c-button--slashed` modifier.
+
+If no `content_start_icon`/`content_end_icon` or `content_start`/`content_end` block content is passed in, the `'bell'` icon will be used by default as the `content_start_icon` value.
 
 You can override the `content_start_icon` value to a different icon.
 
 <Canvas>
   <Story
-    name="Toggling Button"
+    name="Slashed Icon"
     args={{
-      aria_pressed: 'true',
+      class: 'c-button--slashed',
     }}
   >
     {(args) => buttonStory(args)}
   </Story>
   <Story
-    name="Secondary Toggling Button"
+    name="Secondary Button with Slashed Icon"
     args={{
-      class: 'c-button--secondary',
-      aria_pressed: 'true',
+      class: 'c-button--secondary c-button--slashed',
     }}
   >
     {(args) => buttonStory(args)}
   </Story>
   <Story
-    name="Tertiary Toggling Button"
+    name="Tertiary Button with Slashed Icon"
     args={{
-      class: 'c-button--tertiary',
-      aria_pressed: 'true',
+      class: 'c-button--tertiary c-button--slashed',
     }}
   >
     {(args) => buttonStory(args)}
   </Story>
-  <Story name="Custom Icon Toggling Button" args={{ aria_pressed: 'true' }}>
+  <Story
+    name="Slashed Custom Icon"
+    parameters={{
+      docs: { source: { code: iconButtonCustomDemoSource } },
+    }}
+  >
     {(args) => iconButtonCustomDemo(args)}
   </Story>
 </Canvas>
@@ -183,7 +188,6 @@ You can override the `content_start_icon` value to a different icon.
 ## Template Properties
 
 - `aria_expanded` (string, `'true'`/`'false'`): Sets the button's `aria-expanded` attribute.
-- `aria_pressed` (string, `'true'`/`'false'`): Sets the button's `aria-pressed` attribute.
 - `class` (string): Append a class to the root element.
 - `content_start_icon` (string): The name of the [icon](/docs/design-icons--page) to render in the `content_start` block.
 - `content_end_icon` (string): The name of the [icon](/docs/design-icons--page) to render in the `content_end` block.

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -57,10 +57,6 @@ const buttonStory = (args) => {
     disabled: { type: { name: 'boolean' }, defaultValue: false },
     content_start_icon: iconControlConfig,
     content_end_icon: iconControlConfig,
-    aria_pressed: {
-      type: { name: 'enum' },
-      control: { type: 'inline-radio', options: ['true', 'false'] },
-    },
   }}
 />
 

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -12,6 +12,9 @@ import stylesDemo from './demo/styles.twig';
 // eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import iconButtonCustomDemoSource from '!!raw-loader!./demo/icon-button-custom-demo.twig';
 import iconButtonCustomDemo from './demo/icon-button-custom-demo.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import slashedIconButtonCustomDemoSource from '!!raw-loader!./demo/slashed-icon-button-custom-demo.twig';
+import slashedIconButtonCustomDemo from './demo/slashed-icon-button-custom-demo.twig';
 import button from './button.twig';
 const iconControlConfig = {
   type: { name: 'string' },
@@ -140,7 +143,7 @@ The `content_start`/`content_end` blocks override the
 
 ## Icon with slash
 
-To add a slash across the icon(s), use the `c-button--slashed` modifier.
+To add a slash across the icon(s), use the `is-slashed` state modifier CSS class.
 
 If no `content_start_icon`/`content_end_icon` or `content_start`/`content_end` block content is passed in, the `'bell'` icon will be used by default as the `content_start_icon` value.
 
@@ -150,7 +153,7 @@ You can override the `content_start_icon` value to a different icon.
   <Story
     name="Slashed Icon"
     args={{
-      class: 'c-button--slashed',
+      class: 'is-slashed',
     }}
   >
     {(args) => buttonStory(args)}
@@ -158,7 +161,7 @@ You can override the `content_start_icon` value to a different icon.
   <Story
     name="Secondary Button with Slashed Icon"
     args={{
-      class: 'c-button--secondary c-button--slashed',
+      class: 'c-button--secondary is-slashed',
     }}
   >
     {(args) => buttonStory(args)}
@@ -166,7 +169,7 @@ You can override the `content_start_icon` value to a different icon.
   <Story
     name="Tertiary Button with Slashed Icon"
     args={{
-      class: 'c-button--tertiary c-button--slashed',
+      class: 'c-button--tertiary is-slashed',
     }}
   >
     {(args) => buttonStory(args)}
@@ -174,10 +177,10 @@ You can override the `content_start_icon` value to a different icon.
   <Story
     name="Slashed Custom Icon"
     parameters={{
-      docs: { source: { code: iconButtonCustomDemoSource } },
+      docs: { source: { code: slashedIconButtonCustomDemoSource } },
     }}
   >
-    {(args) => iconButtonCustomDemo(args)}
+    {(args) => slashedIconButtonCustomDemo(args)}
   </Story>
 </Canvas>
 

--- a/src/components/button/button.twig
+++ b/src/components/button/button.twig
@@ -1,12 +1,10 @@
 {% set tag_name = tag_name|default(href ? 'a' : 'button') %}
-{# Check if the 'slashed' modifier exists #}
-{% set is_slashed = 'c-button--slashed' in class %}
 {# Check for 'content_start' and 'content_end' content #}
 {% set _content_start = block('content_start') %}
 {% set _content_end = block('content_end') %}
-{# Set a default icon if is_slashed is set and no icon (or block content) was supplied #}
+{# Set a default icon if `is-slashed` exists and no icon (or block content) was supplied #}
 {% if
-  is_slashed and
+  'is-slashed' in class and
   content_start_icon is empty and
   content_end_icon is empty and
   _content_start|trim is empty and

--- a/src/components/button/button.twig
+++ b/src/components/button/button.twig
@@ -1,12 +1,12 @@
 {% set tag_name = tag_name|default(href ? 'a' : 'button') %}
-{# aria_pressed only accepts 'true' or 'false' (string) values #}
-{% set is_aria_pressed_valid = aria_pressed == 'true' or aria_pressed == 'false' %}
+{# Check if the 'slashed' modifier exists #}
+{% set is_slashed = 'c-button--slashed' in class %}
 {# Check for 'content_start' and 'content_end' content #}
 {% set _content_start = block('content_start') %}
 {% set _content_end = block('content_end') %}
-{# Set a default icon if aria-pressed is set and no icon (or block content) was supplied #}
+{# Set a default icon if is_slashed is set and no icon (or block content) was supplied #}
 {% if
-  is_aria_pressed_valid and
+  is_slashed and
   content_start_icon is empty and
   content_end_icon is empty and
   _content_start|trim is empty and
@@ -19,9 +19,6 @@
   class="c-button{% if class %} {{ class }}{% endif %}"
   {% if aria_expanded %}
     aria-expanded="{{ aria_expanded }}"
-  {% endif %}
-  {% if is_aria_pressed_valid %}
-    aria-pressed="{{ aria_pressed }}"
   {% endif %}
   {% if tag_name == 'a' %}
     href="{{ href|default('#') }}"

--- a/src/components/button/demo/icon-button-custom-demo.twig
+++ b/src/components/button/demo/icon-button-custom-demo.twig
@@ -1,4 +1,6 @@
-{% embed '@cloudfour/components/button/button.twig' %}
+{% embed '@cloudfour/components/button/button.twig' with {
+  class: 'c-button--slashed'
+} only %}
   {% block content %}Button with a custom icon{% endblock %}
   {% block content_end %}
     <svg viewBox="0 0 24 24" width="24" height="24" class="c-icon">

--- a/src/components/button/demo/slashed-icon-button-custom-demo.twig
+++ b/src/components/button/demo/slashed-icon-button-custom-demo.twig
@@ -1,4 +1,6 @@
-{% embed '@cloudfour/components/button/button.twig' only %}
+{% embed '@cloudfour/components/button/button.twig' with {
+  class: 'is-slashed'
+} only %}
   {% block content %}Button with a custom icon{% endblock %}
   {% block content_end %}
     <svg viewBox="0 0 24 24" width="24" height="24" class="c-icon">

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -111,7 +111,7 @@
   /**
    * Adds a slash across the "extra" content (most times "extra" content is an icon).
    */
-  &.c-button--slashed {
+  &.is-slashed {
     .c-button__extra {
       &::after {
         background: currentColor;

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -109,11 +109,9 @@
   }
 
   /**
-   * Toggling button
-   * This adds a slash across the icon to visually show the state has changed
-   * when `aria-pressed` is `'true'`.
+   * Adds a slash across the "extra" content (most times "extra" content is an icon).
    */
-  &[aria-pressed='true'] {
+  &.c-button--slashed {
     .c-button__extra {
       &::after {
         background: currentColor;


### PR DESCRIPTION
## Overview

This PR refactors the Button component in response to #1508. Changes include:
- remove the `aria-pressed` logic
- introduce a `is-slashed` CSS state class

## Screenshots

<img width="1007" alt="Screen Shot 2021-09-02 at 9 59 04 AM" src="https://user-images.githubusercontent.com/459757/131886064-e009d3da-bdb8-46d9-929f-5670e58f83ad.png">

## Testing

1. Review https://deploy-preview-1519--cloudfour-patterns.netlify.app/?path=/docs/components-button--slashed-icon#icon-with-slash

---

- Closes #1509 