### PR TITLE
Add u-text-center utility

### DIFF
--- a/.changeset/eight-roses-breathe.md
+++ b/.changeset/eight-roses-breathe.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add u-text-align-center utility CSS class

--- a/.changeset/eight-roses-breathe.md
+++ b/.changeset/eight-roses-breathe.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Add u-text-align-center utility CSS class
+Add u-text-center utility CSS class

--- a/src/utilities/text/demo/text-align.twig
+++ b/src/utilities/text/demo/text-align.twig
@@ -3,6 +3,6 @@
 } only %}
   {% block content %}
     <p>This is default text.</p>
-    <p class="u-text-align-center">This is text that has the utility class applied.</p>
+    <p class="u-text-center">This is text that has the utility class applied.</p>
   {% endblock %}
 {% endembed %}

--- a/src/utilities/text/demo/text-align.twig
+++ b/src/utilities/text/demo/text-align.twig
@@ -1,0 +1,8 @@
+{% embed '@cloudfour/objects/container/container.twig' with {
+  class: 'o-container--pad'
+} only %}
+  {% block content %}
+    <p>This is default text.</p>
+    <p class="u-text-align-center">This is text that has the utility class applied.</p>
+  {% endblock %}
+{% endembed %}

--- a/src/utilities/text/text.scss
+++ b/src/utilities/text/text.scss
@@ -7,3 +7,7 @@
 .u-text-action {
   color: var(--theme-color-text-action) !important;
 }
+
+.u-text-align-center {
+  text-align: center !important;
+}

--- a/src/utilities/text/text.scss
+++ b/src/utilities/text/text.scss
@@ -8,6 +8,6 @@
   color: var(--theme-color-text-action) !important;
 }
 
-.u-text-align-center {
+.u-text-center {
   text-align: center !important;
 }

--- a/src/utilities/text/text.stories.mdx
+++ b/src/utilities/text/text.stories.mdx
@@ -8,17 +8,11 @@ import { Story, Canvas, Meta } from '@storybook/addon-docs';
 // This can be revisited in the future if Storybook no longer relies on Webpack.
 // eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import noWrapDemoSource from '!!raw-loader!./demo/nowrap.twig';
-import noWrapDemo from './demo/nowrap.twig';
-// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
-// See: https://github.com/webpack-contrib/raw-loader#examples
-// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
-// okay with the following Webpack-specific raw loader syntax. It's better to leave
-// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
-// within a Storybook docs page and not within an actual component).
-// This can be revisited in the future if Storybook no longer relies on Webpack.
-// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import colorDemoSource from '!!raw-loader!./demo/color.twig';
+import textAlignDemoSource from '!!raw-loader!./demo/text-align.twig';
+import noWrapDemo from './demo/nowrap.twig';
 import colorDemo from './demo/color.twig';
+import textAlignDemo from './demo/text-align.twig';
 
 <Meta title="Utilities/Text" />
 
@@ -55,5 +49,20 @@ Utility that changes the text color to the "action" text color.
     parameters={{ docs: { source: { code: colorDemoSource } } }}
   >
     {(args) => colorDemo(args)}
+  </Story>
+</Canvas>
+
+## Text-align center
+
+- `u-text-align-center`
+
+Utility that sets `text-align` to `center`
+
+<Canvas>
+  <Story
+    name="Text-align center"
+    parameters={{ docs: { source: { code: textAlignDemoSource } } }}
+  >
+    {(args) => textAlignDemo(args)}
   </Story>
 </Canvas>

--- a/src/utilities/text/text.stories.mdx
+++ b/src/utilities/text/text.stories.mdx
@@ -56,7 +56,7 @@ Utility that changes the text color to the "action" text color.
 
 ## Text-align center
 
-- `u-text-align-center`
+- `u-text-center`
 
 Utility that sets `text-align` to `center`
 

--- a/src/utilities/text/text.stories.mdx
+++ b/src/utilities/text/text.stories.mdx
@@ -8,7 +8,9 @@ import { Story, Canvas, Meta } from '@storybook/addon-docs';
 // This can be revisited in the future if Storybook no longer relies on Webpack.
 // eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import noWrapDemoSource from '!!raw-loader!./demo/nowrap.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import colorDemoSource from '!!raw-loader!./demo/color.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import textAlignDemoSource from '!!raw-loader!./demo/text-align.twig';
 import noWrapDemo from './demo/nowrap.twig';
 import colorDemo from './demo/color.twig';


### PR DESCRIPTION
## Overview

This PR adds a `u-text-center` utility CSS class.

This was introduced to help with the ["More clients we've worked with" heading](https://deploy-preview-1742--cloudfour-patterns.netlify.app/iframe.html?id=prototypes-case-study-listings--example&viewMode=story) (this is a blocker for https://github.com/cloudfour/cloudfour.com-wp/pull/682)

## Screenshots

<img width="1019" alt="Screen Shot 2022-05-05 at 2 32 23 PM" src="https://user-images.githubusercontent.com/459757/167029066-91eca963-2e36-4a09-b5fc-b80959155408.png">



## Testing

1. Review https://deploy-preview-1771--cloudfour-patterns.netlify.app/?path=/docs/utilities-text--text-align-center

---

- Closes #1772