### PR TITLE
Build the project before validating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,5 @@ jobs:
         run: npm ci
       - name: Run Preprocess
         run: npm run preprocess
-      - name: Run Build (necessary for including css file in tests)
-        run: npm run build
       - name: Run Tests
         run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,5 +88,7 @@ jobs:
         run: npm ci
       - name: Run Preprocess
         run: npm run preprocess
+      - name: Run Build (necessary for including css file in tests)
+        run: npm run build
       - name: Run Tests
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "lint:prettier:check": "prettier . --check",
     "test": "jest",
     "test:watch": "jest --watch",
-    "validate": "run-s test lint:check type",
+    "validate": "run-s build test lint:check type",
     "version": "changeset version && prettier --write .",
     "release": "npm run build && changeset publish"
   }


### PR DESCRIPTION
## Overview

Our tests rely on importing files from `/dist` to work correctly. However, for `dist` to be present, you need to run `build` first. So if you run `validate` before building you can end up with unexpected errors like this:

![image](https://user-images.githubusercontent.com/5798536/134569728-79c5328c-a33a-457d-9f02-ceed9707b329.png)

Since it's possible to make changes to the patterns without ever running `build` there's a good chance you're validating against an outdated `dist` directory when running `validate` This PR updates our `validate` script to build the project before testing.

## Questions

As I was writing this it occurred to me that the `test` script should maybe run `build` instead? But it feels like that might be unexpected, whereas I expect `validate` to go off and do a bunch of different things.

If we did move this to the `test` script, then what does that mean for `test:watch`. Does it also need to run `watch`?

Is the actual fix moving away from using our `dist` directory in tests?

What do y'all think?

## Testing

1. Check out `v-next`
2. `npm ci`
3. Delete `/dist`
4. Run `npm run validate`
5. See errors
6. Check out this branch
7. Run `npm run validate`
8. See no errors
9. Note that `dist` was built
