### PR TITLE
Make the author link prop optional

### DIFF
--- a/.changeset/thirty-beans-act.md
+++ b/.changeset/thirty-beans-act.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Allow the author link prop to be optional

--- a/src/components/author/author.stories.mdx
+++ b/src/components/author/author.stories.mdx
@@ -145,7 +145,7 @@ Multiple authors are also supported.
  {
    name: string | () => string;
    avatar: string | () => string;
-   link: string | () => string;
+   link?: string | () => string;
  }
 ```
 

--- a/src/components/author/author.stories.mdx
+++ b/src/components/author/author.stories.mdx
@@ -66,21 +66,21 @@ Displays an author, or set of authors, with optional meta content.
   <Story name="Basic usage" args={{ count: 1 }}>
     {(args) =>
       template({
-        authors: authors(args.count),
+        authors: authorsWithNoLink(args.count),
       })
     }
   </Story>
 </Canvas>
 
-## With no `link`
+## With `link`
 
-If an author object does not contain a `link` property, then the author name does not use an anchor element.
+If an author object contains the optional `link` property, then the author name will be linked.
 
 <Canvas>
-  <Story name="With no link" args={{ count: 1 }}>
+  <Story name="With link" args={{ count: 1 }}>
     {(args) =>
       template({
-        authors: authorsWithNoLink(args.count),
+        authors: authors(args.count),
       })
     }
   </Story>

--- a/src/components/author/author.stories.mdx
+++ b/src/components/author/author.stories.mdx
@@ -33,6 +33,13 @@ const allAuthors = [
   },
 ];
 const authors = (count) => allAuthors.slice(0, count);
+const authorsWithNoLink = (count) =>
+  allAuthors
+    .map(({ name, avatar }) => ({
+      name,
+      avatar,
+    }))
+    .slice(0, count);
 
 <Meta
   title="Components/Author"
@@ -60,6 +67,20 @@ Displays an author, or set of authors, with optional meta content.
     {(args) =>
       template({
         authors: authors(args.count),
+      })
+    }
+  </Story>
+</Canvas>
+
+## With no `link`
+
+If an author object does not contain a `link` property, then the author name does not use an anchor element.
+
+<Canvas>
+  <Story name="With no link" args={{ count: 1 }}>
+    {(args) =>
+      template({
+        authors: authorsWithNoLink(args.count),
       })
     }
   </Story>

--- a/src/components/author/author.test.ts
+++ b/src/components/author/author.test.ts
@@ -84,7 +84,7 @@ test(
 
     const body = await page.evaluateHandle<ElementHandle>(() => document.body);
 
-    // Confirm the meta value is rendered and the date is not rendered
+    // Confirm the author name is "text" and not link
     expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
       text "By"
       text "Shakira Isabel Mebarak Ripoll"

--- a/src/components/author/author.test.ts
+++ b/src/components/author/author.test.ts
@@ -84,7 +84,7 @@ test(
 
     const body = await page.evaluateHandle<ElementHandle>(() => document.body);
 
-    // Confirm the author name is "text" and not link
+    // Confirm the author name is "text" and not a link
     expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
       text "By"
       text "Shakira Isabel Mebarak Ripoll"

--- a/src/components/author/author.test.ts
+++ b/src/components/author/author.test.ts
@@ -65,3 +65,29 @@ test(
     `);
   })
 );
+
+test(
+  'Optional author link prop',
+  withBrowser(async ({ utils, page }) => {
+    await utils.injectHTML(
+      await template({
+        // The avatar is not included because I couldn't figure out how
+        // to include it. For the purposes of this test, though, it is
+        // not important so I left it out.
+        authors: [
+          {
+            name: 'Shakira Isabel Mebarak Ripoll',
+          },
+        ],
+      })
+    );
+
+    const body = await page.evaluateHandle<ElementHandle>(() => document.body);
+
+    // Confirm the meta value is rendered and the date is not rendered
+    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
+      text "By"
+      text "Shakira Isabel Mebarak Ripoll"
+    `);
+  })
+);

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -57,7 +57,11 @@
       <span class="u-hidden-visually">{{ author_prefix|default("By") }}</span>
       {% for author in authors %}
         {% if loop.last and loop.length > 1 %}and {% endif %}
-        <a href="{{ author.link }}">{{ author.name }}</a>
+          {% if author.link %}
+            <a href="{{ author.link }}">{{ author.name }}</a>
+          {% else %}
+            <span>{{ author.name }}</span>
+          {% endif %}
         {%- if not loop.last and loop.length > 2 %},{% endif %}
       {% endfor %}
     </p>


### PR DESCRIPTION
## Overview

The [Talks + Events listing page](https://v-next--cloudfour-patterns.netlify.app/?path=/story/prototypes-speaking-listing--example) calls for the Author component to allow author names to be not linked. This PR sets up the author `link` prop to be optional.

## Screenshots

<img width="677" alt="Screen Shot 2022-04-07 at 10 49 57 AM" src="https://user-images.githubusercontent.com/459757/162265676-5fa207e5-6249-4113-a65f-cef9c637541d.png">

## Testing

1. Review the [Author component page](https://deploy-preview-1718--cloudfour-patterns.netlify.app/?path=/docs/components-author--with-no-link) and confirm a `<span>` is rendered instead of an `<a>` for the default "no link" demo for the author name.

---

- Closes #1715 