### PR TITLE
Conditional rounded corners

### DIFF
--- a/.changeset/light-avocados-enjoy.md
+++ b/.changeset/light-avocados-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Styles that relied on media queries or complicated nesting to negate rounded corners have been simplified using [conditional border radius](https://ishadeed.com/article/conditional-border-radius/). Some elements like code blocks now benefit from conditional rounded corners as well. The Alert component's `full-width` modifier and `full_width` template options are no longer necessary.

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -1,5 +1,6 @@
 @use '../compiled/tokens/scss/color';
 @use '../compiled/tokens/scss/size';
+@use '../mixins/border-radius';
 @use '../mixins/ms';
 @use '../mixins/theme';
 
@@ -127,6 +128,7 @@ pre {
   color: color.$text-light;
   overflow: auto; /* 1 */
   padding: ms.step(1);
+  @include border-radius.conditional();
 }
 
 /**

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -34,12 +34,8 @@
     '. . dismiss';
   grid-template-columns: 0 1fr minmax(0, auto);
   grid-template-rows: ms.step(-1) minmax(0, auto) ms.step(-1);
-
-  /// We only bother constraining this element when it's full-width.
-  .c-alert--full-width & {
-    margin: 0 auto;
-    max-width: size.$max-width-spread;
-  }
+  margin: 0 auto;
+  max-width: size.$max-width-spread;
 }
 
 .c-alert__content {

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -3,20 +3,14 @@
 @use '../../compiled/tokens/scss/scale';
 @use '../../compiled/tokens/scss/size';
 @use '../../compiled/tokens/scss/transition';
+@use '../../mixins/border-radius';
 @use '../../mixins/focus';
 @use '../../mixins/ms';
 
 .c-alert {
   background: var(--theme-color-background-secondary);
-  border-radius: size.$border-radius-medium;
   color: var(--theme-color-text-emphasis);
-}
-
-/// When alert is meant to span the full viewport width, we omit its rounded
-/// corners to avoid awkward counter spaces where the background shows through
-/// those corners.
-.c-alert--full-width {
-  border-radius: 0;
+  @include border-radius.conditional(size.$border-radius-medium);
 }
 
 /// We use a separate inner element so we can constrain it when the alert is

--- a/src/components/alert/alert.stories.mdx
+++ b/src/components/alert/alert.stories.mdx
@@ -6,7 +6,6 @@ import template from './alert.twig';
   argTypes={{
     message: { type: { name: 'string' } },
     dismissable: { type: { name: 'boolean' } },
-    full_width: { type: { name: 'boolean' } },
   }}
 />
 
@@ -49,7 +48,7 @@ When `dismissable` is `true`, a close button will display to the right of the me
 
 ## Full width
 
-By default, alerts assume they'll display within page content. For alerts meant to fill the full browser width, use the `c-alert--full-width` modifier class or set the `full_width` template property to `true`. This removes the rounded corners (which would awkwardly interact with viewport edges) and constrains the content to the value of [our `size.$max-width-spread` token](/docs/design-tokens-layout--page).
+Alerts work well even when displayed at full width. Their contents will constrain to the `max-width` of [our `size.$max-width-spread` token](/docs/design-tokens-layout--page), and rounded corners will disappear when full-width.
 
 <Canvas>
   <Story
@@ -60,7 +59,6 @@ By default, alerts assume they'll display within page content. For alerts meant 
     }}
     args={{
       message: 'You appear to be offline. 🤔',
-      full_width: true,
       dismissable: true,
     }}
   >
@@ -72,7 +70,6 @@ By default, alerts assume they'll display within page content. For alerts meant 
 
 - `class` (string)
 - `dismissable` (boolean, default `false`)
-- `full_width` (boolean, default `false`)
 - `message` (string, default `'Hello world!'`)
 - `tag_name` (string, default `'div'`)
 

--- a/src/components/alert/alert.twig
+++ b/src/components/alert/alert.twig
@@ -1,6 +1,6 @@
 {% set tag_name = tag_name|default('div') %}
 
-<{{ tag_name }} class="c-alert{% if full_width %} c-alert--full-width{% endif %}{% if class %} {{ class }}{% endif %}">
+<{{ tag_name }} class="c-alert{% if class %} {{ class }}{% endif %}">
   <div class="c-alert__inner">
     <div class="c-alert__content">
       {% block content %}

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -4,6 +4,7 @@
 @use '../../compiled/tokens/scss/ease';
 @use '../../compiled/tokens/scss/size';
 @use '../../compiled/tokens/scss/transition';
+@use '../../mixins/border-radius';
 @use '../../mixins/fluid';
 @use '../../mixins/focus';
 @use '../../mixins/headings';
@@ -67,8 +68,8 @@ $_focus-overflow: (size.$edge-large * -1);
 }
 
 .c-card--contained {
-  border-radius: size.$border-radius-card-contained;
   padding: ms.step(1);
+  @include border-radius.conditional();
 
   @include theme.unthemed-styles() {
     background-color: var(--theme-color-background-secondary);

--- a/src/mixins/_border-radius.scss
+++ b/src/mixins/_border-radius.scss
@@ -1,0 +1,15 @@
+@use 'sass:math';
+@use '../compiled/tokens/scss/size';
+
+/// Apply `border-radius` but only when the element is narrower than
+/// the viewport width.
+///
+/// @link https://ishadeed.com/article/conditional-border-radius/
+/// @param {Number} $amount - The amount of border radii to apply.
+@mixin conditional($amount: size.$border-radius-card-contained) {
+  border-radius: clamp(
+    0px,
+    ((100vw - #{math.div($amount, 2)}) - 100%) * 9999,
+    #{$amount}
+  );
+}

--- a/src/objects/container/container.scss
+++ b/src/objects/container/container.scss
@@ -79,26 +79,6 @@ $pad-max: size.$padding-container-max;
       $pad-max * -1
     );
   }
-
-  .o-container--pad:not(.o-container--prose) &,
-  .o-container--pad-inline:not(.o-container--prose) & {
-    // Magic number corresponds to approximate size of fluid padding in addition
-    // to max width container without fluid font size applied (attempts to boil
-    // this down to a repeatable equation resulted in my head exploding). If we
-    // only tested by the max width, the rounded corners would be restored too
-    // early (before there was visible whitespace to either side).
-    @media (width < (size.$max-width-spread + 25em)) {
-      border-radius: 0;
-    }
-  }
-
-  .o-container--pad.o-container--prose &,
-  .o-container--pad-inline.o-container--prose & {
-    // See previous comment about magic number
-    @media (width < (size.$max-width-prose + 7em)) {
-      border-radius: 0;
-    }
-  }
 }
 
 /**

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -3,6 +3,7 @@
 @use '../../../compiled/tokens/scss/color';
 @use '../../../compiled/tokens/scss/line-height';
 @use '../../../compiled/tokens/scss/size';
+@use '../../../mixins/border-radius';
 @use '../../../mixins/button';
 @use '../../../mixins/emdash';
 @use '../../../mixins/ms';
@@ -191,10 +192,10 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
 
 .wp-block-pullquote {
   background-color: var(--theme-color-background-secondary);
-  border-radius: size.$border-radius-medium;
   margin-bottom: 0; /* 1 */
   padding: 0; /* 2 */
   text-align: left; /* 3 */
+  @include border-radius.conditional();
 }
 
 /**
@@ -278,31 +279,5 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
   cite {
     font-size: ms.step(0);
     text-align: left;
-  }
-}
-
-/**
- * Groups
- * Rounds the corners for groups when the has-background class is applied.
- * 1. This value is added to keep the Cloud Four card containers and
- * the Gutenberg styles consistent.
- * 2. When the alignfull class is applied the border radius will go
- * back to 0 to keep the corners flush with the edge of the page.
- * 3. The alignwide class will have the border-radius set to 0 until it hits
- * the large breakpoint because at that point, it no longer sits along the
- * edge of the screen. It's intended to be applied within a container.
- */
-
-.wp-block-group.has-background {
-  border-radius: size.$border-radius-card-contained; /* 1 */
-
-  &.alignfull {
-    border-radius: 0; /* 2 */
-  }
-
-  &.alignwide {
-    @media (width < breakpoint.$l) {
-      border-radius: 0; /* 3 */
-    }
   }
 }

