### PR TITLE
Add min-width to Page contents

### DIFF
--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -1,16 +1,17 @@
 /**
  * Page container
  *
- * Attempts to fill the available area (assuming `height: 100%` is correctly
- * applied to all parent elements) and keeps the footer at the bottom of that
- * area.
- *
- * @see https://css-tricks.com/couple-takes-sticky-footer/#there-is-grid
+ * 1. Avoid grid blowouts by specifying the `min-width` of the column.
+ *    @see https://css-tricks.com/you-want-minmax10px-1fr-not-1fr/
+ * 2. Attempts to fill the available area (assuming `height: 100%` is applied
+ *    to all parent elements) & keep the footer at the bottom of that area.
+ *    @see https://css-tricks.com/couple-takes-sticky-footer/#there-is-grid
  */
 
 .o-page {
   display: grid;
-  grid-template-rows: 1fr auto;
+  grid-template-columns: minmax(0, 1fr); // 1
+  grid-template-rows: 1fr auto; // 2
   min-height: 100%;
 }
 
@@ -18,19 +19,12 @@
  * These classes aren't strictly required, but they keep the HTML source a
  * little easier to read while also supporting swapping of source order if
  * that's ever something that content calls for.
- *
- * 1. By default grid items have `min-width:auto` which is breaking layout on
- *    blog posts with long code samples. Setting `min-width:0` allows the grid
- *    items to shrink, regardless of their intrinsic size.
- *    @see https://ishadeed.com/article/min-content-size-css-grid/
  */
 
 .o-page__content {
   grid-row: 1;
-  min-width: 0; // 1
 }
 
 .o-page__footer {
   grid-row: 2;
-  min-width: 0; // 1
 }

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -19,8 +19,9 @@
  * little easier to read while also supporting swapping of source order if
  * that's ever something that content calls for.
  *
- * 1. By default grid items have min-width:auto which is breaking layout
- *    on blog posts with long code samples.
+ * 1. By default grid items have `min-width:auto` which is breaking layout on
+ *    blog posts with long code samples. Setting `min-width:0` allows the grid
+ *    items to shrink, regardless of their intrinsic size.
  *    @see https://ishadeed.com/article/min-content-size-css-grid/
  */
 

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -18,12 +18,18 @@
  * These classes aren't strictly required, but they keep the HTML source a
  * little easier to read while also supporting swapping of source order if
  * that's ever something that content calls for.
+ *
+ * 1. By default grid items have min-width:auto which is breaking layout
+ *    on blog posts with long code samples.
+ *    @see https://ishadeed.com/article/min-content-size-css-grid/
  */
 
 .o-page__content {
   grid-row: 1;
+  min-width: 0; // 1
 }
 
 .o-page__footer {
   grid-row: 2;
+  min-width: 0; // 1
 }

--- a/src/prototypes/single-article/example/example.twig
+++ b/src/prototypes/single-article/example/example.twig
@@ -1,3 +1,6 @@
+<div class="o-page">
+<div class="o-page__content">
+
 {% include '@cloudfour/components/sky-nav/sky-nav.twig' with {
   "class": "t-dark",
   "include_main_demo": false,
@@ -35,14 +38,19 @@
     ]
   }
 } only %}
+
 {% set content %}
-<button class="Button">
-  <span class="Button-inner">
-    Example
-  </span>
-  <!-- badge, etc. -->
-</button>
+.backButton {
+  display: none;
+}
+
+@media (display-mode: standalone), (display-mode: fullscreen) {
+  .backButton {
+    display: block;
+  }
+}
 {% endset %}
+
 {% embed '@cloudfour/objects/container/container.twig' with {
   class: 'o-container--prose o-container--pad u-pad-block-6'} %}
   {% block content %}
@@ -139,7 +147,7 @@
 
             <p>There are some places where Slowpoke is worshiped because of a long-standing belief that whenever Slowpoke yawns, it rains. Carrying food through <code>Fearow’s territory is dangerous</code>. It will snatch the food away from you in a flash! Oddish searches for fertile, nutrient-rich soil, then plants itself. During the daytime, while it is planted, this <code>Pokémon’s feet</code> are thought to change shape and become similar to the roots of trees.</p>
 
-            <pre><code class="language-markup">{{content|trim|escape}}</code></pre>
+            <pre><code class="language-css">{{content|trim|escape}}</code></pre>
 
             <p>In the distant past, they were fairly strong, but they have become gradually weaker over time. Although known for their splendid tail fins, Goldeen apparently compete among themselves to see whose horn is thickest and sharpest. Beautifly has a long mouth like a coiled needle, which is very convenient for collecting pollen from flowers. This Pokémon rides the spring winds as it flits around gathering pollen.</p>
 
@@ -298,6 +306,10 @@
     {% endembed %}
   {% endblock %}
 {% endembed %}
+
+</div>
+<div class="o-page__footer">
+
 {% include '@cloudfour/components/ground-nav/ground-nav.twig' with {
   "menu": {
     "items": [
@@ -389,3 +401,6 @@
     "founding_date": "2007-12-13"
   }
 } only %}
+
+</div>
+</div>


### PR DESCRIPTION
## Overview

This PR fixes a bug where blog posts that contained lengthy code samples were breaking layout. The bug wasn't actually caused by the code samples, which have the proper `overflow:auto` property set. Instead, this is caused by an oddity of Grid layouts, where the Grid items by default have `min-width:auto`, which can prevent them from reducing width the way you might expect. The fix is to tell the Grid layout the minimum width for Grid items, and then it will shrink the way you'd expect.

Learn more: https://css-tricks.com/you-want-minmax10px-1fr-not-1fr/

## Testing

Unfortunately, the bug was not visible in the pattern library, because we weren't applying the Page object to the Single Article prototype. This PR applies that change so we can test the fix.

1. visit the [Single Article prototype](https://deploy-preview-1591--cloudfour-patterns.netlify.app/?path=/story/prototypes-single-article--example) on the deploy preview
2. Using devtools, disable the `grid-template-columns` rule on `.o-page`.
3. Reduce your browser to small screen size, and you should see the layout break, with a horizontal scrollbar on the entire page.
4. Restore the `grid-template-columns` rule.
5. The layout should now be fixes.

---

- Fixes #1532