### PR TITLE
Allow customizing `tag_name` for deck object

### DIFF
--- a/.changeset/cyan-pots-divide.md
+++ b/.changeset/cyan-pots-divide.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Allow passing `tag_name` to deck object

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -76,6 +76,15 @@ const alignmentClasses = {
       type: { name: 'string' },
       control: { type: 'inline-radio' },
     },
+    tag_name: {
+      type: { name: 'string' },
+      description: 'The root tag for the component',
+      table: {
+        defaultValue: {
+          summary: 'div',
+        },
+      },
+    },
   }}
 />
 

--- a/src/objects/deck/deck.twig
+++ b/src/objects/deck/deck.twig
@@ -1,3 +1,5 @@
-<div class="o-deck{% if class %} {{ class }}{% endif %}">
+{% set tag_name = tag_name|default('div') %}
+
+<{{ tag_name }} class="o-deck{% if class %} {{ class }}{% endif %}">
   {% block content %}{% endblock %}
-</div>
+</{{ tag_name }}>


### PR DESCRIPTION
## Overview

Closes #1770. I will send a follow-up PR to cloudfour.com-wp.

## Testing

[Deploy preview](https://deploy-preview-1804--cloudfour-patterns.netlify.app/?path=/story/objects-deck--basic), check that changing the `tag_name` prop actually changes the tag name.