### PR TITLE
Updated Block Alignment Styles for Deck

### DIFF
--- a/.changeset/heavy-kings-arrive.md
+++ b/.changeset/heavy-kings-arrive.md
@@ -1,5 +1,5 @@
 ---
-"@cloudfour/patterns": minor
+'@cloudfour/patterns': minor
 ---
 
 Updated Block Alignment Styles for Deck

--- a/.changeset/heavy-kings-arrive.md
+++ b/.changeset/heavy-kings-arrive.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": minor
+---
+
+Updated Block Alignment Styles for Deck

--- a/.changeset/heavy-kings-arrive.md
+++ b/.changeset/heavy-kings-arrive.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Updated Block Alignment Styles for Deck
+Update the Deck object to better handle the WordPress block alignment styles `alignwide` and `alignfull`.

--- a/.changeset/heavy-kings-arrive.md
+++ b/.changeset/heavy-kings-arrive.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Update the Deck object to better handle the WordPress block alignment styles `alignwide` and `alignfull`.
+Update the Deck object to better handle the WordPress block alignment styles `alignwide` and `alignfull`. By default, these would pull the Deck content flush with the edge of the screen and even clip a bit in certain circumstances. To resolve this, we add some padding to prevent the content from going full-bleed.

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -48,15 +48,17 @@ ul {
 }
 
 /**
- * Forces the viewport to be filled. Necessary for the footer to "stick" to the
- * bottom of short pages.
- *
- * @see https://css-tricks.com/couple-takes-sticky-footer/#there-is-grid
+ * 1. Forces the viewport to be filled. Necessary for the footer to
+ *    "stick" to the bottom of short pages.
+ *    @see https://css-tricks.com/couple-takes-sticky-footer/#there-is-grid
+ * 2. Keep full-bleed items from triggering a horizontal scrollbar.
+ *    @see https://cloudfour.com/thinks/breaking-out-with-viewport-units-and-calc/
  */
 
 html,
 body {
-  block-size: 100%;
+  block-size: 100%; // 1
+  overflow-x: hidden; // 2
 }
 
 /**

--- a/src/objects/container/container.scss
+++ b/src/objects/container/container.scss
@@ -8,6 +8,24 @@ $pad-block-min: size.$padding-container-vertical-min;
 $pad-block-max: size.$padding-container-vertical-max;
 $pad-inline-min: size.$padding-container-horizontal-min;
 $pad-inline-max: size.$padding-container-horizontal-max;
+$fluid-pad-block: fluid.fluid-clamp(
+  $pad-block-min,
+  $pad-block-max,
+  $pad-breakpoint-min,
+  $pad-breakpoint-max
+);
+$fluid-pad-inline: fluid.fluid-clamp(
+  $pad-inline-min,
+  $pad-inline-max,
+  $pad-breakpoint-min,
+  $pad-breakpoint-max
+);
+$fluid-pad-inline-negative: fluid.fluid-clamp(
+  $pad-inline-min * -1,
+  $pad-inline-max * -1,
+  $pad-breakpoint-min,
+  $pad-breakpoint-max
+);
 
 /**
  * There are no default styles for `o-container`. It acts as a wrapper so that
@@ -21,22 +39,12 @@ $pad-inline-max: size.$padding-container-horizontal-max;
 
 .o-container--pad,
 .o-container--pad-block {
-  padding-block: fluid.fluid-clamp(
-    $pad-block-min,
-    $pad-block-max,
-    $pad-breakpoint-min,
-    $pad-breakpoint-max
-  );
+  padding-block: $fluid-pad-block;
 }
 
 .o-container--pad,
 .o-container--pad-inline {
-  padding-inline: fluid.fluid-clamp(
-    $pad-inline-min,
-    $pad-inline-max,
-    $pad-breakpoint-min,
-    $pad-breakpoint-max
-  );
+  padding-inline: $fluid-pad-inline;
 }
 
 /**
@@ -67,12 +75,7 @@ $pad-inline-max: size.$padding-container-horizontal-max;
 .o-container__fill-pad {
   .o-container--pad &,
   .o-container--pad-inline & {
-    margin-inline: fluid.fluid-clamp(
-      $pad-inline-min * -1,
-      $pad-inline-max * -1,
-      $pad-breakpoint-min,
-      $pad-breakpoint-max
-    );
+    margin-inline: $fluid-pad-inline-negative;
   }
 }
 
@@ -86,11 +89,6 @@ $pad-inline-max: size.$padding-container-horizontal-max;
 .o-container__fill-pad {
   .o-container--pad &,
   .o-container--pad-inline & {
-    padding-inline: fluid.fluid-clamp(
-      $pad-inline-min,
-      $pad-inline-max,
-      $pad-breakpoint-min,
-      $pad-breakpoint-max
-    );
+    padding-inline: $fluid-pad-inline;
   }
 }

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -2,6 +2,7 @@
 @use '../../compiled/tokens/scss/size';
 @use '../../mixins/fluid';
 @use '../../mixins/media-query';
+@use '../container/container.scss';
 
 /**
  * 1. If horizontal items are shown at the wrong column count, they will appear
@@ -65,21 +66,12 @@
  * Block alignment adjustments
  *
  * 1. Set inline padding to match `o-container__fill-pad`.
- *    We're using the container tokens here, but ideally we'd make a
- *    token for the whole `fluid-clamp()` formula, but our token system
- *    doesn't support using Sass formulas that way. This should be okay,
- *    since we're still matching the container's tokens.
  * 2. Remove padding once `alignwide` is no longer full-bleed.
  */
 
 .o-deck.alignfull,
 .o-deck.alignwide {
-  padding-inline: fluid.fluid-clamp(
-    size.$padding-container-horizontal-min,
-    size.$padding-container-horizontal-max,
-    breakpoint.$s,
-    breakpoint.$xl
-  ); // 1
+  padding-inline: container.$fluid-pad-inline; // 1
 }
 
 .o-deck.alignwide {

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -65,7 +65,8 @@
 /**
  * Block alignment adjustments
  *
- * 1. Set inline padding to match `o-container__fill-pad`.
+ * 1. Set inline padding to match `o-container__fill-pad` since we don't want the deck to touch 
+ *     the viewport edges even when it's full bleed.
  * 2. Remove padding once `alignwide` is no longer full-bleed.
  */
 

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -69,34 +69,21 @@
  *    token for the whole `fluid-clamp()` formula, but our token system
  *    doesn't support using Sass formulas that way. This should be okay,
  *    since we're still matching the container's tokens.
- * 2. Adjust default `alignfull` margin to subtract padding.
- *    (see next comment for context.)
- * 3. In a perfect world, we'd just set padding here, and let the default
- *    `alignfull` margins make the layout full-bleed. Unfortunately, the
- *    default margins use viewport units which don't factor in scrollbars.
- *    This meant our content was actually wider than the viewport and got
- *    clipped, with a horizontal scrollbar. So instead of setting padding,
- *    we're overriding the default margins to be less than full-bleed by
- *    the amount of our padding. If anyone fixes the bug with `alignfull`
- *    then this code can be simplified to just set `padding-inline`.
- * 4. Only set margin when `alignwide` is full-bleed, to avoid overriding
- *    the default `alignwide` negative margins.
+ * 2. Remove padding once `alignwide` is no longer full-bleed.
  */
 
-$deck-aligned-padding: fluid.fluid-clamp(
-  size.$padding-container-horizontal-min,
-  size.$padding-container-horizontal-max,
-  breakpoint.$s,
-  breakpoint.$xl
-); // 1
-$deck-aligned-margin: calc(-50vw + 50% + #{$deck-aligned-padding}); // 2
-
-.o-deck.alignfull {
-  margin-inline: $deck-aligned-margin; // 3
+.o-deck.alignfull,
+.o-deck.alignwide {
+  padding-inline: fluid.fluid-clamp(
+    size.$padding-container-horizontal-min,
+    size.$padding-container-horizontal-max,
+    breakpoint.$s,
+    breakpoint.$xl
+  ); // 1
 }
 
 .o-deck.alignwide {
-  @media (width < breakpoint.$l) {
-    margin-inline: $deck-aligned-margin; // 4
+  @media (width >= breakpoint.$l) {
+    padding-inline: 0; // 2
   }
 }

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -63,12 +63,40 @@
 
 /**
  * Block alignment adjustments
+ *
+ * 1. Set inline padding to match `o-container__fill-pad`.
+ *    We're using the container tokens here, but ideally we'd make a
+ *    token for the whole `fluid-clamp()` formula, but our token system
+ *    doesn't support using Sass formulas that way. This should be okay,
+ *    since we're still matching the container's tokens.
+ * 2. Adjust default `alignfull` margin to subtract padding.
+ *    (see next comment for context.)
+ * 3. In a perfect world, we'd just set padding here, and let the default
+ *    `alignfull` margins make the layout full-bleed. Unfortunately, the
+ *    default margins use viewport units which don't factor in scrollbars.
+ *    This meant our content was actually wider than the viewport and got
+ *    clipped, with a horizontal scrollbar. So instead of setting padding,
+ *    we're overriding the default margins to be less than full-bleed by
+ *    the amount of our padding. If anyone fixes the bug with `alignfull`
+ *    then this code can be simplified to just set `padding-inline`.
+ * 4. Only set margin when `alignwide` is full-bleed, to avoid overriding
+ *    the default `alignwide` negative margins.
  */
 
+$deck-aligned-padding: fluid.fluid-clamp(
+  size.$padding-container-horizontal-min,
+  size.$padding-container-horizontal-max,
+  breakpoint.$s,
+  breakpoint.$xl
+); // 1
+$deck-aligned-margin: calc(-50vw + 50% + #{$deck-aligned-padding}); // 2
+
 .o-deck.alignfull {
-  background: pink;
+  margin-inline: $deck-aligned-margin; // 3
 }
 
 .o-deck.alignwide {
-  background: cyan;
+  @media (width < breakpoint.$l) {
+    margin-inline: $deck-aligned-margin; // 4
+  }
 }

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -60,3 +60,15 @@
 .o-deck--align-start {
   align-items: start;
 }
+
+/**
+ * Block alignment adjustments
+ */
+
+.o-deck.alignfull {
+  background: pink;
+}
+
+.o-deck.alignwide {
+  background: cyan;
+}

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -122,6 +122,8 @@ When used in WordPress, the `alignwide` and `alignfull` block alignment styles h
     name="Block Alignment"
     height="400px"
     args={{
+      columns: 3,
+      columnsBreakpoint: '@m',
       alignment: 'alignfull',
     }}
   >

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -3,6 +3,7 @@ import articles from './demo/articles.json';
 import articlesDemo from './demo/articles.twig';
 import alignmentDemo from './demo/alignment.twig';
 const articlesStory = (args) => articlesDemo({ items: articles, ...args });
+const alignmentStory = (args) => alignmentDemo({ items: articles, ...args });
 // Custom function for generating story source from args given
 const articlesTemplateSource = (_src, storyContext) => {
   const args = storyContext.args || {};
@@ -23,6 +24,11 @@ const articlesTemplateSource = (_src, storyContext) => {
   {% endblock %}
 {% endembed %}`;
 };
+const alignmentClasses = {
+  None: '',
+  Full: 'alignfull',
+  Wide: 'alignwide',
+};
 
 <Meta
   title="Objects/Deck"
@@ -40,6 +46,10 @@ const articlesTemplateSource = (_src, storyContext) => {
   }}
   argTypes={{
     class: { type: { name: 'string' } },
+    alignment: {
+      options: alignmentClasses,
+      control: { type: 'select' },
+    },
     columns: {
       control: {
         type: 'range',
@@ -90,8 +100,32 @@ By default, the `o-deck` class will use CSS Grid Layout to arrange child element
 The `o-deck--align-start` modifier can be used to top-align deck items. This modifier is helpful when the deck items have different alignment. For example, the `o-media` object can be middle or top aligned depending on the length of the content. The modifier forces all deck objects to have the same alignment.
 
 <Canvas>
-  <Story name="Alignment" height="200px">
-    {(args) => alignmentDemo(args)}
+  <Story
+    name="Alignment"
+    height="200px"
+    args={{
+      columns: 3,
+      columnsBreakpoint: '@m',
+      class: 'o-deck--align-start',
+    }}
+  >
+    {alignmentStory.bind({})}
+  </Story>
+</Canvas>
+
+## Block Alignment
+
+When used in WordPress, the `alignwide` and `alignfull` block alignment styles have been updated for use with the Deck.
+
+<Canvas>
+  <Story
+    name="Block Alignment"
+    height="400px"
+    args={{
+      alignment: 'alignfull',
+    }}
+  >
+    {articlesStory.bind({})}
   </Story>
 </Canvas>
 

--- a/src/objects/deck/demo/alignment.twig
+++ b/src/objects/deck/demo/alignment.twig
@@ -1,45 +1,27 @@
+{% if columns and columns > 1 and columnsBreakpoint and columnsBreakpoint != 'none' %}
+  {% set _deck_class = 'o-deck--' ~ columns ~ '-column' ~ columnsBreakpoint ~ ' ' ~ class ~ ' ' ~ alignment %}
+{% else %}
+  {% set _deck_class = class ~ ' ' ~ alignment %}
+{% endif %}
+
 {% embed '@cloudfour/objects/deck/deck.twig' with {
-  class: 'o-deck--align-start o-deck--3-column@m'
-} only %}
+  class: _deck_class,
+} %}
   {% block content %}
-    {% embed '@cloudfour/objects/media/media.twig' %}
-      {% block object %}
-        {% include '@cloudfour/components/avatar/avatar.twig' with {
-          "src": "https://placeimg.com/200/200/animals",
-          "sizes": "60px"
-        } only %}
-      {% endblock %}
-      {% block content %}
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </p>
-      {% endblock %}
-    {% endembed %}
-    {% embed '@cloudfour/objects/media/media.twig' %}
-      {% block object %}
-        {% include '@cloudfour/components/avatar/avatar.twig' with {
-          "src": "https://placeimg.com/200/200/animals",
-          "sizes": "60px"
-        } only %}
-      {% endblock %}
-      {% block content %}
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </p>
-      {% endblock %}
-    {% endembed %}
-    {% embed '@cloudfour/objects/media/media.twig' %}
-      {% block object %}
-        {% include '@cloudfour/components/avatar/avatar.twig' with {
-          "src": "https://placeimg.com/200/200/animals",
-          "sizes": "60px"
-        } only %}
-      {% endblock %}
-      {% block content %}
-        <p>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-        </p>
-      {% endblock %}
-    {% endembed %}
+    {% for i in 1..3 %}
+      {% embed '@cloudfour/objects/media/media.twig' %}
+        {% block object %}
+          {% include '@cloudfour/components/avatar/avatar.twig' with {
+            "src": "https://api.lorem.space/image/face?w=120&h=120&t=" ~ loop.index,
+            "sizes": "60px"
+          } only %}
+        {% endblock %}
+        {% block content %}
+          <p>
+            {{ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu ex enim. Nunc efficitur scelerisque dolor et sollicitudin. Donec finibus lorem elit, eu consectetur quam pellentesque sed. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas."|slice(0, loop.index * 50) }}
+          </p>
+        {% endblock %}
+      {% endembed %}
+    {% endfor %}
   {% endblock %}
 {% endembed %}

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -1,11 +1,25 @@
+{% set _deck_class = '' %}
+
 {% if columns and columns > 1 and columnsBreakpoint and columnsBreakpoint != 'none' %}
-  {% set _deck_class = 'o-deck--' ~ columns ~ '-column' ~ columnsBreakpoint ~ ' ' ~ class ~ ' ' ~ alignment %}
-{% else %}
-  {% set _deck_class = class ~ ' ' ~ alignment %}
+  {% set _deck_class = 'o-deck--' ~ columns ~ '-column' ~ columnsBreakpoint %}
 {% endif %}
 
+{% if class %}
+  {% set _deck_class = _deck_class ~ ' ' ~ class %}
+{% endif %}
+
+{% if alignment %}
+  {% set _deck_class = _deck_class ~ ' ' ~ alignment %}
+{% endif %}
+
+{#
+  The Wide alignment demo needs a max-width to work, so we add a container.
+  It's not needed in any other circumstances.
+#}
+{% if alignment == 'alignwide' %}
 <div class="o-container--prose">
   <div class="o-container__content">
+{% endif %}
     {% embed '@cloudfour/objects/deck/deck.twig' with {
       class: _deck_class,
     } %}
@@ -43,5 +57,7 @@
         {% endfor %}
       {% endblock %}
     {% endembed %}
+{% if alignment == 'alignwide' %}
   </div>
 </div>
+{% endif %}

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -4,40 +4,44 @@
   {% set _deck_class = class ~ ' ' ~ alignment %}
 {% endif %}
 
-{% embed '@cloudfour/objects/deck/deck.twig' with {
-  class: _deck_class,
-} %}
-  {% block content %}
-    {% for item in items %}
-      {% if loop.index == horizontalItem and horizontalBreakpoint and horizontalBreakpoint != 'none' %}
-        {% set _card_class = 'c-card--horizontal' ~ horizontalBreakpoint %}
-      {% else %}
-        {% set _card_class = '' %}
-      {% endif %}
-      {% embed '@cloudfour/components/card/card.twig' with {
-        class: _card_class,
-        href: item.link
-      } %}
-        {% block heading %}
-          {{item.title}}
-        {% endblock %}
-        {% block cover %}
-          <img src="{{item.thumbnail}}" alt="">
-        {% endblock %}
-        {% block content %}
-          <p>
-            {% if item.description|length > 140 %}
-              {{item.description|slice(0, 140)|trim}}…
-            {% else %}
-              {{item.description}}
-            {% endif %}
-          </p>
-        {% endblock %}
-        {% block footer %}
-          <p>{{item.author}}</p>
-          <p>{{item.pubDate|date('M j, Y')}}</p>
-        {% endblock %}
-      {% endembed %}
-    {% endfor %}
-  {% endblock %}
-{% endembed %}
+<div class="o-container--prose">
+  <div class="o-container__content">
+    {% embed '@cloudfour/objects/deck/deck.twig' with {
+      class: _deck_class,
+    } %}
+      {% block content %}
+        {% for item in items %}
+          {% if loop.index == horizontalItem and horizontalBreakpoint and horizontalBreakpoint != 'none' %}
+            {% set _card_class = 'c-card--horizontal' ~ horizontalBreakpoint %}
+          {% else %}
+            {% set _card_class = '' %}
+          {% endif %}
+          {% embed '@cloudfour/components/card/card.twig' with {
+            class: _card_class,
+            href: item.link
+          } %}
+            {% block heading %}
+              {{item.title}}
+            {% endblock %}
+            {% block cover %}
+              <img src="{{item.thumbnail}}" alt="">
+            {% endblock %}
+            {% block content %}
+              <p>
+                {% if item.description|length > 140 %}
+                  {{item.description|slice(0, 140)|trim}}…
+                {% else %}
+                  {{item.description}}
+                {% endif %}
+              </p>
+            {% endblock %}
+            {% block footer %}
+              <p>{{item.author}}</p>
+              <p>{{item.pubDate|date('M j, Y')}}</p>
+            {% endblock %}
+          {% endembed %}
+        {% endfor %}
+      {% endblock %}
+    {% endembed %}
+  </div>
+</div>

--- a/src/objects/deck/demo/articles.twig
+++ b/src/objects/deck/demo/articles.twig
@@ -1,7 +1,7 @@
 {% if columns and columns > 1 and columnsBreakpoint and columnsBreakpoint != 'none' %}
-  {% set _deck_class = 'o-deck--' ~ columns ~ '-column' ~ columnsBreakpoint %}
+  {% set _deck_class = 'o-deck--' ~ columns ~ '-column' ~ columnsBreakpoint ~ ' ' ~ class ~ ' ' ~ alignment %}
 {% else %}
-  {% set _deck_class = '' %}
+  {% set _deck_class = class ~ ' ' ~ alignment %}
 {% endif %}
 
 {% embed '@cloudfour/objects/deck/deck.twig' with {


### PR DESCRIPTION
## Overview

This PR updates the Deck object to better handle the WordPress block
alignment styles `alignwide` and `alignfull`. By default, these would
pull the Deck content flush with the edge of the screen and even clip
a bit in certain circumstances. To resolve this, we add some padding
to prevent the content from going full-bleed.

## Screenshots
<img width="1025" alt="Screen Shot 2022-04-21 at 4 00 08 PM" src="https://user-images.githubusercontent.com/257309/164564897-e4e27561-b9f9-4f55-9743-f57032f777c5.png">
<img width="1029" alt="Screen Shot 2022-04-21 at 4 00 47 PM" src="https://user-images.githubusercontent.com/257309/164564916-adf51d7a-4e87-4c00-9d8d-e3458fbfe5e1.png">

## Testing

1. Check out this branch locally
1. Review the "[Block Alignment](http://localhost:6006/?path=/story/objects-deck--block-alignment)" story in the Deck page. Try changing the alignment to test both "Wide" and "Full" at several breakpoints.
    - The content should not touch the edge of the viewport
    - The content should not get cut off
    - There should be no horizontal scrollbar

Test the following browsers:

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
- [x] Mobile Safari

---

- Fixes #1743
