### PR TITLE
Add Media object Align Start modifier

### DIFF
--- a/.changeset/green-fishes-hug.md
+++ b/.changeset/green-fishes-hug.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add Media object Align Start modifier

--- a/src/objects/media/media.scss
+++ b/src/objects/media/media.scss
@@ -28,6 +28,16 @@
 }
 
 /**
+ * Modifier: Align Start
+ *
+ * Uses `align-items: start` instead of `align-items: center`
+ */
+
+.o-media--align-start {
+  align-items: start;
+}
+
+/**
  * Modifier: Generous Gap
  *
  * Increases the size of the gap between the media object and content.

--- a/src/objects/media/media.stories.mdx
+++ b/src/objects/media/media.stories.mdx
@@ -1,4 +1,4 @@
-import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
 // The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
 // See: https://github.com/webpack-contrib/raw-loader#examples
 // For now, it seems likely Storybook is pretty tied to Webpack, therefore, we
@@ -47,6 +47,43 @@ const imageDemoTransformSource = (_src, storyContext) => {
   }}
   argTypes={{
     imgSrc: { type: { name: 'string', required: true } },
+    tag_name: {
+      type: { name: 'string' },
+      description: 'The root tag for the component',
+      table: {
+        defaultValue: {
+          summary: 'div',
+        },
+      },
+    },
+    inner_tag_name: {
+      type: { name: 'string' },
+      description:
+        'The tag for both the media content and media object elements',
+      table: {
+        defaultValue: {
+          summary: 'div',
+        },
+      },
+    },
+    content_tag_name: {
+      type: { name: 'string' },
+      description: 'The tag for both media content element',
+      table: {
+        defaultValue: {
+          summary: 'div',
+        },
+      },
+    },
+    object_tag_name: {
+      type: { name: 'string' },
+      description: 'The tag for both media object element',
+      table: {
+        defaultValue: {
+          summary: 'div',
+        },
+      },
+    },
     text: { type: { name: 'string' } },
     class: { type: { name: 'string' } },
     reverse: { type: { name: 'boolean' } },
@@ -215,3 +252,5 @@ of the same name](/docs/objects-deck--block-alignment).
     {(args) => imageDemo(args)}
   </Story>
 </Canvas>
+
+<ArgsTable story="Align Start" />

--- a/src/objects/media/media.stories.mdx
+++ b/src/objects/media/media.stories.mdx
@@ -68,19 +68,19 @@ const imageDemoTransformSource = (_src, storyContext) => {
     },
     content_tag_name: {
       type: { name: 'string' },
-      description: 'The tag for both media content element',
+      description: 'The tag for the media content element',
       table: {
         defaultValue: {
-          summary: 'div',
+          summary: '`inner_tag_name`',
         },
       },
     },
     object_tag_name: {
       type: { name: 'string' },
-      description: 'The tag for both media object element',
+      description: 'The tag for the media object element',
       table: {
         defaultValue: {
-          summary: 'div',
+          summary: '`inner_tag_name`',
         },
       },
     },
@@ -253,4 +253,20 @@ of the same name](/docs/objects-deck--block-alignment).
   </Story>
 </Canvas>
 
-<ArgsTable story="Align Start" />
+## Template Properties
+
+- `class` (string): Appends to the CSS class of the root element
+- `tag_name` (string, default `'div'`): The root tag for the component
+- `inner_tag_name` (string, default `'div'`): The tag for both the media content and media object elements
+- `object_tag_name` (string, default `inner_tag_name`): The tag for the media object element
+- `content_tag_name` (string, default `inner_tag_name`): The tag for the media content element
+- `align_start` (boolean, default `false`): Adds the `o-media--align-start` CSS class modifier
+- `jaunty` (boolean, default `false`): Adds the `o-media--jaunty` CSS class modifier
+- `generous` (boolean, default `false`): Adds the `o-media--generous` CSS class modifier
+- `reverse` (boolean, default `false`): Adds the `o-media--reverse` CSS class modifier
+- `reverse_markup` (boolean, default `false`): Flips the order of the object and content markup so that the content is first
+
+## Template Blocks
+
+- `object`: Block for the static object (the image, checkbox, etc.)
+- `content`: Block for the wrapping content (typically text)

--- a/src/objects/media/media.stories.mdx
+++ b/src/objects/media/media.stories.mdx
@@ -176,12 +176,15 @@ By adding the `o-media--jaunty` class, the media object will have a fun little r
   </Story>
 </Canvas>
 
-## Align Start
+## Alignment
 
-By adding the `o-media--align-start` class, the media object will use `align-items: start`.
-This can come in handy when the content is vertically shorter than the object
-and there are multiple Media objects side-by-side with varying content.
-It provides a way to visually align the multiple Media objects.
+By default, the Media object optimizes its alignment based on its content alone.
+This may result in inconsistent alignment when multiple Media objects with
+inconsistent content lengths are displayed side by side.
+
+You may add the `o-media--align-start` modifier to force consistent alignment
+between adjacent Media objects. This pairs nicely with [the Deck object modifier
+of the same name](/docs/objects-deck--block-alignment).
 
 <Canvas>
   <Story

--- a/src/objects/media/media.stories.mdx
+++ b/src/objects/media/media.stories.mdx
@@ -1,4 +1,4 @@
-import { Story, Canvas, Meta, ArgsTable } from '@storybook/addon-docs';
+import { Story, Canvas, Meta } from '@storybook/addon-docs';
 // The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
 // See: https://github.com/webpack-contrib/raw-loader#examples
 // For now, it seems likely Storybook is pretty tied to Webpack, therefore, we

--- a/src/objects/media/media.stories.mdx
+++ b/src/objects/media/media.stories.mdx
@@ -175,3 +175,40 @@ By adding the `o-media--jaunty` class, the media object will have a fun little r
     {(args) => imageDemo(args)}
   </Story>
 </Canvas>
+
+## Align Start
+
+By adding the `o-media--align-start` class, the media object will use `align-items: start`.
+This can come in handy when the content is vertically shorter than the object
+and there are multiple Media objects side-by-side with varying content.
+It provides a way to visually align the multiple Media objects.
+
+<Canvas>
+  <Story
+    name="Align Default"
+    args={{
+      text: 'Default alignment',
+    }}
+    parameters={{
+      docs: {
+        transformSource: imageDemoTransformSource,
+      },
+    }}
+  >
+    {(args) => imageDemo(args)}
+  </Story>
+  <Story
+    name="Align Start"
+    args={{
+      align_start: true,
+      text: 'Align start alignment',
+    }}
+    parameters={{
+      docs: {
+        transformSource: imageDemoTransformSource,
+      },
+    }}
+  >
+    {(args) => imageDemo(args)}
+  </Story>
+</Canvas>

--- a/src/objects/media/media.twig
+++ b/src/objects/media/media.twig
@@ -26,7 +26,7 @@
 {#
   Vary where `object_block` outputs based on the `reverse_markup` property.
 #}
-<{{ tag_name }} class="o-media{% if jaunty %} o-media--jaunty{% endif %}{% if generous %} o-media--generous{% endif %}{% if reverse %} o-media--reverse{% endif %}{% if class %} {{ class }}{% endif %}">
+<{{ tag_name }} class="o-media{% if align_start %} o-media--align-start{% endif %}{% if jaunty %} o-media--jaunty{% endif %}{% if generous %} o-media--generous{% endif %}{% if reverse %} o-media--reverse{% endif %}{% if class %} {{ class }}{% endif %}">
   {% if not reverse_markup %}
     {{ object_block }}
   {% endif %}


### PR DESCRIPTION
## Overview

This PR proposes adding an `o-media--align-start` modifier. See #1792 for an example use case.


## Screenshots

<img width="735" alt="Screen Shot 2022-05-12 at 5 34 33 AM" src="https://user-images.githubusercontent.com/459757/168076465-035090c1-37cb-4fbd-964b-95bcd7e973b1.png">

## Testing

1. Review https://deploy-preview-1791--cloudfour-patterns.netlify.app/?path=/docs/objects-media--align-start#align-start

---

- Closes #1792
