### PR TITLE
Incease whitespace for the ground nav component

### DIFF
--- a/.changeset/pretty-ducks-wave.md
+++ b/.changeset/pretty-ducks-wave.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Increase whitespace in the ground-nav component

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -7,7 +7,7 @@
 
 // Whitespace used for gaps, padding and margin
 // (It uses `rem` so space will be consistent throughout the component)
-$_ground-nav-space: ms.step(1, 1rem);
+$_ground-nav-space: ms.step(3, 1rem);
 // Negative value used to reduce the space around elements as well as position elements.
 $_ground-nav-negative-space: ($_ground-nav-space * -1);
 $_ground-nav-border-width: size.$edge-medium;


### PR DESCRIPTION
## Overview

This PR makes a small change of increasing whitespace in the ground nav component so it doesn't look so squished against different backgrounds.

## Screenshots

Before:
<img width="1385" alt="Screen Shot 2021-09-10 at 12 12 42 PM" src="https://user-images.githubusercontent.com/24928337/132905480-1632223a-874b-4966-8b3f-dce9e5201609.png">

After:
<img width="1375" alt="Screen Shot 2021-09-10 at 12 13 26 PM" src="https://user-images.githubusercontent.com/24928337/132905499-03ba564b-fcc4-47f1-8c37-a106a95a6c89.png">

## Testing

1. [Deploy link](https://deploy-preview-1533--cloudfour-patterns.netlify.app/?path=/story/components-ground-nav--cloud-four)

---

- Fixes https://github.com/cloudfour/cloudfour.com-patterns/issues/1528
