### PR TITLE
Add heading_id option to card template

### DIFF
--- a/.changeset/thirty-foxes-melt.md
+++ b/.changeset/thirty-foxes-melt.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add `heading_id` attribute to Card component to improve experience in the VoiceOver rotor

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -1,16 +1,13 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import { uniqueId } from 'lodash';
 import singleDemo from './demo/single.twig';
-const singleDemoStory = (args) => {
+const singleDemoProps = (args) => {
   const props = {
+    heading_id: args.heading_id || uniqueId('card-heading-'),
     href: args.href,
   };
   const classNames = [];
   const modifiers = [];
-  if (args.show.length > 0) {
-    for (const block of args.show) {
-      props[`show_${block}`] = true;
-    }
-  }
   if (args.horizontal !== 'none') {
     modifiers.push(`horizontal${args.horizontal}`);
   }
@@ -29,11 +26,47 @@ const singleDemoStory = (args) => {
   if (classNames.length > 0) {
     props.class = classNames.join(' ');
   }
+  return props;
+};
+const singleDemoStory = (args) => {
+  const props = singleDemoProps(args);
+  if (args.show.length > 0) {
+    for (const block of args.show) {
+      props[`show_${block}`] = true;
+    }
+  }
   return singleDemo(props);
+};
+const singleDemoBlockExamples = {
+  heading: 'Lorem ipsum dolor sit amet',
+  cover: `<img src="https://placeimg.com/800/450/animals" alt="">`,
+  content: `<p>Consectetur adipiscing elit...</p>`,
+  footer: `<p>{{'now'|date('M j, Y')}}</p>`,
+};
+// Custom function for generating story source from args given
+const singleDemoTransformSource = (_src, storyContext) => {
+  const { args } = storyContext;
+  const props = singleDemoProps(args);
+  const propsString =
+    Object.keys(props).length > 0
+      ? ` with ${JSON.stringify(props, null, 2)}`
+      : '';
+  const blocks = args.show.map(
+    (blockName) =>
+      `{% block ${blockName} %}${singleDemoBlockExamples[blockName]}{% endblock %}`
+  );
+  return `{% embed '@cloudfour/components/card/card.twig'${propsString} only %}
+  ${blocks.join('\n  ')}
+{% endembed %}`;
 };
 
 <Meta
   title="Components/Card"
+  parameters={{
+    docs: {
+      transformSource: singleDemoTransformSource,
+    },
+  }}
   args={{
     show: ['heading', 'cover', 'content', 'footer'],
     horizontal: 'none',
@@ -46,6 +79,7 @@ const singleDemoStory = (args) => {
         type: 'inline-check',
       },
     },
+    heading_id: { type: { name: 'string' } },
     href: { type: { name: 'string' } },
     horizontal: {
       options: ['none', '@m', '@l', '@xl'],
@@ -65,20 +99,13 @@ const singleDemoStory = (args) => {
 
 A card contains content and optionally an action summarizing a single piece of content, for example an article, talk or case study.
 
+If your card represents an `article` and includes a heading, it's a good idea to provide a `heading_id` as well. This allows us to use `aria-labelledby` to improve the experience of navigating to individual cards via the [VoiceOver rotor](https://support.apple.com/en-us/HT204783) (and potentially other assistive interfaces as well).
+
 <Canvas>
   <Story
     name="Content Blocks"
-    args={{ show: ['heading', 'content', 'footer'] }}
-    parameters={{
-      docs: {
-        source: {
-          code: `{% embed '@cloudfour/components/card/card.twig' only %}
-  {% block heading %}Lorem ipsum dolor sit amet{% endblock %}
-  {% block content %}<p>Consectetur adipiscing elit...</p>{% endblock %}
-  {% block footer %}<p>{{'now'|date('M j, Y')}}</p>{% endblock %}
-{% endembed %}`,
-        },
-      },
+    args={{
+      show: ['heading', 'content', 'footer'],
     }}
   >
     {singleDemoStory.bind({})}
@@ -92,17 +119,9 @@ If an `href` property is provided, the `heading` (if present) will include a lin
 <Canvas>
   <Story
     name="Link"
-    args={{ href: '#', show: ['heading', 'content', 'footer'] }}
-    parameters={{
-      docs: {
-        source: {
-          code: `{% embed '@cloudfour/components/card/card.twig' with { href: '#' } only %}
-  {% block heading %}Lorem ipsum dolor sit amet{% endblock %}
-  {% block content %}<p>Consectetur adipiscing elit...</p>{% endblock %}
-  {% block footer %}<p>{{'now'|date('M j, Y')}}</p>{% endblock %}
-{% endembed %}`,
-        },
-      },
+    args={{
+      href: '#',
+      show: ['heading', 'content', 'footer'],
     }}
   >
     {singleDemoStory.bind({})}
@@ -114,22 +133,7 @@ If an `href` property is provided, the `heading` (if present) will include a lin
 An optional `cover` block may be provided containing an image or other visual object. This will display using our `wide` [aspect ratio token](/story/design-tokens-aspect-ratio--page), and includes an effect on hover if the card includes an `href` (see above).
 
 <Canvas>
-  <Story
-    name="Cover Image"
-    args={{ href: '#' }}
-    parameters={{
-      docs: {
-        source: {
-          code: `{% embed '@cloudfour/components/card/card.twig' with { href: '#' } only %}
-  {% block heading %}Lorem ipsum dolor sit amet{% endblock %}
-  {% block cover %}<img src="https://placeimg.com/800/450/animals" alt="">{% endblock %}
-  {% block content %}<p>Consectetur adipiscing elit...</p>{% endblock %}
-  {% block footer %}<p>{{'now'|date('M j, Y')}}</p>{% endblock %}
-{% endembed %}`,
-        },
-      },
-    }}
-  >
+  <Story name="Cover Image" args={{ href: '#' }}>
     {singleDemoStory.bind({})}
   </Story>
 </Canvas>
@@ -139,25 +143,7 @@ An optional `cover` block may be provided containing an image or other visual ob
 If a card with a cover is meant to occupy its full container width, it may be preferable to display it horizontally at larger [breakpoints](/docs/design-tokens-breakpoint--page). The `c-card--horizontal@m`, `c-card--horizontal@l` and `c-card--horizontal@xl` modifier classes will do that from their respective breakpoints.
 
 <Canvas>
-  <Story
-    name="Horizontal"
-    args={{ href: '#', horizontal: '@m' }}
-    parameters={{
-      docs: {
-        source: {
-          code: `{% embed '@cloudfour/components/card/card.twig' with {
-  href: '#',
-  class: 'c-card--horizontal@m'
-} only %}
-  {% block heading %}Lorem ipsum dolor sit amet{% endblock %}
-  {% block cover %}<img src="https://placeimg.com/800/450/animals" alt="">{% endblock %}
-  {% block content %}<p>Consectetur adipiscing elit...</p>{% endblock %}
-  {% block footer %}<p>{{'now'|date('M j, Y')}}</p>{% endblock %}
-{% endembed %}`,
-        },
-      },
-    }}
-  >
+  <Story name="Horizontal" args={{ href: '#', horizontal: '@m' }}>
     {singleDemoStory.bind({})}
   </Story>
 </Canvas>
@@ -179,21 +165,6 @@ This variation is best suited for links to bio information, such as on our team 
   <Story
     name="Circular Cover Image"
     args={{ class: 'c-card--circle-cover', href: '#', horizontal: '@m' }}
-    parameters={{
-      docs: {
-        source: {
-          code: `{% embed '@cloudfour/components/card/card.twig' with {
-  class: 'c-card--circle-cover c-card--horizontal@m',
-  href: '#'
-} only %}
-  {% block heading %}Lorem ipsum dolor sit amet{% endblock %}
-  {% block cover %}<img src="https://placeimg.com/800/450/animals" alt="">{% endblock %}
-  {% block content %}<p>Consectetur adipiscing elit...</p>{% endblock %}
-  {% block footer %}<p>{{'now'|date('M j, Y')}}</p>{% endblock %}
-{% endembed %}`,
-        },
-      },
-    }}
   >
     {singleDemoStory.bind({})}
   </Story>
@@ -207,21 +178,6 @@ A card with the `c-card--contained` class will gain a background color, padding 
   <Story
     name="Contained"
     args={{ href: '#', horizontal: '@m', contained: true }}
-    parameters={{
-      docs: {
-        source: {
-          code: `{% embed '@cloudfour/components/card/card.twig' with {
-  href: '#',
-  class: 'c-card--horizontal@m c-card--contained'
-} only %}
-  {% block heading %}Lorem ipsum dolor sit amet{% endblock %}
-  {% block cover %}<img src="https://placeimg.com/800/450/animals" alt="">{% endblock %}
-  {% block content %}<p>Consectetur adipiscing elit...</p>{% endblock %}
-  {% block footer %}<p>{{'now'|date('M j, Y')}}</p>{% endblock %}
-{% endembed %}`,
-        },
-      },
-    }}
   >
     {singleDemoStory.bind({})}
   </Story>
@@ -233,22 +189,7 @@ When the card is a focal point and more contrast is desired, you may also attach
   <Story
     name="Themed"
     args={{ href: '#', horizontal: '@m', contained: true, theme: 'light' }}
-    parameters={{
-      theme: 't-dark',
-      docs: {
-        source: {
-          code: `{% embed '@cloudfour/components/card/card.twig' with {
-  href: '#',
-  class: 'c-card--horizontal@m c-card--contained t-light'
-} only %}
-  {% block heading %}Lorem ipsum dolor sit amet{% endblock %}
-  {% block cover %}<img src="https://placeimg.com/800/450/animals" alt="">{% endblock %}
-  {% block content %}<p>Consectetur adipiscing elit...</p>{% endblock %}
-  {% block footer %}<p>{{'now'|date('M j, Y')}}</p>{% endblock %}
-{% endembed %}`,
-        },
-      },
-    }}
+    parameters={{ theme: 't-dark' }}
   >
     {singleDemoStory.bind({})}
   </Story>
@@ -257,18 +198,19 @@ When the card is a focal point and more contrast is desired, you may also attach
 ## Template Properties
 
 - `class` (string): Append a class to the root element.
-- `tag_name` (string, default `'article'`): The root element tag.
-- `header_tag_name` (string, default `'header'`): The header element tag.
-- `footer_tag_name` (string, default `'footer'`): The footer element tag.
+- `heading_id` (string): Add this `id` to the heading element (if present), as well as the `aria-labelledby` property of the card element (unless `aria_labelledby` is already specified).
 - `heading_level` (number, default `2`): The header heading level (e.g. `2` renders an `<h2>` element).
+- `header_tag_name` (string, default `'header'`): The header element tag.
 - `href` (string): When provided, the `heading` (if present) will include a link that encompasses the entire card.
+- `footer_tag_name` (string, default `'footer'`): The footer element tag.
+- `tag_name` (string, default `'article'`): The root element tag.
 
 ## Template Blocks
 
-- `heading` (optional): The contents of the heading. The heading level may be customized using the `heading_level` property.
-- `cover` (optional): Designed to provide an image or other visual object. Will display using our `wide` [aspect ratio token](/story/design-tokens-aspect-ratio--page), and includes an effect on hover if the card includes an `href`.
 - `content` (optional): The main card content.
+- `cover` (optional): Designed to provide an image or other visual object. Will display using our `wide` [aspect ratio token](/story/design-tokens-aspect-ratio--page), and includes an effect on hover if the card includes an `href`.
 - `footer` (optional): Information about the author or additional supporting content for the card.
+- `heading` (optional): The contents of the heading. The heading level may be customized using the `heading_level` property.
 
 ## Coming soon
 

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -198,7 +198,7 @@ When the card is a focal point and more contrast is desired, you may also attach
 ## Template Properties
 
 - `class` (string): Append a class to the root element.
-- `heading_id` (string): Add this `id` to the heading element (if present), as well as the `aria-labelledby` property of the card element (unless `aria_labelledby` is already specified).
+- `heading_id` (string): Adds this `id` to the heading element (if a heading element is present); this also adds the `aria-labelledby` property of the card element (unless `aria_labelledby` is already specified).
 - `heading_level` (number, default `2`): The header heading level (e.g. `2` renders an `<h2>` element).
 - `header_tag_name` (string, default `'header'`): The header element tag.
 - `href` (string): When provided, the `heading` (if present) will include a link that encompasses the entire card.

--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -99,7 +99,7 @@ const singleDemoTransformSource = (_src, storyContext) => {
 
 A card contains content and optionally an action summarizing a single piece of content, for example an article, talk or case study.
 
-If your card represents an `article` and includes a heading, it's a good idea to provide a `heading_id` as well. This allows us to use `aria-labelledby` to improve the experience of navigating to individual cards via the [VoiceOver rotor](https://support.apple.com/en-us/HT204783) (and potentially other assistive interfaces as well).
+If your card represents an `article` and includes a heading, it's a good idea to provide a `heading_id` as well. This allows us to use `aria-labelledby` to improve the experience of navigating to individual cards via the [macOS VoiceOver rotor](https://support.apple.com/guide/voiceover-guide/navigate-using-the-rotor-mchlp2719/web) (and potentially other assistive interfaces as well).
 
 <Canvas>
   <Story

--- a/src/components/card/card.twig
+++ b/src/components/card/card.twig
@@ -12,11 +12,12 @@
 <{{ tag_name }} class="
   c-card
   {% if href %}c-card--with-link{% endif %}
-  {% if class %}{{ class }}{% endif %}">
+  {% if class %}{{ class }}{% endif %}"
+  {% if heading_id and _heading_block is not empty %}aria-labelledby="{{heading_id}}"{% endif %}>
 
   {% if _heading_block is not empty %}
     <{{ header_tag_name }} class="c-card__header">
-      <h{{ heading_level }} class="c-card__heading">
+      <h{{ heading_level }} class="c-card__heading"{% if heading_id %} id="{{heading_id}}"{% endif %}>
         {% if href %}
           <a href="{{ href }}" class="c-card__link">
             {{ _heading_block }}


### PR DESCRIPTION
## Overview

@Paul-Hebert made a good suggestion to add support for the `aria-labelledby` property on articles to improve the experience of navigating between them via the VoiceOver rotor. After some research in [the web-a11y Slack](https://www.tpgi.com/anybody-can-be-an-a11y-slacker/), I couldn't see any downside to adding this as an option.

I originally implemented the `heading_id` and a separate `aria_labelledby` property, but this felt a bit silly since they should always be the same. Instead, I simplified it down to a single `heading_id` option. If the `heading_id` is specified and the `heading` block isn't empty, it's automatically output to `aria-labelledby` on the root element as well. I wasn't sure if the label had to be on the _heading_ or the immediate container of the heading text (in which case the link would need it, if present), but thankfully after some testing it appears the heading is always the most appropriate element.

Along the way, I found myself struggling a bit to update all of the static code samples, so I also replaced those with a `templateSource` function that builds the examples automatically. This should make the documentation for cards easier to maintain going forward.

## Screenshots

<img width="1060" alt="Screen Shot 2021-11-09 at 1 19 23 PM" src="https://user-images.githubusercontent.com/69633/141006663-4ecfe61c-d781-409c-8b8f-dbacda80237e.png">

## Testing

1. On the deploy preview, try some of the Card examples in the VoiceOver rotor's "Articles" listing. You should see the article heading instead of a generic "Article."
2. Review the docs page to verify that the source examples do not contain any unexpected regressions compared to what's live.

---

- Fixes #1539 