### PR TITLE
Use `overflow-wrap:anywhere` for Word Breaking

### DIFF
--- a/.changeset/purple-drinks-tell.md
+++ b/.changeset/purple-drinks-tell.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": patch
+---
+
+Use `overflow-wrap:anywhere` for Word Breaking

--- a/.changeset/purple-drinks-tell.md
+++ b/.changeset/purple-drinks-tell.md
@@ -1,5 +1,5 @@
 ---
-"@cloudfour/patterns": patch
+'@cloudfour/patterns': patch
 ---
 
 Use `overflow-wrap:anywhere` for Word Breaking

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -27,15 +27,20 @@ html {
 }
 
 /**
- * 1. Prevent size adjustments on orientation change.
- * 2. Allow long words (like URLs) to break at arbitrary points.
+ * 1. Allow long words (like URLs) to break at arbitrary points.
+ *    Note we are using `anywhere` rather than `break-word`. They behave
+ *    identically, but break points introduced by `break-word` are not
+ *    considered when calculating `min-content` intrinsic sizes, which means
+ *    layout remains broken in any CSS Grid layout.
+ *    @see https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#values
+ * 2. Prevent size adjustments on orientation change.
  */
 
 body {
   font-family: font-family.$sans-fallback;
   line-height: line-height.$loose;
-  text-size-adjust: none; /* 1 */
-  word-wrap: break-word; /* 2 */
+  overflow-wrap: anywhere; /* 1 */
+  text-size-adjust: none; /* 2 */
 
   @supports (font-variation-settings: normal) {
     font-family: font-family.$sans;

--- a/src/prototypes/article-listing/data/recent.json
+++ b/src/prototypes/article-listing/data/recent.json
@@ -21,14 +21,14 @@
       "description": "We recently set up a GitHub Action to automatically upload our site updates to WP Engine whenever we push to a specific branch. we suspect other teams might find it useful, too."
     },
     {
-      "title": "Perfectly Broken Code",
+      "title": "Perfectly Broken Code in Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch",
       "pubDate": "2020-10-30 08:00:21",
       "link": "https://cloudfour.com/thinks/perfectly-broken-code/",
       "guid": "https://cloudfour.com/?p=5898",
       "author": "Gerardo Rodriguez",
       "avatar": "https://cloudfour.com/wp-content/uploads/2016/07/gerardo-r2.png",
       "thumbnail": "https://cloudfour.com/wp-content/uploads/2020/10/perfectly-broken-code-preview-2.png",
-      "description": "Join me in exploring a recent experience where I started with flawed logic (without realizing it) and the steps I took to fix my bug. Let’s experience some broken code together. 🎉"
+      "description": "Join me in Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch, exploring a recent experience where I started with flawed logic (without realizing it) and the steps I took to fix my bug. Let’s experience some broken code together. 🎉"
     },
     {
       "title": "Designers, Design Systems and Finding Our Focus",

--- a/src/prototypes/case-study-listings/example/example.twig
+++ b/src/prototypes/case-study-listings/example/example.twig
@@ -90,7 +90,7 @@
 
           <div class="c-card__content">
             <p>
-              Ceasefire Oregon is a small, non-profit organization working for sensible gun law reform. Their site had a wealth of information, but was difficult to navigate and read. We helped...
+              Ceasefire Oregon is a small, non-profit organization in Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch working for sensible gun law reform. Their site had a wealth of information, but was difficult to navigate and read. We helped...
             </p>
           </div>
         </article>

--- a/src/prototypes/comment-thread/example/example.twig
+++ b/src/prototypes/comment-thread/example/example.twig
@@ -9,7 +9,7 @@
             <h2 class="username">Kurtis Conner</h2>
           </div>
           <div class="comment-content">
-            <p>I’m an example of a longer comment. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<p>
+            <p>I’m an example of a longer comment. Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.<p>
             <div class="timestamp">
               <span>2hrs ago</span>
               <a href="#" class="reply">

--- a/src/prototypes/single-article/example/example.twig
+++ b/src/prototypes/single-article/example/example.twig
@@ -88,7 +88,7 @@
 
             <p>The color of its body changes with the water temperature. The coloration of Gorebyss in Alola is almost blindingly vivid. Numel stores magma of almost 2,200 degrees Fahrenheit within its body. If it gets wet, the magma cools and hardens. In that event, the Pokémon’s body grows heavy and its movements become sluggish. Recordings of Jigglypuff’s strange lullabies can be purchased from department stores. These CDs can be found near the bedding area.</p>
 
-            <p>Rapidash usually can be seen casually cantering in the fields and plains. However, when this Pokémon turns serious, its fiery manes flare and blaze as it gallops its way up to 150 mph. Individuals that have been set free by Trainers who could no longer raise them have become common, and they can now be found in Alola. When the bacteria living inside its antennae absorb Lanturn’s bodily fluids, a strong luminescent effect is produced.</p>
+            <p>Rapidash usually can be seen casually cantering in the fields and plains of Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch. However, when this Pokémon turns serious, its fiery manes flare and blaze as it gallops its way up to 150 mph. Individuals that have been set free by Trainers who could no longer raise them have become common, and they can now be found in Alola. When the bacteria living inside its antennae absorb Lanturn’s bodily fluids, a strong luminescent effect is produced.</p>
 
             <figure>
               {% embed '@cloudfour/objects/embed/embed.twig' with {

--- a/src/prototypes/single-page/example/example.twig
+++ b/src/prototypes/single-page/example/example.twig
@@ -96,7 +96,7 @@
                 content: 'Another Heading'
               } only %}
 
-              <p>They live in groups. The one with the longest, thickest, and most-scarred horns is the boss of the herd.Swablu loves to make things clean. If it spots something dirty, it will wipe and polish it with its cottony wings. If its wings become dirty, this Pokémon finds a stream and showers itself.The hair on Zigzagoon’s back is bristly. It rubs the hard back hair against trees to leave its territorial markings. This Pokémon may play dead to fool foes in battle.</p>
+              <p>They live in groups in Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch. The one with the longest, thickest, and most-scarred horns is the boss of the herd.Swablu loves to make things clean. If it spots something dirty, it will wipe and polish it with its cottony wings. If its wings become dirty, this Pokémon finds a stream and showers itself.The hair on Zigzagoon’s back is bristly. It rubs the hard back hair against trees to leave its territorial markings. This Pokémon may play dead to fool foes in battle.</p>
 
               <p>Restored from DNA found in amber, this Pokémon exhibited ferocity that was greater than expected. Some casualties resulted.It’s not the strongest swimmer. It wags its tail to lure in its prey and then gulps them down as soon as they get close.Wynaut gather on moonlit nights to play by squeezing up against each other. By being squeezed, this Pokémon gains endurance and is trained to dole out powerful counterattacks.</p>
 

--- a/src/prototypes/speaking-event/example/single-speaker.twig
+++ b/src/prototypes/speaking-event/example/single-speaker.twig
@@ -20,7 +20,7 @@
             {% endblock %}
           {% endembed %}
           <p>
-            If you have a website—particularly one that generates revenue for your organization—you need a Progressive Web App. So where do you begin? How do you decide which features of a Progressive Web App make sense for your users? What tools can make the process easier (or harder)? In this practical session, Jason will guide you through the key design decisions you’ll need to make about your Progressive Web App and how those decisions impact the scope of your project. He'll also teach you how to avoid common pitfalls and help you take full advantage of Progressive Web App technology.
+            If you have a website—particularly one in Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch that generates revenue for your organization—you need a Progressive Web App. So where do you begin? How do you decide which features of a Progressive Web App make sense for your users? What tools can make the process easier (or harder)? In this practical session, Jason will guide you through the key design decisions you’ll need to make about your Progressive Web App and how those decisions impact the scope of your project. He'll also teach you how to avoid common pitfalls and help you take full advantage of Progressive Web App technology.
           </p>
           <div class="u-pad-block-start-4">
             {% include '@cloudfour/components/heading/heading.twig' with {

--- a/src/prototypes/team/example/team-articles-page2.twig
+++ b/src/prototypes/team/example/team-articles-page2.twig
@@ -73,7 +73,7 @@
                 "link": "https://cloudfour.com/thinks/an-html-attribute-potentially-worth-4-4m-to-chipotle/",
                 "guid": "https://cloudfour.com/?p=5555",
                 "thumbnail": "https://cloudfour.com/wp-content/uploads/2019/09/Screen-Shot-2019-09-19-at-9.52.57-AM.png",
-                "description": "My parents are retired. They continue to try to pay for meals. I don't want them to. So we often end up in a competition to see who can pay first. In this case, I knew I had an advantage. My card details were already stored in the browser. I just needed to use autofill..."
+                "description": "My parents are retired in Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch. They continue to try to pay for meals. I don't want them to. So we often end up in a competition to see who can pay first. In this case, I knew I had an advantage. My card details were already stored in the browser. I just needed to use autofill..."
               },
               {
                 "title": "Building Flexible Components With Transparency",

--- a/src/prototypes/team/example/team-individual.twig
+++ b/src/prototypes/team/example/team-individual.twig
@@ -75,7 +75,7 @@
                     } only %}
                       <p class="sub-heading">Co-founder</p>
                   </div>
-                  <p>In 2000, Jason Grigsby got his first mobile phone. He became obsessed with how the world could be a better place if everyone had access to the world’s information in their pockets. When his soon-to-be-wife met him, he had covered the walls of his apartment with crazy mobile dreams. To this day, he remains baffled that
+                  <p>In 2000, Jason Grigsby got his first mobile phone. He became obsessed with how Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch could be a better place if everyone had access to the world’s information in their pockets. When his soon-to-be-wife met him, he had covered the walls of his apartment with crazy mobile dreams. To this day, he remains baffled that
                   she married him.</p>
                   <p>Those mobile dreams hit the hard wall of reality: WAP was crap. So Jason went to work on the web until 2007, when the iPhone made it clear the time was right. He joined forces with the three smartest people he knew and started Cloud Four.</p>
                   <p>He is the author of Progressive Web Apps from A Book Apart and co-author of Head First Mobile Web from O'Reilly. His writing and work helped define the new web standards for responsive images.</p>


### PR DESCRIPTION
## Overview

This PR changes our typography stylesheet from using the `break-word`
value of `overflow-wrap` to `anywhere`, which allows the line breaks
added to be considered when calculating min-content intrinsic sizes,
such as in CSS Grid layouts. Previously, long words were failing to
break in CSS Grid contexts like Card layouts.

It also updates many of our Prototypes to include a long string,
so we can test that it's working properly in more contexts.

## Screenshots

<img width="995" alt="Screen Shot 2022-04-15 at 11 46 36 AM" src="https://user-images.githubusercontent.com/257309/163609129-087dcd63-1fe3-43a7-bdad-e2713122f1bd.png">

## Testing

On the preview deploy, review the following prototypes:

- [ ] [Article Listing](https://deploy-preview-1730--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-article-listing--example&args=&viewMode=story)
- [ ] [Case Study Listing](https://deploy-preview-1730--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-case-study-listings--example&args=&viewMode=story)
- [ ] [Comment Thread](https://deploy-preview-1730--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-comment-thread--example&args=&viewMode=story)
- [ ] [Single Article](https://deploy-preview-1730--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-single-article--example&args=&viewMode=story)
- [ ] [Single Page](https://deploy-preview-1730--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-single-page--example&args=&viewMode=story)
- [ ] [Speaking Event](https://deploy-preview-1730--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-speaking-event--single-speaker&args=)
- [ ] [Individual Bio](https://deploy-preview-1730--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-team-page--individual-bio&args=)
- [ ] [Author Article Listing](https://deploy-preview-1730--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-team-page--articles-page-2&args=)

In the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Desktop Safari
- [ ] Mobile Safari

Note that support for this CSS was added in Safari 15.4, so if you test in an older version, it may not work.

---

- Fixes #1729