### PR TITLE
Outdent Code Blocks

### DIFF
--- a/.changeset/flat-bobcats-lie.md
+++ b/.changeset/flat-bobcats-lie.md
@@ -1,5 +1,5 @@
 ---
-"@cloudfour/patterns": patch
+"@cloudfour/patterns": minor
 ---
 
 Outdent Code blocks so the code is aligned with page content.

--- a/.changeset/flat-bobcats-lie.md
+++ b/.changeset/flat-bobcats-lie.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": patch
+---
+
+Outdent Code blocks so the code is aligned with page content.

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,6 @@
 
 # Ignore syntax highlighting examples
 /src/vendor/prism/demo/samples
+
+# Ignore changeset files (these are temporary)
+.changeset/*

--- a/src/mixins/_spacing.scss
+++ b/src/mixins/_spacing.scss
@@ -1,4 +1,46 @@
+@use '../compiled/tokens/scss/breakpoint';
 @use '../compiled/tokens/scss/size';
+@use '../mixins/fluid';
+
+/// Fluid Spacing Mixins
+/// Used by Container and similar items to apply a consistent fluid
+/// amount of padding and margins.
+$fluid-spacing-breakpoint-min: breakpoint.$s;
+$fluid-spacing-breakpoint-max: breakpoint.$xl;
+$fluid-spacing-block-min: size.$padding-container-vertical-min;
+$fluid-spacing-block-max: size.$padding-container-vertical-max;
+$fluid-spacing-inline-min: size.$padding-container-horizontal-min;
+$fluid-spacing-inline-max: size.$padding-container-horizontal-max;
+$fluid-spacing-block: fluid.fluid-clamp(
+  $fluid-spacing-block-min,
+  $fluid-spacing-block-max,
+  $fluid-spacing-breakpoint-min,
+  $fluid-spacing-breakpoint-max
+);
+$fluid-spacing-inline: fluid.fluid-clamp(
+  $fluid-spacing-inline-min,
+  $fluid-spacing-inline-max,
+  $fluid-spacing-breakpoint-min,
+  $fluid-spacing-breakpoint-max
+);
+$fluid-spacing-inline-negative: fluid.fluid-clamp(
+  $fluid-spacing-inline-min * -1,
+  $fluid-spacing-inline-max * -1,
+  $fluid-spacing-breakpoint-min,
+  $fluid-spacing-breakpoint-max
+);
+
+@mixin fluid-padding-block() {
+  padding-block: $fluid-spacing-block;
+}
+
+@mixin fluid-padding-inline() {
+  padding-inline: $fluid-spacing-inline;
+}
+
+@mixin fluid-margin-inline-negative() {
+  margin-inline: $fluid-spacing-inline-negative;
+}
 
 /// Applies styles for a vertical rhythm layout object. Used by the `o-rhythm`
 /// pattern and for relevant Gutenberg blocks. Makes heavy use of Heydon

--- a/src/objects/container/container.scss
+++ b/src/objects/container/container.scss
@@ -1,31 +1,5 @@
-@use '../../compiled/tokens/scss/breakpoint';
 @use '../../compiled/tokens/scss/size';
-@use '../../mixins/fluid';
-
-$pad-breakpoint-min: breakpoint.$s;
-$pad-breakpoint-max: breakpoint.$xl;
-$pad-block-min: size.$padding-container-vertical-min;
-$pad-block-max: size.$padding-container-vertical-max;
-$pad-inline-min: size.$padding-container-horizontal-min;
-$pad-inline-max: size.$padding-container-horizontal-max;
-$fluid-pad-block: fluid.fluid-clamp(
-  $pad-block-min,
-  $pad-block-max,
-  $pad-breakpoint-min,
-  $pad-breakpoint-max
-);
-$fluid-pad-inline: fluid.fluid-clamp(
-  $pad-inline-min,
-  $pad-inline-max,
-  $pad-breakpoint-min,
-  $pad-breakpoint-max
-);
-$fluid-pad-inline-negative: fluid.fluid-clamp(
-  $pad-inline-min * -1,
-  $pad-inline-max * -1,
-  $pad-breakpoint-min,
-  $pad-breakpoint-max
-);
+@use '../../mixins/spacing';
 
 /**
  * There are no default styles for `o-container`. It acts as a wrapper so that
@@ -39,12 +13,12 @@ $fluid-pad-inline-negative: fluid.fluid-clamp(
 
 .o-container--pad,
 .o-container--pad-block {
-  padding-block: $fluid-pad-block;
+  @include spacing.fluid-padding-block;
 }
 
 .o-container--pad,
 .o-container--pad-inline {
-  padding-inline: $fluid-pad-inline;
+  @include spacing.fluid-padding-inline;
 }
 
 /**
@@ -75,7 +49,7 @@ $fluid-pad-inline-negative: fluid.fluid-clamp(
 .o-container__fill-pad {
   .o-container--pad &,
   .o-container--pad-inline & {
-    margin-inline: $fluid-pad-inline-negative;
+    @include spacing.fluid-margin-inline-negative;
   }
 }
 
@@ -89,6 +63,6 @@ $fluid-pad-inline-negative: fluid.fluid-clamp(
 .o-container__fill-pad {
   .o-container--pad &,
   .o-container--pad-inline & {
-    padding-inline: $fluid-pad-inline;
+    @include spacing.fluid-padding-inline;
   }
 }

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -2,6 +2,7 @@
 @use '../../compiled/tokens/scss/size';
 @use '../../mixins/fluid';
 @use '../../mixins/media-query';
+@use '../../mixins/spacing';
 @use '../container/container';
 
 /**
@@ -65,14 +66,14 @@
 /**
  * Block alignment adjustments
  *
- * 1. Set inline padding to match `o-container__fill-pad` since we don't want
- *    the deck to touch the viewport edges even when it's full bleed.
+ * 1. Set inline padding since we don't want the deck to touch the viewport
+ *    edges even when it's full bleed.
  * 2. Remove padding once `alignwide` is no longer full-bleed.
  */
 
 .o-deck.alignfull,
 .o-deck.alignwide {
-  padding-inline: container.$fluid-pad-inline; // 1
+  @include spacing.fluid-padding-inline; // 1
 }
 
 .o-deck.alignwide {

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -3,7 +3,6 @@
 @use '../../mixins/fluid';
 @use '../../mixins/media-query';
 @use '../../mixins/spacing';
-@use '../container/container';
 
 /**
  * 1. If horizontal items are shown at the wrong column count, they will appear

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -2,7 +2,7 @@
 @use '../../compiled/tokens/scss/size';
 @use '../../mixins/fluid';
 @use '../../mixins/media-query';
-@use '../container/container.scss';
+@use '../container/container';
 
 /**
  * 1. If horizontal items are shown at the wrong column count, they will appear
@@ -65,8 +65,8 @@
 /**
  * Block alignment adjustments
  *
- * 1. Set inline padding to match `o-container__fill-pad` since we don't want the deck to touch 
- *     the viewport edges even when it's full bleed.
+ * 1. Set inline padding to match `o-container__fill-pad` since we don't want
+ *    the deck to touch the viewport edges even when it's full bleed.
  * 2. Remove padding once `alignwide` is no longer full-bleed.
  */
 

--- a/src/vendor/wordpress/core-blocks.stories.mdx
+++ b/src/vendor/wordpress/core-blocks.stories.mdx
@@ -1,5 +1,6 @@
 import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
 import blockImageDemo from './demo/image.twig';
+import blockCodeDemo from './demo/code.twig';
 const alignmentClasses = {
   None: '',
   Left: 'alignleft',
@@ -96,17 +97,12 @@ and border radius.
 ## Code
 
 The code block adds the class `wp-block-code` to a `pre` tag wrapping content inside
-`code` tags.
+`code` tags. We apply the same CSS as `o-container__fill-pad` to pull the code block
+out so the code itself aligns with the page content. This also applies to fenced
+code sections in Markdown blocks.
 
 <Canvas>
-  <Story name="Code">
-    {() => {
-      const example = `* {
-  box-sizing: border-box;
-}`;
-      return `<pre class="wp-block-code"><code class="language-css">${example}</code></pre>`;
-    }}
-  </Story>
+  <Story name="Code">{() => blockCodeDemo()}</Story>
 </Canvas>
 
 ## Columns

--- a/src/vendor/wordpress/demo/code.twig
+++ b/src/vendor/wordpress/demo/code.twig
@@ -1,0 +1,15 @@
+<div
+  class="demo-container o-rhythm"
+  style="max-width: 40rem; margin: 0 auto; padding: 0 1.25rem"
+>
+  <p>Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Nullam quis risus eget urna mollis ornare vel eu leo. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec id elit non mi porta gravida at eget metus. Vestibulum id ligula porta felis euismod semper.</p>
+  <pre class="wp-block-code language-css"><code class="language-css">/* CSS */
+.card {
+  background: #f5f5f5;
+  display: inline-block;
+  margin: 0 0 1em;
+  width: 100%;
+  cursor: pointer;
+}</code></pre>
+  <p>Etiam porta sem malesuada magna mollis euismod. Maecenas sed diam eget risus varius blandit sit amet non magna. Nulla vitae elit libero, a pharetra augue. Aenean lacinia bibendum nulla sed consectetur. Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam.</p>
+</div>

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -9,6 +9,7 @@
 @use '../../../mixins/ms';
 @use '../../../mixins/table';
 @use '../../../mixins/theme';
+@use '../../../objects/container/container';
 
 /**
  * Gutenberg block: Button
@@ -92,6 +93,18 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
       color: inherit !important; /* 1 */
     }
   }
