### PR TITLE
Fix Theme Pages

### DIFF
--- a/src/design/demo/theme-alternate.twig
+++ b/src/design/demo/theme-alternate.twig
@@ -3,7 +3,7 @@
 } %}
   {% block content %}
     <h1>t-{{theme}}</h1>
-    {% include '@cloudfour/design/typography/demo/inline-elements.twig' only %}
+    {% include '@cloudfour/design/demo/theme-content.twig' only %}
     {% include '@cloudfour/components/button/demo/styles.twig' only %}
   {% endblock %}
 {% endembed %}
@@ -12,7 +12,7 @@
 } %}
   {% block content %}
     <h2>t-alternate within t-{{theme}}</h2>
-    {% include '@cloudfour/design/typography/demo/inline-elements.twig' only %}
+    {% include '@cloudfour/design/demo/theme-content.twig' only %}
     {% include '@cloudfour/components/button/demo/styles.twig' only %}
   {% endblock %}
 {% endembed %}

--- a/src/design/demo/theme-content.twig
+++ b/src/design/demo/theme-content.twig
@@ -1,0 +1,11 @@
+{% embed '@cloudfour/objects/rhythm/rhythm.twig' %}
+  {% block content %}
+    <p>
+      <b>Progressive Web Apps</b> are awesome, <em>especially</em> when they make the <del>best</del> <ins>most</ins> of the web! That means using both tried and true <abbr title="HyperText Markup Language">HTML</abbr> techniques like <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">links</a> alongside new techniques like <code>display: grid</code> or <a href="https://github.com/WICG/focus-visible"><code>focus-visible</code></a>!
+    </p>
+
+    <p>
+      You can use <kbd>ctrl</kbd> + <kbd>c</kbd> on Windows and <kbd>⌘</kbd> + <kbd>c</kbd> on Mac.
+    </p>
+  {% endblock %}
+{% endembed %}

--- a/src/design/demo/theme.twig
+++ b/src/design/demo/theme.twig
@@ -3,7 +3,7 @@
 } %}
   {% block content %}
     <h1>t-{{theme}}</h1>
-    {% include '@cloudfour/design/typography/demo/inline-elements.twig' only %}
+    {% include '@cloudfour/design/demo/theme-content.twig' only %}
     {% include '@cloudfour/components/button/demo/styles.twig' only %}
     {% set _card_class = 'c-card--horizontal@m c-card--contained' %}
     {% include '@cloudfour/components/card/demo/single.twig' with {

--- a/src/prototypes/single-article/example/example.twig
+++ b/src/prototypes/single-article/example/example.twig
@@ -35,6 +35,14 @@
     ]
   }
 } only %}
+{% set content %}
+<button class="Button">
+  <span class="Button-inner">
+    Example
+  </span>
+  <!-- badge, etc. -->
+</button>
+{% endset %}
 {% embed '@cloudfour/objects/container/container.twig' with {
   class: 'o-container--prose o-container--pad u-pad-block-6'} %}
   {% block content %}
@@ -131,7 +139,7 @@
 
             <p>There are some places where Slowpoke is worshiped because of a long-standing belief that whenever Slowpoke yawns, it rains. Carrying food through <code>Fearow’s territory is dangerous</code>. It will snatch the food away from you in a flash! Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this <code>Pokémon’s feet</code> are thought to change shape and become similar to the roots of trees.</p>
 
-            {% include '@cloudfour/design/typography/demo/code-block.twig' only %}
+            <pre><code class="language-markup">{{content|trim|escape}}</code></pre>
 
             <p>In the distant past, they were fairly strong, but they have become gradually weaker over time. Although known for their splendid tail fins, Goldeen apparently compete among themselves to see whose horn is thickest and sharpest. Beautifly has a long mouth like a coiled needle, which is very convenient for collecting pollen from flowers. This Pokémon rides the spring winds as it flits around gathering pollen.</p>
 


### PR DESCRIPTION
## Overview

This PR fixes a bug where the theme pages were trying to include a
twig template that was deleted in #1569. This restores that template
in a new name to make it clear it's used in the theme pages.

## Testing

Review the [Theme pages](https://deploy-preview-1587--cloudfour-patterns.netlify.app/?path=/story/design-themes--light) and [Single Article prototype](https://deploy-preview-1587--cloudfour-patterns.netlify.app/?path=/story/prototypes-single-article--example) on the preview deploy. They should not display an error.

---

- Fixes #1585