### PR TITLE
Style horizontal rules and separators

### DIFF
--- a/.changeset/fifty-pigs-sniff.md
+++ b/.changeset/fifty-pigs-sniff.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add default hr styles and improved WordPress Separator block styles

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @use '../compiled/tokens/scss/color';
 @use '../compiled/tokens/scss/size';
 @use '../mixins/border-radius';
@@ -267,4 +268,18 @@ figcaption {
 
 address {
   font-style: normal;
+}
+
+/**
+ * Horizontal rules
+ *
+ * We use border styles and `currentColor` for greater compatibility with
+ * the WordPress Gutenberg "Separator" block.
+ */
+
+hr {
+  border-color: currentColor;
+  border-style: solid;
+  border-width: math.div(size.$edge-medium, 2) 0;
+  color: var(--theme-color-border-text-group);
 }

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -275,11 +275,15 @@ address {
  *
  * We use border styles and `currentColor` for greater compatibility with
  * the WordPress Gutenberg "Separator" block.
+ *
+ * 1. Our goal is for the borders to add together to form the total desired
+ *    width. We do this because that's what WordPress's Gutenberg block does
+ *    in order to support weird border+background style combinations.
  */
 
 hr {
   border-color: currentColor;
   border-style: solid;
-  border-width: math.div(size.$edge-medium, 2) 0;
+  border-width: math.div(size.$edge-medium, 2) 0; /* 1 */
   color: var(--theme-color-border-text-group);
 }

--- a/src/design/defaults.stories.mdx
+++ b/src/design/defaults.stories.mdx
@@ -112,3 +112,17 @@ For syntax highlighting, see [our Prism theme](/docs/vendor-prism--bash-shell).
     }}
   </Story>
 </Canvas>
+
+## Horizontal rule
+
+Only use `hr` elements to represent a "thematic break" in content, such as a change in topic within a section. For divisions that are purely presentational, use CSS instead.
+
+To add space between the `hr` and adjacent elements, consider wrapping the section of content in [a Rhythm object](/docs/objects-rhythm--default-story).
+
+<Canvas>
+  <Story name="Horizontal rule">
+    {`<p>…and so ends this topic.</p>
+<hr>
+<p>Shifting our focus to something else entirely…</p>`}
+  </Story>
+</Canvas>

--- a/src/vendor/wordpress/core-blocks.stories.mdx
+++ b/src/vendor/wordpress/core-blocks.stories.mdx
@@ -1,4 +1,4 @@
-import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
 import blockImageDemo from './demo/image.twig';
 const alignmentClasses = {
   None: '',
@@ -502,14 +502,26 @@ The separator block adds the `wp-block-separator` class to an `hr` element.
 
 Styles controls add `is-style-default`, `is-style-wide` or `is-style-dots` classes.
 
-The color controls, if used, can add both `has-text-color` and `has-background`
-classes, as well as modifier classes for predefined color choices.
+The color controls, if used, can add both `has-text-color` and `has-background` classes, as well as modifier classes for predefined color choices. For consistency with [our default hr](/docs/design-defaults--horizontal-rule), we only support the text color option.
 
-<Canvas>
-  <Story name="Separator">
-    {`<hr class="wp-block-separator has-text-color has-background has-subtle-background-background-color has-subtle-background-color is-style-wide">`}
+<Canvas isColumn>
+  <Story
+    name="Separator"
+    args={{ style: 'default' }}
+    argTypes={{
+      style: {
+        options: ['default', 'wide', 'dots'],
+        control: {
+          type: 'select',
+        },
+      },
+    }}
+  >
+    {(args) => `<hr class="wp-block-separator is-style-${args.style}">`}
   </Story>
 </Canvas>
+
+<ArgsTable story="Separator" />
 
 ## Spacer
 

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -281,3 +281,16 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
     text-align: left;
   }
 }
+
+/**
+ * Gutenberg block: Separator
+ *
+ * The default separator is intended to be partial-width, so we apply those
+ * styles selectively here rather than un-applying them to the other modifiers.
+ */
+
+.wp-block-separator.is-style-default {
+  margin-left: auto;
+  margin-right: auto;
+  width: calc(100% / 3);
+}


### PR DESCRIPTION
## Overview

We lacked a default style for `hr`. This changes that. It uses the top border of `footnote-group` for basic appearance, but takes more color cues from the left comment border so that it will have slightly better contrast (and better compatibility with secondary themes). (I resisted the urge to style the footnote group to match because that feels like a visual distinction that does not necessarily warrant greater contrast.)

It also extends those styles to the WordPress "Separator" block.

## Screenshots

<img width="1032" alt="Screen Shot 2021-11-08 at 10 32 54 AM" src="https://user-images.githubusercontent.com/69633/140798519-91665b3b-cf09-4dd3-a6fb-9ed2d1399e50.png">
<img width="1024" alt="Screen Shot 2021-11-08 at 10 33 04 AM" src="https://user-images.githubusercontent.com/69633/140798521-2e556554-87cf-46e9-b8ca-85e49ac47442.png">
<img width="1046" alt="Screen Shot 2021-11-08 at 10 33 18 AM" src="https://user-images.githubusercontent.com/69633/140798522-c41e5d06-35b7-4efb-af8f-bfe1301fdf28.png">
<img width="1038" alt="Screen Shot 2021-11-08 at 10 33 23 AM" src="https://user-images.githubusercontent.com/69633/140798526-af709d40-168a-49bf-a7f3-98288ce62e25.png">
<img width="1044" alt="Screen Shot 2021-11-08 at 10 33 30 AM" src="https://user-images.githubusercontent.com/69633/140798527-725a8ddc-508d-4cf5-a456-c4b956438b10.png">

---

- Fixes #1520 