### PR TITLE
Remove duplicate CI step from test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,6 @@ jobs:
           restore-keys: ${{ runner.os }}-node-
       - name: Install Dependencies
         run: npm ci
-      - name: Run Preprocess
-        run: npm run preprocess
       - name: Run Build (necessary for including css file in tests)
         run: npm run build
       - name: Run Tests


### PR DESCRIPTION
## Overview

(The build script runs preprocess, so running preprocess manually was redundant)

## Testing

I believe we just need to confirm the CI passes.