### PR TITLE
Don't assume storyContext.args exists

### DIFF
--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -1,7 +1,7 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs';
 import { uniqueId } from 'lodash';
 import singleDemo from './demo/single.twig';
-const singleDemoProps = (args) => {
+const singleDemoProps = (args = {}) => {
   const props = {
     heading_id: args.heading_id || uniqueId('card-heading-'),
     href: args.href,
@@ -30,7 +30,7 @@ const singleDemoProps = (args) => {
 };
 const singleDemoStory = (args) => {
   const props = singleDemoProps(args);
-  if (args.show.length > 0) {
+  if (args.show && args.show.length > 0) {
     for (const block of args.show) {
       props[`show_${block}`] = true;
     }
@@ -45,13 +45,13 @@ const singleDemoBlockExamples = {
 };
 // Custom function for generating story source from args given
 const singleDemoTransformSource = (_src, storyContext) => {
-  const { args } = storyContext;
+  const args = storyContext.args || {};
   const props = singleDemoProps(args);
   const propsString =
     Object.keys(props).length > 0
       ? ` with ${JSON.stringify(props, null, 2)}`
       : '';
-  const blocks = args.show.map(
+  const blocks = (args.show || []).map(
     (blockName) =>
       `{% block ${blockName} %}${singleDemoBlockExamples[blockName]}{% endblock %}`
   );

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -56,7 +56,7 @@ import demo from './demo/demo.twig';
       transformSource: (_src, storyContext) =>
         makeTwigEmbedIfHtml(
           '@cloudfour/components/heading/heading.twig',
-          storyContext.args,
+          storyContext.args || {},
           ['content', 'subheading']
         ),
     },

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -5,7 +5,7 @@ import alignmentDemo from './demo/alignment.twig';
 const articlesStory = (args) => articlesDemo({ items: articles, ...args });
 // Custom function for generating story source from args given
 const articlesTemplateSource = (_src, storyContext) => {
-  const { args } = storyContext;
+  const args = storyContext.args || {};
   let twigArgs = '';
   if (
     args.columns &&

--- a/src/objects/embed/embed.stories.mdx
+++ b/src/objects/embed/embed.stories.mdx
@@ -26,7 +26,7 @@ const defaultArgs = {
 };
 // Custom embed source function to preserve args in source code examples
 const embedTransformSource = (_src, storyContext) => {
-  const { args } = storyContext;
+  const args = storyContext.args || {};
   const argsString =
     Object.keys(args).length > 0
       ? ` with ${JSON.stringify(args, null, 2)}`


### PR DESCRIPTION
## Overview

This PR updates certain story files to no longer assume that the `storyContext` argument will contain an `args` object. This makes those pages visible again.

## Testing

Confirm in the deploy preview the visibility of affected pages:

### Objects
- [x] [Deck](https://deploy-preview-1714--cloudfour-patterns.netlify.app/?path=/docs/objects-deck--basic)
- [x] [Embed](https://deploy-preview-1714--cloudfour-patterns.netlify.app/?path=/docs/objects-embed--image)

### Components
- [x] [Card](https://deploy-preview-1714--cloudfour-patterns.netlify.app/?path=/docs/components-card--content-blocks) (Note: This page has performance issues, possibly related to #1695 and source transformations. In Firefox eventually a message will appear offering to stop the code execution, at which point the page becomes visible, but the source code previews will not function.)
- [x] [Heading](https://deploy-preview-1714--cloudfour-patterns.netlify.app/?path=/docs/components-heading--example)

---

- Fixes #1692 