+}
+
+/**
+ * Gutenberg Block: Code
+ * Styles for Gutenberg code blocks (and code inside Markdown blocks)
+ *
+ * 1. Set inline margins to match `o-container__fill-pad` since we need
+ *    to pull the block out a bit to align code with content.
+ */
+.wp-block-code,
+.wp-block-jetpack-markdown pre {
+  margin-inline: container.$fluid-pad-inline-negative; // 1
 }
 
 /**

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -7,9 +7,9 @@
 @use '../../../mixins/button';
 @use '../../../mixins/emdash';
 @use '../../../mixins/ms';
+@use '../../../mixins/spacing';
 @use '../../../mixins/table';
 @use '../../../mixins/theme';
-@use '../../../objects/container/container';
 
 /**
  * Gutenberg block: Button
@@ -99,12 +99,13 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
  * Gutenberg Block: Code
  * Styles for Gutenberg code blocks (and code inside Markdown blocks)
  *
- * 1. Set inline margins to match `o-container__fill-pad` since we need
- *    to pull the block out a bit to align code with content.
+ * 1. Set inline margins and padding to outdent the block out a bit,
+ *    but keep the code aligned with the page content.
  */
 .wp-block-code,
 .wp-block-jetpack-markdown pre {
-  margin-inline: container.$fluid-pad-inline-negative; // 1
+  @include spacing.fluid-margin-inline-negative; // 1
+  @include spacing.fluid-padding-inline; // 1
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR updates the styles for Gutenberg Code blocks and fenced code
sections in Markdown blocks to outdent the block so the code is aligned
with the page content.

## Screenshots

<img width="1014" alt="Screen Shot 2022-05-06 at 10 34 24 AM" src="https://user-images.githubusercontent.com/257309/167183876-4968074e-6567-4066-a68e-2e5f85300d1e.png">

## Testing

1. Review the Code block section of the WordPress Core Blocks page.