### PR TITLE
Move static directories to configuration

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,6 +9,7 @@ const {
 module.exports = {
   // We load the welcome story separately so it will be the first sidebar item.
   stories: ['../src/welcome.stories.mdx', '../src/**/*.stories.@(js|mdx)'],
+  staticDirs: ['../static', '../src/assets'],
   addons: [
     {
       name: '@storybook/addon-essentials',

--- a/package.json
+++ b/package.json
@@ -119,8 +119,8 @@
   "scripts": {
     "start": "npm run storybook",
     "storybook": "npm run preprocess && run-p watch start-storybook",
-    "start-storybook": "start-storybook -p 6006 -s ./static,./src/assets",
-    "build-storybook": "npm run preprocess && build-storybook -s ./static,./src/assets",
+    "start-storybook": "start-storybook -p 6006",
+    "build-storybook": "npm run preprocess && build-storybook",
     "preprocess": "run-p preprocess:*",
     "preprocess:svg-to-twig": "gulp svgToTwig",
     "preprocess:tokens": "node .style-dictionary/build.js",


### PR DESCRIPTION
## Overview

[Storybook 6.4 replaced the `-s` CLI flag with a `staticDirs` configuration property](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated---static-dir-cli-flag). This applies that change to resolve a deprecation warning.

## Testing

1. Confirm that there were no build errors on this PR
1. On the deploy preview, confirm that [the Logo Group story](https://deploy-preview-1722--cloudfour-patterns.netlify.app/?path=/story/objects-logo-group--default-story) still displays correctly (the client logos are all static)
