### PR TITLE
Fix npm version used in release workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 12
+      - name: Update npm
+        run: npm i -g npm@7
       - name: Install Dependencies
         run: CYPRESS_INSTALL_BINARY=0 npm ci
       - name: Run Preprocess


### PR DESCRIPTION
## Overview

In a [dep update PR](https://github.com/cloudfour/cloudfour.com-patterns/pull/1538) I changed the npm version being used to v7, because github was failing to install the packages using npm 6: https://github.com/cloudfour/cloudfour.com-patterns/compare/43e5a38...e640e35

But, I forgot to also update the changeset release workflow to also use npm 7, so now it fails. This PR updates the npm version in that as well.