### PR TITLE
Use aria-labelledby to add accessible names to articles

### DIFF
--- a/.changeset/rude-pears-breathe.md
+++ b/.changeset/rude-pears-breathe.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Add accessible names to comments

--- a/src/components/comment/comment.twig
+++ b/src/components/comment/comment.twig
@@ -12,22 +12,23 @@
 <article
   class="c-comment {{_comment_modifiers}}"
   id="comment-{{comment.ID}}"
+  aria-labelledby="comment-heading-{{comment.ID}}"
 >
-<header class="c-comment__header">
-  {% block header_content %}
-    <h{{_heading_depth}} class="c-comment__heading">
-      {% block heading_content %}
-        {% block author_title %}
-          {{comment.author.name}}
-        {% endblock %}
+  <header class="c-comment__header">
+    {% block header_content %}
+      <h{{_heading_depth}} class="c-comment__heading" id="comment-heading-{{comment.ID}}">
+        {% block heading_content %}
+          {% block author_title %}
+            {{comment.author.name}}
+          {% endblock %}
 
-        <span class="u-hidden-visually">
-          {% if comment.is_child %}replied{% else %}said{% endif %}:
-        </span>
-      {% endblock %}
-    </h{{_heading_depth}}>
-  {% endblock %}
-</header>
+          <span class="u-hidden-visually">
+            {% if comment.is_child %}replied{% else %}said{% endif %}:
+          </span>
+        {% endblock %}
+      </h{{_heading_depth}}>
+    {% endblock %}
+  </header>
   <div class="c-comment__object">
     {% include '@cloudfour/components/avatar/avatar.twig' with {
       src: comment.avatar,


### PR DESCRIPTION
## Overview

Recently @gerardo-rodriguez pointed out:

> While testing a PR with VoiceOver, I noticed that the rotor lists all comments as "article". It seems we might be able to enhance the experience by adding accessible names to the <article> elements? (e.g. aria-labelledby)

![article](https://user-images.githubusercontent.com/5798536/132749476-41d5ae59-ff37-490b-92bc-081c32f95c06.gif)

This PR adds `aria-labelledby` to link the existing comment headings to the comment article.

You're gonna wanna hide whitespace changes while reviewing. There was an indentation issue in the file that was fixed as well.

## Screenshots

![comment names](https://user-images.githubusercontent.com/5798536/132749338-943fdf08-ca40-4535-897c-b2558a3fd3c9.gif)


## Testing

1. Review  `/?path=/story/components-comment--with-reply-thread` on the preview deploy in VoiceOver. Check the rotor and note the articles have accessible names.
