### PR TITLE
Fix Card docs performance issue

### DIFF
--- a/src/components/card/card.stories.mdx
+++ b/src/components/card/card.stories.mdx
@@ -1,9 +1,8 @@
 import { Story, Canvas, Meta } from '@storybook/addon-docs';
-import { uniqueId } from 'lodash';
 import singleDemo from './demo/single.twig';
-const singleDemoProps = (args = {}) => {
+const singleDemoProps = (args = {}, storyId) => {
   const props = {
-    heading_id: args.heading_id || uniqueId('card-heading-'),
+    heading_id: args.heading_id || `${storyId}-heading`,
     href: args.href,
   };
   const classNames = [];
@@ -45,8 +44,8 @@ const singleDemoBlockExamples = {
 };
 // Custom function for generating story source from args given
 const singleDemoTransformSource = (_src, storyContext) => {
-  const args = storyContext.args || {};
-  const props = singleDemoProps(args);
+  const args = storyContext.args || storyContext.initialArgs;
+  const props = singleDemoProps(args, storyContext.id);
   const propsString =
     Object.keys(props).length > 0
       ? ` with ${JSON.stringify(props, null, 2)}`


### PR DESCRIPTION
## Overview

I assumed that the performance issues on the Card docs page were related to the failing syntax highlighting, but that was a poor assumption since that page is defining its own `transformSource` function. It turns out that the unique ID fallback for `heading_id` was triggering a reevaluation in Storybook, which would then generate a new unique ID, which resulted in an endless loop.

This PR replaces the fallback ID with one using the story's ID, which won't be invalidated. This makes the page usable again.

## Testing

Try viewing the docs tab for the Card component, confirm it no longer causes the browser tab to hang.
