### PR TITLE
Fix Twig syntax highlighting

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -53,6 +53,9 @@ export const parameters = {
     // Docs support for inlining plain HTML stories
     // https://github.com/storybookjs/storybook/blob/v6.0.21/addons/docs/docs/docspage.md#inline-stories-vs-iframe-stories
     inlineStories: true,
+    source: {
+      language: 'twig',
+    },
     prepareForInline: (storyFn) => htmlToReactParser.parse(storyFn()),
     transformSource(src, storyContext) {
       try {


### PR DESCRIPTION
## Overview

This is a follow-up to #1733 and restores Twig syntax highlighting to code samples. In a previous version of Storybook docs, the language of the source samples was detected automatically, but at some point this seems to have changed to use the base framework (which honestly makes some sense and is probably more performant). This simply sets the default value of the `docs.source.language` parameter to `'twig'`, which resolves the issue. This can still be overridden manually for specific stories or for code blocks with a language defined.

## Screenshots

## Before

<img width="1046" alt="Screen Shot 2022-04-18 at 9 33 04 AM" src="https://user-images.githubusercontent.com/69633/163840601-518c398b-1935-4a91-8788-2aa47ec7ba8e.png">

## After

<img width="1056" alt="Screen Shot 2022-04-18 at 9 32 29 AM" src="https://user-images.githubusercontent.com/69633/163840621-0bfdf1f0-b4a3-47c0-a5c4-bf80d9155cb1.png">

## Testing

1. View deploy preview
2. Confirm that Twig code previews are correctly highlighted

---

- See #1695 