### PR TITLE
Fix automatic source code previews

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -68,10 +68,7 @@ export const parameters = {
         // that correspond to that output
         const input = window.__twig_inputs__?.get(rendered);
         if (!input) return src;
-        const twigInclude = makeTwigInclude(input.path, input.args);
-        // When I do this, I see the source output many times... some with the
-        // args intact, some without args at all. Alert is a good example.
-        return twigInclude;
+        return = makeTwigInclude(input.path, input.args);
       } catch {
         return src;
       }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -56,7 +56,8 @@ export const parameters = {
     prepareForInline: (storyFn) => htmlToReactParser.parse(storyFn()),
     transformSource(src, storyContext) {
       try {
-        const storyFunction = storyContext.getOriginal();
+        const storyFunction = storyContext.originalStoryFn;
+        if (!storyFunction) return src;
         const rendered = storyFunction(storyContext.args);
         // The twing/source-inputs-loader.js file makes it so that whenever twig templates are rendered,
         // the arguments and input path are stored in the window.__twig_inputs__ variable.
@@ -65,7 +66,11 @@ export const parameters = {
         // that correspond to that output
         const input = window.__twig_inputs__?.get(rendered);
         if (!input) return src;
-        return makeTwigInclude(input.path, input.args);
+        const twigInclude = makeTwigInclude(input.path, input.args);
+        // When I do this, I see the source output many times... some with the
+        // args intact, some without args at all. Alert is a good example.
+        console.log(storyContext.id, storyContext.args, twigInclude);
+        return twigInclude;
       } catch {
         return src;
       }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -68,7 +68,7 @@ export const parameters = {
         // that correspond to that output
         const input = window.__twig_inputs__?.get(rendered);
         if (!input) return src;
-        return = makeTwigInclude(input.path, input.args);
+        return makeTwigInclude(input.path, input.args);
       } catch {
         return src;
       }

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -58,7 +58,9 @@ export const parameters = {
       try {
         const storyFunction = storyContext.originalStoryFn;
         if (!storyFunction) return src;
-        const rendered = storyFunction(storyContext.args);
+        const rendered = storyFunction(
+          storyContext.args || storyContext.initialArgs
+        );
         // The twing/source-inputs-loader.js file makes it so that whenever twig templates are rendered,
         // the arguments and input path are stored in the window.__twig_inputs__ variable.
         // __twig_inputs__ is a map between the output HTML and and objects with the arguments and input paths
@@ -69,7 +71,6 @@ export const parameters = {
         const twigInclude = makeTwigInclude(input.path, input.args);
         // When I do this, I see the source output many times... some with the
         // args intact, some without args at all. Alert is a good example.
-        console.log(storyContext.id, storyContext.args, twigInclude);
         return twigInclude;
       } catch {
         return src;


### PR DESCRIPTION
Fixes #1695 

You can test patterns that have auto-generated source code previews, for example:
- https://deploy-preview-1733--cloudfour-patterns.netlify.app/?path=/docs/components-alert--basic
- https://deploy-preview-1733--cloudfour-patterns.netlify.app/?path=/docs/components-author--basic-usage

Tyler did most of the figuring out/fixing, and I just added a fallback for `storyContext.initialArgs`.

I did not fix the syntax highlighting, I don't remember how that works and I don't know how to fix it