### PR TITLE
Add `--icon-size` property, use within `c-button`

### DIFF
--- a/.changeset/new-pets-care.md
+++ b/.changeset/new-pets-care.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add `--icon-size` CSS custom property to the Icon component to allow sizing via CSS without impacting `font-size` or selector depth.

--- a/.changeset/odd-sloths-allow.md
+++ b/.changeset/odd-sloths-allow.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Remove extra `.c-button__extra` selectors from WordPress block button styles.

--- a/.changeset/tough-books-sing.md
+++ b/.changeset/tough-books-sing.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Size Icons consistently in Buttons. Previously, Icon-only Buttons achieved by including an Icon as the primary content were inconsistently sized compared to Icons included before or after a label.

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -19,3 +19,19 @@
 .c-button--tertiary {
   @include button.tertiary;
 }
+
+/**
+ * Element: Extra
+ */
+
+.c-button__extra {
+  @include button.extra;
+
+  /**
+   * Show visual slash through element when button is in slashed state
+   */
+
+  .c-button.is-slashed & {
+    @include button.extra-slashed;
+  }
+}

--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -6,6 +6,7 @@
   @include svg.inherit-color;
   @include svg.inherit-size;
   display: inline-block;
+  font-size: var(--icon-size, inherit);
   position: relative;
   vertical-align: middle;
 }

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -57,6 +57,10 @@ Icons without a flex or grid container may appear [slightly low in comparison to
   </Story>
 </Canvas>
 
+## CSS Properties
+
+- `--icon-size`: By default, icons are sized based on `font-size`. Alternatively, `--icon-size` may be used in cases where you want to size an icon without impacting `font-size`.
+
 ## Template Properties
 
 The component template supports the following unique properties:

--- a/src/design/icons/icons.stories.mdx
+++ b/src/design/icons/icons.stories.mdx
@@ -44,7 +44,7 @@ const brandIconElements = brandIconDir.keys().map((key) => {
 
 Our icons are designed to be compact yet friendly. They embrace bold shapes, rounded corners and circular caps. They work well adjacent to text, but should rarely be used on their own to convey meaning.
 
-For icon usage examples, see [the icon object](/docs/components-icon--basic).
+For icon usage examples, see [the icon component](/docs/components-icon--basic).
 
 <IconGallery>{iconElements}</IconGallery>
 

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -46,6 +46,7 @@
  */
 
 @mixin default {
+  --icon-size: #{size.$icon-medium};
   align-items: center;
   background: var(--theme-color-background-button-default);
   border-color: var(--theme-color-border-button-default);
@@ -93,65 +94,6 @@
     transform: none;
   }
 
-  .c-button__extra {
-    display: flex;
-    font-size: size.$icon-medium;
-    margin: 0 size.$spacing-gap-button-extra;
-    position: relative;
-
-    &:first-child {
-      margin-left: size.$spacing-gap-button-extra * -1;
-    }
-
-    &:last-child {
-      margin-right: size.$spacing-gap-button-extra * -1;
-    }
-  }
-
-  /**
-   * Adds a slash across the "extra" content (most times "extra" content is an icon).
-   */
-  &.is-slashed {
-    .c-button__extra {
-      &::after {
-        background: currentColor;
-        border-radius: size.$border-radius-full;
-        content: '';
-        height: size.$edge-medium;
-        left: 0;
-        position: absolute;
-        top: 50%;
-        transform: rotate(-30deg);
-        width: 100%;
-      }
-
-      $clip-path: polygon(
-        -5% -5%,
-        105% -5%,
-        105% 23%,
-        -5% 87%,
-        -5% 101.4711%,
-        105% 37.9626%,
-        105% 105%,
-        -5% 105%
-      );
-
-      /**
-       * 1. Fixes a bug where some browsers would render the element as
-       *    slightly offset from others.
-       * 2. Helps normalize the box the clipping path renders to.
-       */
-      & > * {
-        clip-path: $clip-path;
-        transform: translate(0, 0); /* 1 */
-
-        @supports (clip-path: view-box) {
-          clip-path: view-box $clip-path; /* 2 */
-        }
-      }
-    }
-  }
-
   @include focus.focus-visible {
     box-shadow: 0 0 0 size.$edge-large color.$brand-primary-lighter;
   }
@@ -175,4 +117,58 @@
   background-color: transparent;
   border-color: transparent;
   color: var(--theme-color-text-button-tertiary);
+}
+
+/// Rules for extra element. Used to contain icons or other visual affordances.
+@mixin extra {
+  display: flex;
+  margin: 0 size.$spacing-gap-button-extra;
+  position: relative;
+
+  &:first-child {
+    margin-left: size.$spacing-gap-button-extra * -1;
+  }
+
+  &:last-child {
+    margin-right: size.$spacing-gap-button-extra * -1;
+  }
+}
+
+/// Clip path used for extra element when button's slashed state is active
+$extra-slashed-clip-path: polygon(
+  -5% -5%,
+  105% -5%,
+  105% 23%,
+  -5% 87%,
+  -5% 101.4711%,
+  105% 37.9626%,
+  105% 105%,
+  -5% 105%
+);
+
+// Styles for extra specific to slashed button state
+@mixin extra-slashed {
+  &::after {
+    background: currentColor;
+    border-radius: size.$border-radius-full;
+    content: '';
+    height: size.$edge-medium;
+    left: 0;
+    position: absolute;
+    top: 50%;
+    transform: rotate(-30deg);
+    width: 100%;
+  }
+
+  // 1. Fixes a bug where some browsers would render the element as
+  //    slightly offset from others.
+  // 2. Helps normalize the box the clipping path renders to.
+  & > * {
+    clip-path: $extra-slashed-clip-path;
+    transform: translate(0, 0); // 1
+
+    @supports (clip-path: view-box) {
+      clip-path: view-box $extra-slashed-clip-path; // 2
+    }
+  }
 }

--- a/src/prototypes/article-listing/example/example.scss
+++ b/src/prototypes/article-listing/example/example.scss
@@ -88,8 +88,4 @@
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
   }
-
-  .search-btn .c-icon {
-    font-size: ms.step(1);
-  }
 }

