### PR TITLE
Add missing EventSummary `note` prop documentation

### DIFF
--- a/.changeset/stupid-moose-march.md
+++ b/.changeset/stupid-moose-march.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Add missing EventSummary `note` prop documentation

--- a/.changeset/stupid-moose-march.md
+++ b/.changeset/stupid-moose-march.md
@@ -1,5 +1,0 @@
----
-'@cloudfour/patterns': patch
----
-
-Add missing EventSummary `note` prop documentation

--- a/src/components/event-summary/event-summary.stories.mdx
+++ b/src/components/event-summary/event-summary.stories.mdx
@@ -31,6 +31,7 @@ Combines the [Media object](/docs/objects-media--image) and [Calendar Date compo
 - `event` (string): The name of the event (e.g. `'Smashing Magazine'`)
 - `href` (string): The event URL (e.g. `https://cloudfour.com`)
 - `location` (string): The location of the event (e.g. `'Portland, OR'`)
+- `note` (string): A short event note (e.g. "3 day event")
 - `speakers` (string array): An array of string names of the speakers:
   ```ts
   ['Megan', 'Aileen'];


### PR DESCRIPTION
## Overview

Not critical, but something I noticed along the way.