### PR TITLE
Add supporting materials to speaking event prototype

### DIFF
--- a/src/objects/button-group/button-group.scss
+++ b/src/objects/button-group/button-group.scss
@@ -21,5 +21,5 @@
  * Full button width modifier
  */
 .o-button-group--grow > * {
-  flex-grow: 1;
+  flex: 1 1 0;
 }

--- a/src/prototypes/speaking-event/example/example.scss
+++ b/src/prototypes/speaking-event/example/example.scss
@@ -18,8 +18,4 @@
   .muted-text {
     color: color.$text-dark-muted;
   }
-
-  .o-button-group .c-button {
-    flex: 1 1 0;
-  }
 }

--- a/src/prototypes/speaking-event/example/example.scss
+++ b/src/prototypes/speaking-event/example/example.scss
@@ -18,4 +18,17 @@
   .muted-text {
     color: color.$text-dark-muted;
   }
+
+  .button-columns {
+    display: grid;
+    grid-gap: ms.step(-2);
+    grid-template-columns: 1fr;
+    @media (min-width: breakpoint.$l) {
+      grid-template-columns: repeat((2, 1fr));
+    }
+  }
+
+  // .o-button-group .c-button {
+  //   flex: 1 1 0;
+  // }
 }

--- a/src/prototypes/speaking-event/example/example.scss
+++ b/src/prototypes/speaking-event/example/example.scss
@@ -24,11 +24,7 @@
     grid-gap: ms.step(-2);
     grid-template-columns: 1fr;
     @media (min-width: breakpoint.$l) {
-      grid-template-columns: repeat((2, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(ms.step(10), 1fr));
     }
   }
-
-  // .o-button-group .c-button {
-  //   flex: 1 1 0;
-  // }
 }

--- a/src/prototypes/speaking-event/example/example.scss
+++ b/src/prototypes/speaking-event/example/example.scss
@@ -19,12 +19,7 @@
     color: color.$text-dark-muted;
   }
 
-  .button-columns {
-    display: grid;
-    grid-gap: ms.step(-2);
-    grid-template-columns: 1fr;
-    @media (min-width: breakpoint.$l) {
-      grid-template-columns: repeat(auto-fit, minmax(ms.step(10), 1fr));
-    }
+  .o-button-group .c-button {
+    flex: 1 1 0;
   }
 }

--- a/src/prototypes/speaking-event/example/multiple-speakers.twig
+++ b/src/prototypes/speaking-event/example/multiple-speakers.twig
@@ -38,7 +38,7 @@
             "class": "o-embed--wide",
             "src": deck
           } only %}
-          <div class="o-button-group">
+          <div class="o-button-group o-button-group--grow">
             {% include '@cloudfour/components/button/button.twig' with {
               "content_start_icon": "brands/github",
               "label": "GitHub"

--- a/src/prototypes/speaking-event/example/multiple-speakers.twig
+++ b/src/prototypes/speaking-event/example/multiple-speakers.twig
@@ -38,7 +38,7 @@
             "class": "o-embed--wide",
             "src": deck
           } only %}
