### PR TITLE
Set a default form_id for the subscribe pattern for testing

### DIFF
--- a/src/components/subscribe/subscribe.test.ts
+++ b/src/components/subscribe/subscribe.test.ts
@@ -4,9 +4,11 @@ import { withBrowser, getAccessibilityTree } from 'pleasantest';
 import { loadTwigTemplate, loadGlobalCSS } from '../../../test-utils';
 
 // Helper to load the Twig template file
-const componentMarkup = loadTwigTemplate(
-  path.join(__dirname, './subscribe.twig')
-);
+const componentMarkup = (args = {}) =>
+  loadTwigTemplate(path.join(__dirname, './subscribe.twig'))({
+    form_id: 'example-form',
+    ...args,
+  });
 // Helper to load the demo Twig template file
 const demoMarkup = loadTwigTemplate(path.join(__dirname, './demo/demo.twig'));
 
@@ -74,7 +76,7 @@ describe('Subscription', () => {
             heading "Get Weekly Digests"
               text "Get Weekly Digests"
             text "Email"
-            textbox
+            textbox "Email"
             button "Subscribe"
       `);
     })


### PR DESCRIPTION
Conversation here: https://github.com/cloudfour/cloudfour.com-patterns/pull/1679#discussion_r836628459

@gerardo-rodriguez an alternate solution would be to make the twig file itself have its own default value for the form ID, but I don't know if that is the best because it would mean that the form id would be duplicated on the page if you included the subscribe component multiple times on the same page. Do you know if there is a way to make a twig prop required, so that it'll throw an error or something if the prop is missing?