### PR TITLE
Remove defaultValue from author demo

### DIFF
--- a/src/components/author/author.stories.mdx
+++ b/src/components/author/author.stories.mdx
@@ -32,8 +32,8 @@ const allAuthors = [
     link: 'https://cloudfour.com/is/gerardo',
   },
 ];
-const authors = (count) => allAuthors.slice(0, count);
-const authorsWithNoLink = (count) =>
+const authors = (count = 1) => allAuthors.slice(0, count);
+const authorsWithNoLink = (count = 1) =>
   allAuthors
     .map(({ name, avatar }) => ({
       name,
@@ -46,7 +46,6 @@ const authorsWithNoLink = (count) =>
   argTypes={{
     count: {
       type: 'number',
-      defaultValue: 1,
       description: 'Number of authors to show',
       control: {
         type: 'range',


### PR DESCRIPTION
## Overview

I noticed this morning a deprecated `defaultValue` warning in our console. The author stories were the only ones I could find that were still using this value, so I updated those stories so they no longer did.

(Note that this only applies to `defaultValue` in `argTypes`, not `table.defaultValue`, which is used to customize the default output of an `ArgsTable`.)