### PR TITLE
Fix issues related to columned lists in Safari

### DIFF
--- a/.changeset/ten-candles-guess.md
+++ b/.changeset/ten-candles-guess.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix for List objects with columns in Safari that include visually hidden elements or elements with content divided between columns

--- a/src/objects/list/list.scss
+++ b/src/objects/list/list.scss
@@ -4,33 +4,29 @@
 @use '../../mixins/fluid';
 @use '../../mixins/media-query';
 
-/**
- * Override browser defaults. Note that this means it's very important to
- * include `[role="list"]` to prevent disruption of list navigation in Safari
- * VoiceOver.
- *
- * @see https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
- */
+/// Override browser defaults. Note that this means it's very important to
+/// include `[role="list"]` to prevent disruption of list navigation in Safari
+/// VoiceOver, unless the content itself makes its nature obvious.
+///
+/// @link https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
 
 .o-list {
   list-style: none;
   padding-inline-start: 0;
 }
 
-/**
- * Modifier: Inline
- *
- * By default, this uses negative margins on the sides to account for extra
- * margin between child elements. This allows child elements to reach the edges
- * of their parent while maintaining consistent gaps between.
- *
- * This would be a _lot_ more elegant if it used the Flexbox-compatible `gap`
- * property. But unfortunately there is no way to test for that without false
- * positives as of this writing.
- *
- * @see https://medium.com/@schofeld/mind-the-flex-gap-c9cd1b4b35d8
- * @see https://github.com/w3c/csswg-drafts/issues/3559
- */
+/// Modifier: Inline
+///
+/// By default, this uses negative margins on the sides to account for extra
+/// margin between child elements. This allows child elements to reach the edges
+/// of their parent while maintaining consistent gaps between.
+///
+/// This would be a _lot_ more elegant if it used the Flexbox-compatible `gap`
+/// property. But unfortunately there is no way to test for that without false
+/// positives as of this writing.
+///
+/// @link https://medium.com/@schofeld/mind-the-flex-gap-c9cd1b4b35d8
+/// @link https://github.com/w3c/csswg-drafts/issues/3559
 
 .o-list--inline {
   display: flex;
@@ -52,6 +48,19 @@
         breakpoint.$xl
       );
       columns: #{$i};
+      position: relative;
+
+      // Safari has some odd bugs related to CSS multi-column. Specifically:
+      //
+      // 1. Without this, the top of an item may appear in one column with the
+      //    bottom half in the following column.
+      // 2. Without this, `position: absolute` elements will impact the overall
+      //    window scroll height, even if they're invisible (as with our
+      //    `u-hidden-visually` utility).
+      > * {
+        break-inside: avoid; // 1
+        position: relative; // 2
+      }
     }
   }
 }

--- a/src/objects/list/list.scss
+++ b/src/objects/list/list.scss
@@ -50,13 +50,13 @@
       columns: #{$i};
       position: relative;
 
-      // Safari has some odd bugs related to CSS multi-column. Specifically:
-      //
-      // 1. Without this, the top of an item may appear in one column with the
-      //    bottom half in the following column.
-      // 2. Without this, `position: absolute` elements will impact the overall
-      //    window scroll height, even if they're invisible (as with our
-      //    `u-hidden-visually` utility).
+      /// Safari has some odd bugs related to CSS multi-column. Specifically:
+      ///
+      /// 1. Without this, the top of an item may appear in one column with the
+      ///    bottom half in the following column.
+      /// 2. Without this, `position: absolute` elements will impact the overall
+      ///    window scroll height, even if they're invisible (as with our
+      ///    `u-hidden-visually` utility).
       > * {
         break-inside: avoid; // 1
         position: relative; // 2

--- a/src/objects/overview/demo/advanced.twig
+++ b/src/objects/overview/demo/advanced.twig
@@ -26,7 +26,11 @@
     } %}
       {% block content %}
         {% for topic in topics %}
-          <li class="u-space-block-end-0">
+          {#
+            We must use padding between items because Safari likes to carry
+            margin across columns.
+          #}
+          <li class="u-pad-block-end-0">
             {% include '@cloudfour/components/dot-leader/dot-leader.twig' with {
               label: topic.title,
               count: topic.count,

--- a/src/prototypes/article-listing/example/example.twig
+++ b/src/prototypes/article-listing/example/example.twig
@@ -203,7 +203,11 @@
           } %}
             {% block content %}
               {% for topic in topics %}
-                <li class="u-space-block-end-0">
+                {#
+                  We must use padding between items because Safari likes to
+                  carry margin across columns.
+                #}
+                <li class="u-pad-block-end-0">
                   {% include '@cloudfour/components/dot-leader/dot-leader.twig' with {
                     label: topic.title,
                     count: topic.count,


### PR DESCRIPTION
## Overview

This PR fixes three Safari issues that were visible in different situations in the article topics listing:

- Any `u-hidden-visually` elements within the list would cause Safari to increase the scrollable height of the window. This was resolved by adding `position: relative` to children of the list. (It was not effective to add this to the parent.)
- Some elements would appear divided between columns. This was resolved by adding `break-inside: avoid` to children of the list. (`page-break-inside` and `-webkit-column-break-inside` are common suggestions, but these are older properties that didn't seem to have any more effect)
- The bottom margin of an item could carry into the next column. This was fixed by swapping `u-space-block-end-0` with `u-pad-block-end-0` in the relevant templates.

## Screenshots

### Before

Highlighting visually divided items and extra space...

<img width="1366" alt="Screen Shot 2021-12-07 at 1 09 56 PM" src="https://user-images.githubusercontent.com/69633/145107277-4535fec2-1ba9-44bf-a3bb-c993da397fda.png">

### After

<img width="1113" alt="Screen Shot 2021-12-07 at 1 09 18 PM" src="https://user-images.githubusercontent.com/69633/145107330-fd403b43-6fde-437e-9c2c-9f7f6428069a.png">

## Testing

The issue was previously symptomatic in "Objects ▸ Overview ▸ Advanced" and "Prototypes ▸ Article Listing ▸ Example," so those are good stories to verify the fix in.

---

- Fixes #1596 
