### PR TITLE
Add width/height properties to Avatar component

### DIFF
--- a/.changeset/gentle-grapes-camp.md
+++ b/.changeset/gentle-grapes-camp.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add width and height properties to Avatar component

--- a/src/components/avatar/avatar.stories.mdx
+++ b/src/components/avatar/avatar.stories.mdx
@@ -31,6 +31,8 @@ const avatarStory = (args) => {
     srcset: { type: { name: 'string' } },
     sizes: { type: { name: 'string' } },
     alt: { type: { name: 'string' } },
+    width: { type: { name: 'number' } },
+    height: { type: { name: 'number' } },
   }}
 />
 
@@ -99,11 +101,13 @@ The `c-avatar--full` modifier sizes the component to `100%` of its container wid
 - `alt`: Value for the inner `img` element's `alt` attribute.
 - `class`: Append a class to the `c-avatar` element.
 - `content` (block): Directly specify content for the element. Useful for adding a `picture` or `svg` element directly.
+- `height`: Value for the inner `img` element's `height` attribute. Will default to `width` if specified.
 - `loading`: Value for the inner `img` element's `loading` attribute. Defaults to `lazy`.
 - `size`: Shorthand for appending a size modifier class, for example `full`.
 - `sizes`: Value for the inner `img` element's `sizes` attribute.
 - `src`: Value for the inner `img` element's `src` attribute. If omitted, no `img` will be output.
 - `srcset`: Value for the inner `img` element's `srcset` attribute.
+- `width`: Value for the inner `img` element's `width` attribute. Will default to `height` if specified.
 
 ## See also…
 

--- a/src/components/avatar/avatar.twig
+++ b/src/components/avatar/avatar.twig
@@ -12,6 +12,10 @@
           (if provided).
         #}
         {% if sizes %}sizes="{{ sizes }}"{% endif %}
+        {% if width or height %}
+          width="{{width|default(height)}}"
+          height="{{height|default(width)}}"
+        {% endif %}
         alt="{{ alt|default('')|trim }}"
         loading="{{ loading|default('lazy') }}">
     {%- endif -%}


### PR DESCRIPTION
## Overview

Adds `width` and `height` properties to the Avatar component's Twig template. This has no impact on the visual appearance of the element (since it is using an aspect ratio hack for layout) and no performance impact (since modern browsers will use `sizes` to determine the best `srcset` image), but it does provide a means of constraining the size in case the CSS fails to load or the page is viewed using an alternative user agent or older browser.

Because Avatars are circular, you can provide either `width` or `height` and it will be used as the default for the other.

## Testing

These tests involve [viewing an Avatar story's "canvas" tab](https://deploy-preview-1713--cloudfour-patterns.netlify.app/?path=/story/components-avatar--with-image), changing its properties and observing the "HTML" tab to confirm that the markup has changed as expected.

- [x] With no `width` or `height` specified, the `<img>` element should not have a `width` or `height` attribute.
- [x] When either the `width` _or_ the `height` is specified, both properties should be present on the `<img>` element using whichever value was provided.
- [x] When both the `width` _and_ `height` properties are specified and are different, both properties should be present on the the `<img>` element with their distinct values intact.
- [x] None of these properties should result in a visual change to the component.

---

- Fixes #1693