--- a/src/vendor/wordpress/styles/_utilities.scss
+++ b/src/vendor/wordpress/styles/_utilities.scss
@@ -2,6 +2,7 @@
 @use '../../../compiled/tokens/scss/breakpoint';
 @use '../../../compiled/tokens/scss/color-base';
 @use '../../../compiled/tokens/scss/size';
+@use '../../../mixins/border-radius';
 @use '../../../mixins/headings';
 @use '../../../mixins/ms';
 
@@ -30,17 +31,7 @@
 /// element unless the element has alignment that will cause it to meet the
 /// viewport edge.
 .has-background {
-  border-radius: size.$border-radius-card-contained;
-
-  &.alignfull {
-    border-radius: 0;
-  }
-
-  &.alignwide {
-    @media (width < breakpoint.$l) {
-      border-radius: 0;
-    }
-  }
+  @include border-radius.conditional();
 }
 
 /// Utilities for Block Color Palettes


### PR DESCRIPTION
## Overview

This PR adds a mixin for [Ahmad Shadeed's conditional border radius technique](https://ishadeed.com/article/conditional-border-radius/), and applies that technique to various elements:

- Code blocks now have rounded corners above full-width by default. This will appear more consistent with other block elements like groups and cards.
- Alerts no longer require a `full-width` modifier. (I don't consider this a breaking change because the existing options have no effect.)
- Contained cards no longer require border radii negation. This removes the need to include complicated `border-radius` rules in the otherwise layout-focused container object.
- Gutenberg styles for pull quotes, backgrounds and groups have been significantly streamlined.

## Screenshots

![border-radius-conditional](https://user-images.githubusercontent.com/69633/140584669-9ff4ef7d-114d-43bc-a468-cc5358400077.gif)

---

- Fixes #1559