### PR TITLE
Add heading_id property to Event Log

### DIFF
--- a/.changeset/shy-fireants-mix.md
+++ b/.changeset/shy-fireants-mix.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add `heading_id` property to Event Log component

--- a/src/components/event-log/demo/events.json
+++ b/src/components/event-log/demo/events.json
@@ -1,5 +1,6 @@
 [
   {
+    "heading_id": "event-aea-2017-12-11",
     "date": "2017-12-11",
     "title": "An Event Apart",
     "link": "https://aneventapart.com/event/denver-2017",
@@ -16,30 +17,35 @@
     ]
   },
   {
+    "heading_id": "event-pdx-2017-07-13",
     "date": "2017-07-13",
     "title": "Portland Digital Summit",
     "link": "https://portland.digitalsummit.com/agenda/",
     "location": "Portland, OR"
   },
   {
+    "heading_id": "event-aea-2017-07-10",
     "date": "2017-07-10",
     "title": "An Event Apart",
     "link": "https://aneventapart.com/event/washington-dc-2017",
     "location": "Washington, DC"
   },
   {
+    "heading_id": "event-padnug-2017-06-06",
     "date": "2017-06-06",
     "title": "PADNUG",
     "link": "https://www.meetup.com/PADNUG/events/237142614/",
     "location": "Hillsboro, OR"
   },
   {
+    "heading_id": "event-aea-2017-05-15",
     "date": "2017-05-15",
     "title": "An Event Apart",
     "link": "https://aneventapart.com/event/boston-2017",
     "location": "Boston, MA"
   },
   {
+    "heading_id": "event-smashing-2017-04-04",
     "date": "2017-04-04",
     "title": "Smashing Conference",
     "link": "https://smashingconf.com/",
@@ -52,6 +58,7 @@
     ]
   },
   {
+    "heading_id": "event-velocity-2016-11-07",
     "date": "2016-11-07",
     "title": "Velocity",
     "link": "http://conferences.oreilly.com/velocity/devops-web-performance-eu",

--- a/src/components/event-log/event-log.stories.mdx
+++ b/src/components/event-log/event-log.stories.mdx
@@ -46,6 +46,7 @@ For a less specialized display of tabular data, consider using [Table](/docs/com
 
 - `date`: A string that is parseable by [Twig's `date` filter](https://twig.symfony.com/doc/3.x/functions/date.html). Used for the date display and for a semantic `time` element.
 - `extras` (Block): Additional supporting content, for example an [inline list](/docs/objects-list--inline) of related links.
+- `heading_id`: The `id` to use for the heading element, which will be associated with the `article` via the `aria-labelledby` attribute. This improves the experience of navigating event log items via the [macOS VoiceOver rotor](https://support.apple.com/guide/voiceover-guide/navigate-using-the-rotor-mchlp2719/web) (and potentially other assistive interfaces as well).
 - `heading_level`: Specifies the level of `h*` element to use. Should be one lower than whatever the preceding section heading is to preserve the document outline. Defaults to `3`.
 - `link`: An external URL for the event.
 - `location`: The location of the event, for example "Portland, OR" or "Online."

--- a/src/components/event-log/item.twig
+++ b/src/components/event-log/item.twig
@@ -2,8 +2,10 @@
 {% set _heading_level = heading_level|default(3) %}
 {% set _extra_block %}{% block extra %}{% endblock %}{% endset %}
 
-<article class="c-event-log__item">
-  <h{{ _heading_level }} class="c-event-log__date">
+<article class="c-event-log__item"
+  {% if heading_id %}aria-labelledby="{{heading_id}}"{% endif %}>
+  <h{{ _heading_level }} class="c-event-log__date"
+    {% if heading_id %}id="{{heading_id}}"{% endif %}>
     <time datetime="{{ _datetime|date('Y-m-d') }}">
       {{ _datetime|date('M j, Y') }}
     </time>


### PR DESCRIPTION
## Overview

This adds support for a `heading_id` property for individual Event Log items. When provided, it will be used as the `id` of the heading and within the `aria-labelledby` property on the containing article, which can [improve the screen reader experience](https://support.apple.com/guide/voiceover-guide/navigate-using-the-rotor-mchlp2719/web). This also makes it consistent with our Card component.

## Testing

1. [View the Event Log story](https://deploy-preview-1720--cloudfour-patterns.netlify.app/?path=/story/components-event-log--example)
2. Confirm that the markup contains example `id` and `aria-labelledby` attributes
3. Confirm that the experience is improved using Safari VoiceOver.

---

- Fixes #1707 
