### PR TITLE
Lint Fix for `currentcolor`

### DIFF
--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -291,7 +291,7 @@ address {
  */
 
 hr {
-  border-color: currentColor;
+  border-color: currentcolor;
   border-style: solid;
   border-width: math.div(size.$edge-medium, 2) 0; /* 1 */
   color: var(--theme-color-border-text-group);

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -44,7 +44,7 @@
     appearance: none; /* 2 */
     background-color: color.$text-light;
     block-size: size.$square-toggle-medium;
-    border: size.$edge-control solid currentColor;
+    border: size.$edge-control solid currentcolor;
     border-radius: size.$border-radius-medium;
     color: color.$text-dark;
     cursor: pointer;
@@ -111,7 +111,7 @@
      */
 
     &:checked {
-      background-color: currentColor;
+      background-color: currentcolor;
 
       /**
        * End state of animation

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -18,7 +18,7 @@
 @include theme.props(dark) {
   --theme-color-background-input-disabled: #{color.$brand-primary-lighter};
   --theme-color-border-input-disabled: #{color.$brand-primary-dark};
-  --theme-color-border-input-hover: currentColor;
+  --theme-color-border-input-hover: currentcolor;
 }
 
 /**
@@ -39,7 +39,7 @@
   appearance: none; /* 1 */
   background-color: color.$text-light;
   block-size: size.$height-control-default; /* 2 */
-  border: size.$edge-control solid currentColor;
+  border: size.$edge-control solid currentcolor;
   border-radius: size.$border-radius-medium;
   color: color.$text-dark;
   display: block;

--- a/src/components/pagination/pagination.scss
+++ b/src/components/pagination/pagination.scss
@@ -261,7 +261,7 @@ $indicator-width-current: $indicator-height-current;
  */
 
 .c-pagination__number::after {
-  background: currentColor;
+  background: currentcolor;
   block-size: $indicator-height;
   border-radius: size.$border-radius-full;
   content: '';

--- a/src/components/sky-nav/sky-nav.scss
+++ b/src/components/sky-nav/sky-nav.scss
@@ -183,7 +183,7 @@ $_masthead-height-sm: ms.step(7);
 .c-sky-nav__logo-object {
   block-size: auto;
   display: block; /* 1 */
-  fill: currentColor;
+  fill: currentcolor;
   inline-size: fluid.fluid-calc(
     ms.step(7),
     ms.step(9),

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -149,7 +149,7 @@ $extra-slashed-clip-path: polygon(
 // Styles for extra specific to slashed button state
 @mixin extra-slashed {
   &::after {
-    background: currentColor;
+    background: currentcolor;
     block-size: size.$edge-medium;
     border-radius: size.$border-radius-full;
     content: '';

--- a/src/mixins/_svg.scss
+++ b/src/mixins/_svg.scss
@@ -7,8 +7,8 @@
  *    makes visible strokes opt-in.
  */
 @mixin inherit-color {
-  fill: currentColor;
-  stroke: currentColor;
+  fill: currentcolor;
+  stroke: currentcolor;
   stroke-width: 0; /* 1 */
 }
 


### PR DESCRIPTION
## Overview

`currentColor` was brought into CSS from SVG, and that's why it kept
the unusual capitalization. The CSS level 4 spec formally changed it
to `currentcolor` and Stylelint recently updated their rules to
enforce that.

See discussion here: https://github.com/stylelint/stylelint/issues/5863