--- a/src/prototypes/article-listing/example/example.twig
+++ b/src/prototypes/article-listing/example/example.twig
@@ -189,8 +189,9 @@
             }  %}
               {% block content %}
                 {% include '@cloudfour/components/icon/icon.twig' with {
-                  name: 'magnifying-glass'
-                } %}
+                  name: 'magnifying-glass',
+                  inline: true
+                } only %}
               {% endblock %}
             {% endembed %}
           </div>


### PR DESCRIPTION
## Overview

Addresses an issue where icons were inconsistently sized if included as the primary button content, as one might expect for an icon-only button.

Previously, button icon sizes were controlled via `font-size` on the icon container, `c-button__extra`. When an icon was included as the primary content, `c-button__content`, there was no such `font-size` declaration, and so the icon would appear smaller by comparison.

I considered adding some utility classes and/or icon modifiers to solve this problem, but I realized when futzing with the component that there were other potential issues with relying on `font-size` on a containing element. For example, it's impossible to reliably negate the gap between the `__extra` and `__content` elements since the `font-size` for the icon increases the computed size of that gap to a spot between two of our modular scale steps.

Instead, I added an optional `--icon-size` property to the `c-icon` component. This allows us to set the desired size of the icon on `c-button`, which cascades to _all_ elements below. It also means the computed impact of the icon's size is not effective until the icon itself, so any margins or other relative values on its container will be more consistent with adjacent elements.

Along the way, I noticed that the `c-button__extra` styles were being unnecessarily output a second time within the context of WordPress buttons. I separated those styles into their own mixins to prevent this.

(This PR originally included other changes to `c-button` to streamline its template code, but I realized partway in that the actual solution to the issue was a smaller subset of that, which I've separated into this PR.)

## Screenshots

### Before

<img width="364" alt="Screen Shot 2021-11-16 at 2 33 54 PM" src="https://user-images.githubusercontent.com/69633/142077783-decf8fac-888a-47e6-92f3-163360d01d13.png">

### After

<img width="353" alt="Screen Shot 2021-11-16 at 2 40 35 PM" src="https://user-images.githubusercontent.com/69633/142077852-a056d3d0-6ccf-4fbc-b502-7ad1e72436e4.png">

## Testing

On the deploy preview…

1. Review Button component for regressions
2. Review Icon component for regressions
3. Review Article Listing prototype search form for regressions

---

- Fixes #1540 