### PR TITLE
Add Short Date Format and Unlinking to Author

### DIFF
--- a/.changeset/eighty-berries-knock.md
+++ b/.changeset/eighty-berries-knock.md
@@ -1,5 +1,5 @@
 ---
-"@cloudfour/patterns": minor
+'@cloudfour/patterns': minor
 ---
 
 Add Short Date Format and Unlinking to Author

--- a/.changeset/eighty-berries-knock.md
+++ b/.changeset/eighty-berries-knock.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": minor
+---
+
+Add Short Date Format and Unlinking to Author

--- a/src/components/author/author.stories.mdx
+++ b/src/components/author/author.stories.mdx
@@ -119,7 +119,7 @@ date object value. The Author template has extra logic to create a more
 accessible user experience.
 
 If used in a space-constrained area, you may set the `date_format` property
-to "short" to display an abbreviated version.
+to "short" to display an abbreviated version. (e.g. `Mar 31, 2021` instead of `March 31st, 2021`)
 
 **Note:** The `meta` property will override the `date` if both are set.
 

--- a/src/components/author/author.stories.mdx
+++ b/src/components/author/author.stories.mdx
@@ -76,7 +76,7 @@ Displays an author, or set of authors, with optional meta content.
 
 If an author object contains the optional `link` property, then the author name will be linked.
 
-If you don't want a link, you can use the `unlink` property to remove it. (This is useful for when it's not convenient to modify the author data.)
+If you don't want a link, you can use the `unlink` property to remove it.
 
 <Canvas>
   <Story name="With link" args={{ count: 1 }}>

--- a/src/components/author/author.stories.mdx
+++ b/src/components/author/author.stories.mdx
@@ -76,11 +76,22 @@ Displays an author, or set of authors, with optional meta content.
 
 If an author object contains the optional `link` property, then the author name will be linked.
 
+If you don't want a link, you can use the `unlink` property to remove it. (This is useful for when it's not convenient to modify the author data.)
+
 <Canvas>
   <Story name="With link" args={{ count: 1 }}>
     {(args) =>
       template({
         authors: authors(args.count),
+        unlink: false,
+      })
+    }
+  </Story>
+  <Story name="Remove link" args={{ count: 1 }}>
+    {(args) =>
+      template({
+        authors: authors(args.count),
+        unlink: true,
       })
     }
   </Story>
@@ -107,6 +118,9 @@ If a date is desired for the meta content, use the `date` property with a
 date object value. The Author template has extra logic to create a more
 accessible user experience.
 
+If used in a space-constrained area, you may set the `date_format` property
+to "short" to display an abbreviated version.
+
 **Note:** The `meta` property will override the `date` if both are set.
 
 <Canvas>
@@ -114,7 +128,16 @@ accessible user experience.
     {(args) =>
       template({
         authors: authors(args.count),
-        date: new Date('March 31, 2021'),
+        date: new Date('September 29, 2021'),
+      })
+    }
+  </Story>
+  <Story name="Short date format" args={{ count: 1 }}>
+    {(args) =>
+      template({
+        authors: authors(args.count),
+        date: new Date('September 29, 2021'),
+        date_format: 'short',
       })
     }
   </Story>
@@ -152,8 +175,12 @@ accessible user experience by adding visually hidden text, prefixes the author n
 
 `date` (optional, date object): Represents a publication date
 
+`date_format` (optional, string): Set to `short` to use abbreviated date formatting.
+
 `date_prefix` (optional, string, default "Published on"): Used to create a more
 accessible user experience by adding visually hidden text, prefixes the date value (e.g. "Published on March 31st, 2021")
+
+`unlink` (optional, boolean): Used to remove the link from an author that contains a `link` property.
 
 ## Template Blocks
 

--- a/src/components/author/author.stories.mdx
+++ b/src/components/author/author.stories.mdx
@@ -175,7 +175,7 @@ accessible user experience by adding visually hidden text, prefixes the author n
 
 `date` (optional, date object): Represents a publication date
 
-`date_format` (optional, string): Set to `short` to use abbreviated date formatting.
+`date_format` (optional, string): Set to `short` to use abbreviated date formatting. (e.g. `Mar 31, 2021` instead of `March 31st, 2021`)
 
 `date_prefix` (optional, string, default "Published on"): Used to create a more
 accessible user experience by adding visually hidden text, prefixes the date value (e.g. "Published on March 31st, 2021")

--- a/src/components/author/author.test.ts
+++ b/src/components/author/author.test.ts
@@ -53,6 +53,8 @@ test(
       })
     );
 
+    // The short date formatting applies to the visible date text
+    // (not our visually hidden screen reader text)
     const visibleDateText = await screen.getByText('Mar 31, 2021');
     await expect(visibleDateText).toHaveAttribute('aria-hidden', 'true');
   })

