### PR TITLE
Author avatar prop can be an object

### DIFF
--- a/.changeset/beige-books-battle.md
+++ b/.changeset/beige-books-battle.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Avatar values passed to the Author component may now be an object, which will be passed directly to the Avatar component. This allows additional properties like `srcset`, `sizes`, etc. to be set.

--- a/src/components/author/author.stories.mdx
+++ b/src/components/author/author.stories.mdx
@@ -13,7 +13,7 @@ const allAuthors = [
   },
   {
     name: 'Danielle Romo',
-    avatar: danielleImage,
+    avatar: { src: danielleImage, width: 64 },
     link: 'https://cloudfour.com/is/danielle',
   },
   {
@@ -139,15 +139,11 @@ Multiple authors are also supported.
 
 `class` (string): CSS class(es) to append to the root element
 
-`authors` (array): Array of [author objects](https://timber.github.io/docs/reference/timber-user/#properties) of the type:
+`authors` (array): Array of [author objects](https://timber.github.io/docs/reference/timber-user/#properties), each containing:
 
-```ts
- {
-   name: string | () => string;
-   avatar: string | () => string;
-   link?: string | () => string;
- }
-```
+- `name` (string): The author's name.
+- `avatar` (string or object): If this is an object containing a `src`, this will be passed directly to [the Avatar component](/?path=/docs/components-avatar--empty) (along with any other properties, for example `srcset` or `sizes`). Otherwise, it is assumed to be a string and used as the Avatar's `src` property.
+- `link` (optional, string): An `href` for the author's name to link to, for example a bio page.
 
 `author_prefix` (optional, string, default "By"): Used to create a more
 accessible user experience by adding visually hidden text, prefixes the author name (e.g. "By Arianna Chau")

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -45,7 +45,11 @@
   {% embed '@cloudfour/objects/bunch/bunch.twig' with { class: 'o-media__object' } %}
     {% block content %}
       {% for author in authors %}
-        {% include '@cloudfour/components/avatar/avatar.twig' with { src: author.avatar } only %}
+        {% if author.avatar.src is defined %}
+          {% include '@cloudfour/components/avatar/avatar.twig' with author.avatar only %}
+        {% else %}
+          {% include '@cloudfour/components/avatar/avatar.twig' with { src: author.avatar } only %}
+        {% endif %}
       {% endfor %}
     {% endblock %}
   {% endembed %}


### PR DESCRIPTION
## Overview

This PR modifies the Author component to allow the `avatar` property of an `authors` array item to be an object. If an object containing at least a `src`, it will be passed directly to the Avatar component. Otherwise, it will be passed as the Avatar `src` as it was before.

This will allow developers the option of preparing a more detailed `avatar` object including whatever properties Avatar supports, for example `srcset` and `sizes`.

**Note:** I also considered creating a `block` for avatars, but since the author information is provided as an array, it seemed weird to have the avatars customizable only as a block and not as data. But I'm open to feedback on that!

## Testing

1. [View the multiple authors story in Canvas view](https://deploy-preview-1719--cloudfour-patterns.netlify.app/?path=/story/components-author--multiple-authors)
2. Check the HTML tab
3. Confirm that the second image includes a `width` and `height` in addition to a `src` (other images should be the same as before)

---

- Fixes #1709 