### PR TITLE
Allow input `name` attribute value to be set for Subscribe component

### DIFF
--- a/.changeset/nasty-bags-jog.md
+++ b/.changeset/nasty-bags-jog.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Allow `name` attribute to be set for Subscribe component email input

--- a/src/components/subscribe/subscribe.stories.mdx
+++ b/src/components/subscribe/subscribe.stories.mdx
@@ -137,14 +137,21 @@ const templateStory = (args) => {
     },
     email_input_label: {
       type: 'string',
-      description: 'The email input `<label>` value',
+      description: 'The value for the email input `<label>`',
       table: {
         defaultValue: { summary: 'Email' },
       },
     },
+    email_input_name: {
+      type: 'string',
+      description: 'The value for the email input `name` attribute',
+      table: {
+        defaultValue: { summary: 'email' },
+      },
+    },
     email_input_placeholder: {
       type: 'string',
-      description: 'The email input placeholder text',
+      description: 'The value for the email input `placeholder` attribute',
       table: {
         defaultValue: { summary: 'Your Email Address' },
       },

--- a/src/components/subscribe/subscribe.test.ts
+++ b/src/components/subscribe/subscribe.test.ts
@@ -222,6 +222,7 @@ describe('Subscription', () => {
           notifications_btn_initial_visual_label: 'Yes to notifications',
           weekly_digests_btn_class: 'world',
           weekly_digests_btn_label: 'I want weekly digests',
+          email_input_name: 'email-input-name',
           email_input_placeholder: 'Gimme email',
           submit_btn_label: 'Sign up',
         })
@@ -244,6 +245,7 @@ describe('Subscription', () => {
       expect(form).toHaveAttribute('action', 'test-action.com');
       emailInput = await screen.getByRole('textbox', { name: 'Email' });
       expect(emailInput).toHaveAttribute('placeholder', 'Gimme email');
+      expect(emailInput).toHaveAttribute('name', 'email-input-name');
 
       // Confirm custom notifications button
       const notificationsBtn = await screen.getByRole('button', {

--- a/src/components/subscribe/subscribe.twig
+++ b/src/components/subscribe/subscribe.twig
@@ -52,6 +52,7 @@
     {% embed '@cloudfour/objects/input-group/input-group.twig' with {
       class: 'c-subscribe__form-input-group',
       form_id: form_id,
+      email_input_name: email_input_name,
       email_input_placeholder: email_input_placeholder,
       submit_btn_label: submit_btn_label
     } only %}
@@ -60,6 +61,7 @@
           id: "subscription-email-#{form_id}",
           type: 'email',
           class: 'c-subscribe__form-input',
+          name: email_input_name|default('email'),
           placeholder: email_input_placeholder|default('Your Email Address'),
           autocomplete: 'home email',
           required: 'required'

--- a/src/components/subscribe/subscribe.twig
+++ b/src/components/subscribe/subscribe.twig
@@ -12,10 +12,14 @@
         'js-subscribe__control',
         notifications_btn_class|default('')
       ]|join(' '),
-      initial_label: notifications_btn_initial_label|default('Notifications have been turned off.'),
-      initial_visual_label: notifications_btn_initial_visual_label|default('Get notifications'),
-      swapped_label: notifications_btn_swapped_label|default('Notifications have been turned on.'),
-      swapped_visual_label: notifications_btn_swapped_visual_label|default('Turn off notifications'),
+      initial_label:
+        notifications_btn_initial_label|default('Notifications have been turned off.'),
+      initial_visual_label:
+        notifications_btn_initial_visual_label|default('Get notifications'),
+      swapped_label:
+        notifications_btn_swapped_label|default('Notifications have been turned on.'),
+      swapped_visual_label:
+        notifications_btn_swapped_visual_label|default('Turn off notifications'),
     } only %}
 
     {% include '@cloudfour/components/button/button.twig' with {


### PR DESCRIPTION
## Overview

This PR adds the ability to pass a value for the `name` attribute to the subscription form email input. 

This is a blocker for https://github.com/cloudfour/cloudfour.com-wp/issues/560

## Screenshots

<img width="1279" alt="Screen Shot 2022-05-02 at 9 16 29 AM" src="https://user-images.githubusercontent.com/459757/166269083-c84348a3-bcc2-4fdc-8f32-2867703d3e11.png">

## Testing

Open the [Subscribe component](https://deploy-preview-1765--cloudfour-patterns.netlify.app/?path=/story/components-subscribe--default-story) and confirm:

- [ ] You can customize the `name` attribute value by setting the value from the `email_input_name` prop

---

- Closes #1766 