### PR TITLE
Remove paddings add-on

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -19,7 +19,6 @@ module.exports = {
     },
     '@storybook/addon-a11y',
     'storybook-mobile',
-    'storybook-addon-paddings',
     'storybook-addon-outline',
     '@whitespace/storybook-addon-html',
     '@storybook/addon-postcss',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,20 +13,6 @@ const breakpoints = tokens.size.breakpoint;
 // Extend the languages Storybook will highlight
 ReactSyntaxHighlighter.registerLanguage('twig', twig);
 
-// Padding values from modular scale
-const paddings = { values: [], default: 'Step 0' };
-for (let i = -3; i <= 6; i++) {
-  paddings.values.push({
-    name: `Step ${i}`,
-    // `toFixed` keeps the values from extending past two decimal points.
-    // The leading `+` keeps values from having decimal points where they don't
-    // need them, so `1.00` becomes `1`.
-    value: `${+Math.pow(tokens.number.scale.modular.ratio.value, i).toFixed(
-      2
-    )}em`,
-  });
-}
-
 // Create viewports using widths defined in design tokens
 const breakpointViewports = Object.keys(breakpoints).map((name) => {
   return {
@@ -90,7 +76,6 @@ export const parameters = {
       ...INITIAL_VIEWPORTS,
     },
   },
-  paddings,
 };
 
 export const globalTypes = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "sass": "1.38.0",
         "sass-loader": "10.2.0",
         "storybook-addon-outline": "1.4.1",
-        "storybook-addon-paddings": "4.2.1",
         "storybook-mobile": "0.1.31",
         "style-dictionary": "3.0.3",
         "style-loader": "2.0.0",
@@ -32647,31 +32646,6 @@
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
-    "node_modules/storybook-addon-paddings": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/addons": "^6.2.0",
-        "@storybook/api": "^6.2.0",
-        "@storybook/components": "^6.2.0",
-        "@storybook/theming": "^6.2.0",
-        "core-js": "^3.12.0",
-        "memoizerific": "^1.11.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/storybook-mobile": {
       "version": "0.1.31",
       "dev": true,
@@ -61578,18 +61552,6 @@
         "@storybook/components": "^6.3.0",
         "@storybook/core-events": "^6.3.0",
         "ts-dedent": "^2.1.1"
-      }
-    },
-    "storybook-addon-paddings": {
-      "version": "4.2.1",
-      "dev": true,
-      "requires": {
-        "@storybook/addons": "^6.2.0",
-        "@storybook/api": "^6.2.0",
-        "@storybook/components": "^6.2.0",
-        "@storybook/theming": "^6.2.0",
-        "core-js": "^3.12.0",
-        "memoizerific": "^1.11.0"
       }
     },
     "storybook-mobile": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "sass": "1.38.0",
     "sass-loader": "10.2.0",
     "storybook-addon-outline": "1.4.1",
-    "storybook-addon-paddings": "4.2.1",
     "storybook-mobile": "0.1.31",
     "style-dictionary": "3.0.3",
     "style-loader": "2.0.0",

