### PR TITLE
Remove Stray Spaces from Author Component

### DIFF
--- a/.changeset/silent-carpets-doubt.md
+++ b/.changeset/silent-carpets-doubt.md
@@ -1,5 +1,5 @@
 ---
-"@cloudfour/patterns": patch
+'@cloudfour/patterns': patch
 ---
 
 Bugfix: Remove Stray Spaces from Author Component

--- a/.changeset/silent-carpets-doubt.md
+++ b/.changeset/silent-carpets-doubt.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": patch
+---
+
+Bugfix: Remove Stray Spaces from Author Component

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -67,11 +67,11 @@
       {% block authors %}
         {% for author in authors %}
           {% if loop.last and loop.length > 1 %}and {% endif %}
-            {% if author.link and not unlink %}
+            {%- if author.link and not unlink -%}
               <a href="{{ author.link }}">{{ author.name }}</a>
-            {% else %}
+            {%- else -%}
               <span>{{ author.name }}</span>
-            {% endif %}
+            {%- endif -%}
           {%- if not loop.last and loop.length > 2 %},{% endif %}
         {% endfor %}
       {% endblock %}


### PR DESCRIPTION
## Overview

A recent change to the Author component unintentionally added spaces
between the author names and trailing commas when there are multiple
authors. This PR removes the whitespace to prevent this.

## Testing

On the preview deploy, review the [Multiple Author story](https://deploy-preview-1742--cloudfour-patterns.netlify.app/?path=/story/components-author--multiple-authors), and confirm there are no spaces between the name and the comma (contrast with the [live version](https://v-next--cloudfour-patterns.netlify.app/?path=/story/components-author--multiple-authors)).