### PR TITLE
Fix double scrollbar issue

### DIFF
--- a/.changeset/forty-bottles-move.md
+++ b/.changeset/forty-bottles-move.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix double-scrollbar issue

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -47,7 +47,6 @@ ul {
   margin: 0;
 }
 
-
 /**
  * 1. Forces the viewport to be filled. Necessary for the footer to
  *    "stick" to the bottom of short pages.
@@ -62,7 +61,8 @@ html {
  *    @see https://cloudfour.com/thinks/breaking-out-with-viewport-units-and-calc/
  */
 
-html, body {
+html,
+body {
   overflow-x: hidden; // 1
 }
 

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -47,13 +47,22 @@ ul {
   margin: 0;
 }
 
+
+/**
+ * 1. Forces the viewport to be filled. Necessary for the footer to
+ *    "stick" to the bottom of short pages.
+ *    @see https://css-tricks.com/couple-takes-sticky-footer/#there-is-grid
+ */
+html {
+  block-size: 100%; // 1
+}
+
 /**
  * 1. Keep full-bleed items from triggering a horizontal scrollbar.
  *    @see https://cloudfour.com/thinks/breaking-out-with-viewport-units-and-calc/
  */
 
-html,
-body {
+html, body {
   overflow-x: hidden; // 1
 }
 

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -48,17 +48,13 @@ ul {
 }
 
 /**
- * 1. Forces the viewport to be filled. Necessary for the footer to
- *    "stick" to the bottom of short pages.
- *    @see https://css-tricks.com/couple-takes-sticky-footer/#there-is-grid
- * 2. Keep full-bleed items from triggering a horizontal scrollbar.
+ * 1. Keep full-bleed items from triggering a horizontal scrollbar.
  *    @see https://cloudfour.com/thinks/breaking-out-with-viewport-units-and-calc/
  */
 
 html,
 body {
-  block-size: 100%; // 1
-  overflow-x: hidden; // 2
+  overflow-x: hidden; // 1
 }
 
 /**

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -3,16 +3,16 @@
  *
  * 1. Avoid grid blowouts by specifying the `min-width` of the column.
  *    @see https://css-tricks.com/you-want-minmax10px-1fr-not-1fr/
- * 2. Attempts to fill the available area
- *    & keep the footer at the bottom of that area.
- *    @see https://css-tricks.com/couple-takes-sticky-footer/#aa-there-is-grid
+ * 2. Attempts to fill the available area (assuming `height: 100%` is applied
+ *    to all parent elements) & keep the footer at the bottom of that area.
+ *    @see https://css-tricks.com/couple-takes-sticky-footer/#there-is-grid
  */
 
 .o-page {
   display: grid;
   grid-template-columns: minmax(0, 1fr); // 1
   grid-template-rows: 1fr auto; // 2
-  min-block-size: 100vh;
+  min-block-size: 100%;
 }
 
 /**

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -3,16 +3,16 @@
  *
  * 1. Avoid grid blowouts by specifying the `min-width` of the column.
  *    @see https://css-tricks.com/you-want-minmax10px-1fr-not-1fr/
- * 2. Attempts to fill the available area (assuming `height: 100%` is applied
- *    to all parent elements) & keep the footer at the bottom of that area.
- *    @see https://css-tricks.com/couple-takes-sticky-footer/#there-is-grid
+ * 2. Attempts to fill the available area
+ *    & keep the footer at the bottom of that area.
+ *    @see https://css-tricks.com/couple-takes-sticky-footer/#aa-there-is-grid
  */
 
 .o-page {
   display: grid;
   grid-template-columns: minmax(0, 1fr); // 1
   grid-template-rows: 1fr auto; // 2
-  min-block-size: 100%;
+  min-block-size: 100vh;
 }
 
 /**


### PR DESCRIPTION
## Overview

Closes #1754

- Fixes the double-scrollbar issue
- Preserves the "pin to bottom" behavior of the footer for short pages

In order to reproduce this issue you must set the visible scrollbars macos option:

<img src="https://user-images.githubusercontent.com/13206945/170148147-164d3726-73b5-4e80-ad1a-4ea6c445f274.png" width=600/>

## Testing

- Get your local wp running
- Link your `@cloudfour/patterns` in the wp site to your local copy:
  - Go to your local repo copy of `@cloudfour/patterns`
  - `git checkout fix-double-scrollbar`
  - `npm run build`
  - `npm link` - this sets up a global symlink to this copy of the repo
  - Go to your local wp folder
  - `cd app/public/wp-content/themes/cloudfour2021`
  - `npm link @cloudfour/patterns` - this sets up that folder in node_modules to be symlinked to your local copy of the repo.
- Hard-refresh pages in the browser to make sure the new CSS is read through the symlinks
- Test a short page (that the footer stays pinned to the bottom): https://cloudfour.local/contributes/ (for comparison, [on c4dev](https://c4dev.wpengine.com/contributes/))
- Test a long page (that only one scrollbar shows up) https://cloudfour.local/thinks/faster-integration-with-web-components/ (for comparison, [on c4dev](https://c4dev.wpengine.com/thinks/faster-integration-with-web-components/))
- Test more if you want