--- a/src/components/alert/alert.stories.mdx
+++ b/src/components/alert/alert.stories.mdx
@@ -55,7 +55,6 @@ Alerts work well even when displayed at full width. Their contents will constrai
     name="Full width"
     parameters={{
       layout: 'fullscreen',
-      paddings: { disable: true },
     }}
     args={{
       message: 'You appear to be offline. 🤔',

--- a/src/components/cloud-cover/cloud-cover.stories.mdx
+++ b/src/components/cloud-cover/cloud-cover.stories.mdx
@@ -9,7 +9,7 @@ import robotImage from './demo/robot.svg';
   title="Components/Cloud Cover"
   parameters={{
     docs: { inlineStories: false },
-    paddings: { disable: true },
+    layout: 'fullscreen',
     themes: { disable: true },
   }}
 />

--- a/src/components/ground-nav/ground-nav.stories.mdx
+++ b/src/components/ground-nav/ground-nav.stories.mdx
@@ -55,7 +55,7 @@ embedded examples.
 
 <Meta
   title="Components/Ground Nav"
-  parameters={{ docs: { inlineStories: false }, paddings: { disable: true } }}
+  parameters={{ docs: { inlineStories: false }, layout: 'fullscreen' }}
 />
 
 # Ground Nav

--- a/src/components/sky-nav/sky-nav.stories.mdx
+++ b/src/components/sky-nav/sky-nav.stories.mdx
@@ -37,7 +37,6 @@ The Sky Nav is intended for use with our [our dark theme](/docs/design-themes--d
     height="200px"
     parameters={{
       layout: 'fullscreen',
-      paddings: { disable: true },
       themes: { disable: true },
       docs: {
         source: {
@@ -72,7 +71,6 @@ But it works without a theme, too, just in case:
     height="200px"
     parameters={{
       layout: 'fullscreen',
-      paddings: { disable: true },
       themes: { disable: true },
       docs: {
         source: {

--- a/src/design/favicons.stories.mdx
+++ b/src/design/favicons.stories.mdx
@@ -20,7 +20,7 @@ We also provide `favicon-dev.ico` and `favicon-dev.svg` to help differentiate ta
   <Story
     name="Favicons"
     parameters={{
-      paddings: { disable: true },
+      layout: 'fullscreen',
       docs: {
         source: {
           code: `<link rel="icon" href="path/to/favicon.ico" />
@@ -34,7 +34,7 @@ We also provide `favicon-dev.ico` and `favicon-dev.svg` to help differentiate ta
   <Story
     name="Favicons (Dev)"
     parameters={{
-      paddings: { disable: true },
+      layout: 'fullscreen',
       docs: {
         source: {
           code: `<link rel="icon" href="path/to/favicon-dev.ico" />

--- a/src/objects/container/container.stories.mdx
+++ b/src/objects/container/container.stories.mdx
@@ -38,7 +38,6 @@ embedded examples.
   parameters={{
     layout: 'fullscreen',
     docs: { inlineStories: false },
-    paddings: { disable: true },
   }}
   argTypes={{
     prose: {

--- a/src/objects/page/page.stories.mdx
+++ b/src/objects/page/page.stories.mdx
@@ -14,7 +14,7 @@ import exampleDemo from './demo/example.twig';
 
 <Meta
   title="Objects/Page"
-  parameters={{ docs: { inlineStories: false }, paddings: { disable: true } }}
+  parameters={{ docs: { inlineStories: false }, layout: 'fullscreen' }}
 />
 
 # Page

--- a/src/prototypes/article-listing/articles.stories.js
+++ b/src/prototypes/article-listing/articles.stories.js
@@ -8,7 +8,7 @@ export default {
   title: 'Prototypes/Article Listing',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/articles/articles.stories.js
+++ b/src/prototypes/articles/articles.stories.js
@@ -8,7 +8,7 @@ export default {
   title: 'Prototypes/Articles',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/card-variations/card-variations.stories.js
+++ b/src/prototypes/card-variations/card-variations.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Prototypes/Card Variations',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/case-study-listings/case-study-listings.stories.js
+++ b/src/prototypes/case-study-listings/case-study-listings.stories.js
@@ -9,7 +9,7 @@ export default {
   title: 'Prototypes/Case Study Listings',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/cloud-divider/clouds.stories.js
+++ b/src/prototypes/cloud-divider/clouds.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Prototypes/Clouds',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/comment-thread/thread.stories.js
+++ b/src/prototypes/comment-thread/thread.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Prototypes/Comment Thread',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/email-signup/signup.stories.js
+++ b/src/prototypes/email-signup/signup.stories.js
@@ -6,7 +6,7 @@ export default {
   title: 'Prototypes/Email Signup Form',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/error/error.stories.js
+++ b/src/prototypes/error/error.stories.js
@@ -6,7 +6,7 @@ export default {
   title: 'Prototypes/Error Pages',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/home-page/home-page.stories.js
+++ b/src/prototypes/home-page/home-page.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Prototypes/Home Page Content',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/no-content/no-content.stories.js
+++ b/src/prototypes/no-content/no-content.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Prototypes/No Content',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/no-results/articles.stories.js
+++ b/src/prototypes/no-results/articles.stories.js
@@ -6,7 +6,7 @@ export default {
   title: 'Prototypes/No Results',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/quotes/quotes.stories.js
+++ b/src/prototypes/quotes/quotes.stories.js
@@ -4,7 +4,7 @@ export default {
   title: 'Prototypes/Quotes',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/single-article/single-article.stories.js
+++ b/src/prototypes/single-article/single-article.stories.js
@@ -4,7 +4,7 @@ import { useSkyNav } from '../use-sky-nav.ts';
 export default {
   title: 'Prototypes/Single Article',
   parameters: {
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/single-page/single-page.stories.js
+++ b/src/prototypes/single-page/single-page.stories.js
@@ -6,7 +6,7 @@ import { useSkyNav } from '../use-sky-nav.ts';
 export default {
   title: 'Prototypes/Single Page',
   parameters: {
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/speaking-event/speaking.stories.js
+++ b/src/prototypes/speaking-event/speaking.stories.js
@@ -8,7 +8,7 @@ export default {
   title: 'Prototypes/Speaking Event',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/speaking-listing/speaking.stories.js
+++ b/src/prototypes/speaking-listing/speaking.stories.js
@@ -7,7 +7,7 @@ export default {
   title: 'Prototypes/Speaking Listing',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 

--- a/src/prototypes/team/team.stories.js
+++ b/src/prototypes/team/team.stories.js
@@ -9,7 +9,7 @@ export default {
   title: 'Prototypes/Team Page',
   parameters: {
     docs: { page: null },
-    paddings: { disable: true },
+    layout: 'fullscreen',
   },
 };
 


### PR DESCRIPTION
## Overview

[A bug popped up a while ago in the Storybook padding add-on we used](https://github.com/rbardini/storybook-addon-paddings/issues/28), but it's been a challenging issue for the developer to resolve because of some very odd markup structure in Storybook Docs.

Although our add-on supported multiple steps in our modular scale, I realized when looking at the various stories that we were only ever applying or disabling the add-on. This makes the value of the toolbar item questionable compared to the `layout` feature that Storybook includes, which can be set to `fullscreen` for stories that are meant to fill the viewport width.

So this PR removes the add-on, and replaces any parameters related to removing padding with `layout: 'fullscreen'`.

---

- Fixes #1371