--- a/src/components/author/author.test.ts
+++ b/src/components/author/author.test.ts
@@ -36,6 +36,33 @@ test(
 );
 
 test(
+  'Short date formatting',
+  withBrowser(async ({ utils, page }) => {
+    await utils.injectHTML(
+      await template({
+        // The avatar is not included because I couldn't figure out how
+        // to include it. For the purposes of this test, though, it is
+        // not important so I left it out.
+        authors: [
+          {
+            name: 'Shakira Isabel Mebarak Ripoll',
+          },
+        ],
+        date: new Date('March 31, 2021'),
+        date_format: 'short',
+      })
+    );
+
+    const body = await page.evaluateHandle<ElementHandle>(() => document.body);
+    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
+      text "By"
+      text "Shakira Isabel Mebarak Ripoll"
+      text "Published on Mar 31, 2021"
+    `);
+  })
+);
+
+test(
   'meta is prioritized over date',
   withBrowser(async ({ utils, page }) => {
     await utils.injectHTML(
@@ -79,6 +106,34 @@ test(
             name: 'Shakira Isabel Mebarak Ripoll',
           },
         ],
+      })
+    );
+
+    const body = await page.evaluateHandle<ElementHandle>(() => document.body);
+
+    // Confirm the author name is "text" and not a link
+    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
+      text "By"
+      text "Shakira Isabel Mebarak Ripoll"
+    `);
+  })
+);
+
+test(
+  'Can remove author link prop',
+  withBrowser(async ({ utils, page }) => {
+    await utils.injectHTML(
+      await template({
+        // The avatar is not included because I couldn't figure out how
+        // to include it. For the purposes of this test, though, it is
+        // not important so I left it out.
+        authors: [
+          {
+            name: 'Shakira Isabel Mebarak Ripoll',
+            link: 'https://www.shakira.com/',
+          },
+        ],
+        unlink: true,
       })
     );
 

--- a/src/components/author/author.test.ts
+++ b/src/components/author/author.test.ts
@@ -37,7 +37,7 @@ test(
 
 test(
   'Short date formatting',
-  withBrowser(async ({ utils, page }) => {
+  withBrowser(async ({ utils, screen }) => {
     await utils.injectHTML(
       await template({
         // The avatar is not included because I couldn't figure out how
@@ -53,12 +53,8 @@ test(
       })
     );
 
-    const body = await page.evaluateHandle<ElementHandle>(() => document.body);
-    expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      text "By"
-      text "Shakira Isabel Mebarak Ripoll"
-      text "Published on Mar 31, 2021"
-    `);
+    const visibleDateText = await screen.getByText('Mar 31, 2021');
+    await expect(visibleDateText).toHaveAttribute('aria-hidden', 'true');
   })
 );
 

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -16,7 +16,7 @@
       <p>
         {# This creates a more accessible, and less confusing, user experience #}
         <span class="u-hidden-visually">
-          {{ date_prefix|default('Published on') }} {{ _formatted_date }}
+          {{ date_prefix|default('Published on') }} {{ date|date('F jS, Y') }}
         </span>
         {#
           The <time> element is not well supported by screen readers, therefore,

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -10,10 +10,13 @@
     {% if meta %}
       <p>{{ meta }}</p>
     {% elseif date %}
+      {% set _formatted_date =
+        date_format == 'short' ? date|date('M j, Y') : date|date('F jS, Y')
+      %}
       <p>
         {# This creates a more accessible, and less confusing, user experience #}
         <span class="u-hidden-visually">
-          {{ date_prefix|default('Published on') }} {{ date|date('F jS, Y') }}
+          {{ date_prefix|default('Published on') }} {{ _formatted_date }}
         </span>
         {#
           The <time> element is not well supported by screen readers, therefore,
@@ -33,7 +36,7 @@
           @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
         #}
         <time aria-hidden="true" datetime="{{ date|date('Y-m-d') }}">
-          {{ date|date('F jS, Y') }}
+          {{ _formatted_date }}
         </time>
       </p>
     {% endif %}
@@ -67,7 +70,7 @@
       {% block authors %}
         {% for author in authors %}
           {% if loop.last and loop.length > 1 %}and {% endif %}
-            {% if author.link %}
+            {% if author.link and not unlink %}
               <a href="{{ author.link }}">{{ author.name }}</a>
             {% else %}
               <span>{{ author.name }}</span>

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -10,9 +10,6 @@
     {% if meta %}
       <p>{{ meta }}</p>
     {% elseif date %}
-      {% set _formatted_date =
-        date_format == 'short' ? date|date('M j, Y') : date|date('F jS, Y')
-      %}
       <p>
         {# This creates a more accessible, and less confusing, user experience #}
         <span class="u-hidden-visually">
@@ -36,7 +33,7 @@
           @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
         #}
         <time aria-hidden="true" datetime="{{ date|date('Y-m-d') }}">
-          {{ _formatted_date }}
+          {{ date_format == 'short' ? date|date('M j, Y') : date|date('F jS, Y') }}
         </time>
       </p>
     {% endif %}


### PR DESCRIPTION
## Overview

This PR adds two new features to the Author component. First, it adds
the `unlink` property, which will prevent a link from being rendered
even if one is provided as part of the Author object. This is useful
for situations where removing the link property from the Author is
a hassle. Second, it adds a `date_format` property, which can be set
to `short` to use abbreviate date formatting.

## Screenshots

<img width="600" alt="Screen Shot 2022-04-14 at 10 38 25 AM" src="https://user-images.githubusercontent.com/257309/163443624-55c20c14-a372-4c4f-8e10-05edf1d40748.png">

## Testing

1. On the preview deploy, ensure that the `short` date format displays correctly
1. ensure the `unlink` property removes the author link when provided.
2. ensure tests pass on this PR