-          <div class="button-columns">
+          <div class="o-button-group">
             {% include '@cloudfour/components/button/button.twig' with {
               "content_start_icon": "brands/github",
               "label": "GitHub"

--- a/src/prototypes/speaking-event/example/multiple-speakers.twig
+++ b/src/prototypes/speaking-event/example/multiple-speakers.twig
@@ -27,10 +27,27 @@
           <p>
             If you have a website—particularly one that generates revenue for your organization—you need a Progressive Web App. So where do you begin? How do you decide which features of a Progressive Web App make sense for your users? What tools can make the process easier (or harder)? In this practical session, Jason will guide you through the key design decisions you’ll need to make about your Progressive Web App and how those decisions impact the scope of your project. He'll also teach you how to avoid common pitfalls and help you take full advantage of Progressive Web App technology.
           </p>
+          <div class="u-pad-block-start-4">
+            {% include '@cloudfour/components/heading/heading.twig' with {
+              level: 1,
+              tag_name: 'h2',
+              content: 'Resources',
+            } only %}
+          </div>
           {% include '@cloudfour/objects/embed/demo/image.twig' with {
             "class": "o-embed--wide",
             "src": deck
           } only %}
+          <div class="button-columns">
+            {% include '@cloudfour/components/button/button.twig' with {
+              "content_start_icon": "brands/github",
+              "label": "GitHub"
+            } only %}
+            {% include '@cloudfour/components/button/button.twig' with {
+              "content_start_icon": "link",
+              "label": "Progressive Web Apps"
+            } only %}
+          </div>
           <div class="u-pad-block-start-4">
             {% embed '@cloudfour/components/heading/heading.twig' with {
               level: 1,

--- a/src/prototypes/speaking-event/example/single-speaker.twig
+++ b/src/prototypes/speaking-event/example/single-speaker.twig
@@ -33,7 +33,7 @@
             "class": "o-embed--wide",
             "src": deck
           } only %}
-          <div class="o-button-group">
+          <div class="o-button-group o-button-group--grow">
             {% include '@cloudfour/components/button/button.twig' with {
               "content_start_icon": "brands/github",
               "label": "GitHub"

--- a/src/prototypes/speaking-event/example/single-speaker.twig
+++ b/src/prototypes/speaking-event/example/single-speaker.twig
@@ -33,7 +33,7 @@
             "class": "o-embed--wide",
             "src": deck
           } only %}
-          <div class="button-columns">
+          <div class="o-button-group">
             {% include '@cloudfour/components/button/button.twig' with {
               "content_start_icon": "brands/github",
               "label": "GitHub"

--- a/src/prototypes/speaking-event/example/single-speaker.twig
+++ b/src/prototypes/speaking-event/example/single-speaker.twig
@@ -22,10 +22,23 @@
           <p>
             If you have a website—particularly one that generates revenue for your organization—you need a Progressive Web App. So where do you begin? How do you decide which features of a Progressive Web App make sense for your users? What tools can make the process easier (or harder)? In this practical session, Jason will guide you through the key design decisions you’ll need to make about your Progressive Web App and how those decisions impact the scope of your project. He'll also teach you how to avoid common pitfalls and help you take full advantage of Progressive Web App technology.
           </p>
+          <div class="u-pad-block-start-4">
+            {% include '@cloudfour/components/heading/heading.twig' with {
+              level: 1,
+              tag_name: 'h2',
+              content: 'Resources',
+            } only %}
+          </div>
           {% include '@cloudfour/objects/embed/demo/image.twig' with {
             "class": "o-embed--wide",
             "src": deck
           } only %}
+          <div class="button-columns">
+            {% include '@cloudfour/components/button/button.twig' with {
+              "content_start_icon": "brands/github",
+              "label": "GitHub"
+            } only %}
+          </div>
           <div class="u-pad-block-start-4">
             {% embed '@cloudfour/components/heading/heading.twig' with {
               level: 1,


### PR DESCRIPTION
## Overview

Some of the talks have links to additional resources/supporting materials. This PR updates the prototypes to include an example with one link and one with multiple.

## Screenshots

![Screen Shot 2022-03-31 at 2 20 50 PM](https://user-images.githubusercontent.com/42841342/161153488-4dbff213-a898-4a44-ae18-26321954c6a8.png)
![Screen Shot 2022-03-31 at 2 20 55 PM](https://user-images.githubusercontent.com/42841342/161153496-60bb71a6-c2ff-4a92-8d4a-57afa4b2f02e.png)
![Screen Shot 2022-03-31 at 2 21 06 PM](https://user-images.githubusercontent.com/42841342/161153500-0c12d97f-550f-42fe-8d2c-05826656bb9b.png)

## Testing

https://deploy-preview-1696--cloudfour-patterns.netlify.app/?path=/story/prototypes-speaking-event--single-speaker


---

- Fixes #1694

