### PR TITLE
Increase container block/vertical padding

### DIFF
--- a/.changeset/tasty-rules-argue.md
+++ b/.changeset/tasty-rules-argue.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': major
+---
+
+Replaces the `size.$padding-container-*` tokens into `size.$padding-container-vertical-*` and `size.$padding-container-horizontal-*` tokens so the vertical padding will not need to be overridden across actual layout templates.

--- a/src/objects/container/container.scss
+++ b/src/objects/container/container.scss
@@ -4,8 +4,10 @@
 
 $pad-breakpoint-min: breakpoint.$s;
 $pad-breakpoint-max: breakpoint.$xl;
-$pad-min: size.$padding-container-min;
-$pad-max: size.$padding-container-max;
+$pad-block-min: size.$padding-container-vertical-min;
+$pad-block-max: size.$padding-container-vertical-max;
+$pad-inline-min: size.$padding-container-horizontal-min;
+$pad-inline-max: size.$padding-container-horizontal-max;
 
 /**
  * There are no default styles for `o-container`. It acts as a wrapper so that
@@ -17,28 +19,21 @@ $pad-max: size.$padding-container-max;
  * Modifiers for `o-container` that add some standard, responsive padding.
  */
 
-.o-container--pad {
-  padding: fluid.fluid-clamp(
-    $pad-min,
-    $pad-max,
-    $pad-breakpoint-min,
-    $pad-breakpoint-max
-  );
-}
-
+.o-container--pad,
 .o-container--pad-block {
   padding-block: fluid.fluid-clamp(
-    $pad-min,
-    $pad-max,
+    $pad-block-min,
+    $pad-block-max,
     $pad-breakpoint-min,
     $pad-breakpoint-max
   );
 }
 
+.o-container--pad,
 .o-container--pad-inline {
   padding-inline: fluid.fluid-clamp(
-    $pad-min,
-    $pad-max,
+    $pad-inline-min,
+    $pad-inline-max,
     $pad-breakpoint-min,
     $pad-breakpoint-max
   );
@@ -73,8 +68,8 @@ $pad-max: size.$padding-container-max;
   .o-container--pad &,
   .o-container--pad-inline & {
     margin-inline: fluid.fluid-clamp(
-      $pad-min * -1,
-      $pad-max * -1,
+      $pad-inline-min * -1,
+      $pad-inline-max * -1,
       $pad-breakpoint-min,
       $pad-breakpoint-max
     );
@@ -92,8 +87,8 @@ $pad-max: size.$padding-container-max;
   .o-container--pad &,
   .o-container--pad-inline & {
     padding-inline: fluid.fluid-clamp(
-      $pad-min,
-      $pad-max,
+      $pad-inline-min,
+      $pad-inline-max,
       $pad-breakpoint-min,
       $pad-breakpoint-max
     );

--- a/src/prototypes/home-page/example/example.twig
+++ b/src/prototypes/home-page/example/example.twig
@@ -39,7 +39,7 @@
 
 
   {% embed '@cloudfour/objects/container/container.twig' with {
-    class: 'o-container--pad u-pad-block-6'
+    class: 'o-container--pad'
   } only %}
     {% block content %}
       {% embed '@cloudfour/objects/deck/deck.twig' only %}
@@ -74,7 +74,7 @@
 
   <div class="t-alternate">
     {% embed '@cloudfour/objects/container/container.twig' with {
-    class: 'o-container--pad u-pad-block-6'
+    class: 'o-container--pad'
     } only %}
       {% block content %}
         {% embed '@cloudfour/objects/feature-group/feature-group.twig' %}
@@ -143,7 +143,7 @@
   </div>
 
   {% embed '@cloudfour/objects/container/container.twig' with {
-  class: 'o-container--pad u-pad-block-6'
+  class: 'o-container--pad'
   } only %}
     {% block content %}
       {% embed '@cloudfour/objects/feature-group/feature-group.twig' %}

--- a/src/prototypes/single-article/example/example.twig
+++ b/src/prototypes/single-article/example/example.twig
@@ -52,7 +52,7 @@
 {% endset %}
 
 {% embed '@cloudfour/objects/container/container.twig' with {
-  class: 'o-container--prose o-container--pad u-pad-block-6'} %}
+  class: 'o-container--prose o-container--pad'} %}
   {% block content %}
     {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
       class: 'o-rhythm--generous' } %}

--- a/src/tokens/size/padding.js
+++ b/src/tokens/size/padding.js
@@ -18,13 +18,28 @@ module.exports = {
         },
       },
       container: {
-        min: {
-          value: modularRem(-1),
-          comment: 'Minimum fluid padding for container objects.',
+        horizontal: {
+          min: {
+            value: modularRem(-1),
+            comment:
+              'Minimum inline (horizontal) fluid padding for container objects.',
+          },
+          max: {
+            value: modularRem(3),
+            comment:
+              'Maximum inline (horizontal) padding for container objects.',
+          },
         },
-        max: {
-          value: modularRem(3),
-          comment: 'Maximum fluid padding for container objects.',
+        vertical: {
+          min: {
+            value: modularRem(3),
+            comment:
+              'Minimum block (vertical) fluid padding for container objects.',
+          },
+          max: {
+            value: modularRem(6),
+            comment: 'Maximum block (vertical) padding for container objects.',
+          },
         },
       },
     },


### PR DESCRIPTION
## Overview

In a PR discussion, @gerardo-rodriguez and I observed that every single page was overriding the container's block padding. The padding values for container are the same in both dimensions, but that simply didn't look balanced when the container was adjacent to something like the Cloud Cover with its viewport units.

This PR uses the same values as the Deck gap. But to do that, I had to break apart the vertical and horizontal padding tokens, which is why I consider this a breaking change (since references to the old token would now result in an error). Happy to modify that if others feel it's a bit too extreme.

## Screenshots

### Before

<img width="1322" alt="Screen Shot 2022-04-18 at 3 39 31 PM" src="https://user-images.githubusercontent.com/69633/163888522-5d0bedfc-6fa4-4d84-aa23-390388b5a41f.png">

### After

<img width="1405" alt="Screen Shot 2022-04-18 at 3 39 46 PM" src="https://user-images.githubusercontent.com/69633/163888545-076a7cdc-841e-4219-ad16-1eefe7117ece.png">

## Testing

1. On the deploy preview, observe that [the block padding in the container stories](https://deploy-preview-1740--cloudfour-patterns.netlify.app/?path=/story/objects-container--basic) is larger than before.
2. Also on the deploy preview, observe that the container in [the Single Article prototype](https://deploy-preview-1740--cloudfour-patterns.netlify.app/?path=/story/prototypes-single-article--example) appears to have adequate padding.

---

- Fixes #1726 