### PR TITLE
Add Core Element Comparison Stories

### DIFF
--- a/.changeset/perfect-rats-raise.md
+++ b/.changeset/perfect-rats-raise.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": patch
+---
+
+Update styles for vanilla blockquotes and tables in Markdown blocks, HTML blocks, and legacy posts to match Gutenberg block styles.

--- a/.changeset/perfect-rats-raise.md
+++ b/.changeset/perfect-rats-raise.md
@@ -1,5 +1,5 @@
 ---
-"@cloudfour/patterns": patch
+"@cloudfour/patterns": minor
 ---
 
 Update styles for vanilla blockquotes and tables in Markdown blocks, HTML blocks, and legacy posts to match Gutenberg block styles.

--- a/src/vendor/wordpress/core-element-comparison.stories.mdx
+++ b/src/vendor/wordpress/core-element-comparison.stories.mdx
@@ -1,0 +1,34 @@
+import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import MarkdownDemo from './demo/compare-markdown.twig';
+import HTMLDemo from './demo/compare-html.twig';
+import GutenbergDemo from './demo/compare-gutenberg.twig';
+
+<Meta title="Vendor/WordPress/Core Element Comparison" />
+
+# Comparing Core Element Rendering
+
+Some native HTML elements, like `blockquote` and `table` can be added by multiple means, including legacy blog posts containing Classic blocks with markup, HTML blocks, Markdown blocks, and core WordPress blocks.
+
+This page compares how they render so we can ensure things work the same way across the board.
+
+## Markdown Block
+
+<Canvas>
+  <Story name="Markdown">{() => MarkdownDemo()}</Story>
+</Canvas>
+
+## HTML Block
+
+This is a block containing raw HTML markup. It also represents legacy blog posts containing Classic blocks. Even when those blog posts were originally written in Markdown, the Classic block converts them to raw HTML.
+
+<Canvas>
+  <Story name="HTML">{() => HTMLDemo()}</Story>
+</Canvas>
+
+## Gutenberg blocks
+
+This shows the same set of elements created using core WordPress blocks.
+
+<Canvas>
+  <Story name="Gutenberg">{() => GutenbergDemo()}</Story>
+</Canvas>

--- a/src/vendor/wordpress/demo/compare-gutenberg.twig
+++ b/src/vendor/wordpress/demo/compare-gutenberg.twig
@@ -1,0 +1,80 @@
+<div
+  class="demo-container o-rhythm"
+  style="max-width: 40rem; margin: 0 auto; padding: 0 1.25rem"
+>
+  <h1>Heading Level 1</h1>
+  <h2>Heading Level 2</h2>
+  <h3>Heading Level 3</h3>
+  <h4>Heading Level 4</h4>
+  <h5>Heading Level 5</h5>
+  <h6>Heading Level 6</h6>
+
+  <p>
+    This is a paragraph. It contains some&nbsp;<em>italic text</em>,
+    some&nbsp;<strong>bold text</strong>, some&nbsp;<em
+      ><strong>bold and italic text</strong></em
+    >, and some inline&nbsp;<code>code</code>, and a&nbsp;<a
+      href="https://example.com/"
+      >link</a
+    >.
+  </p>
+
+  <pre class="wp-block-code"><code>.code-block { color: hotpink; }</code></pre>
+
+  <blockquote class="wp-block-quote"><p>Here’s a blockquote</p></blockquote>
+
+  <ul>
+    <li>Alpha</li>
+    <li>
+      Beta
+      <ul>
+        <li>Beta A</li>
+        <li>Beta B</li>
+      </ul>
+    </li>
+    <li>Gamma</li>
+  </ul>
+
+  <ol>
+    <li>Alpha</li>
+    <li>
+      Beta
+      <ol>
+        <li>Beta A</li>
+        <li>Beta B</li>
+      </ol>
+    </li>
+    <li>Gamma</li>
+  </ol>
+
+  <figure class="wp-block-table">
+    <table>
+      <thead>
+        <tr>
+          <th>First Header</th>
+          <th>Second Header</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Content Cell</td>
+          <td>Content Cell</td>
+        </tr>
+        <tr>
+          <td>Content Cell</td>
+          <td>Content Cell</td>
+        </tr>
+      </tbody>
+    </table>
+  </figure>
+
+  <p>Here’s an image:</p>
+
+  <figure class="wp-block-image size-large">
+    <img src="https://api.lorem.space/image/movie?w=150&amp;h=220&t=3" alt="" />
+  </figure>
+
+  <p>And to wrap it all up, here’s a horizontal rule:</p>
+
+  <hr class="wp-block-separator" />
+</div>

--- a/src/vendor/wordpress/demo/compare-gutenberg.twig
+++ b/src/vendor/wordpress/demo/compare-gutenberg.twig
@@ -21,7 +21,10 @@
 
   <pre class="wp-block-code"><code>.code-block { color: hotpink; }</code></pre>
 
-  <blockquote class="wp-block-quote"><p>Here’s a blockquote</p></blockquote>
+  <blockquote class="wp-block-quote">
+    <p>Here’s a blockquote</p>
+    <cite>with a citation</cite>
+  </blockquote>
 
   <ul>
     <li>Alpha</li>

--- a/src/vendor/wordpress/demo/compare-html.twig
+++ b/src/vendor/wordpress/demo/compare-html.twig
@@ -1,5 +1,5 @@
 <div
-  class="demo-container o-rhythm"
+  class="demo-container o-rhythm legacy-post"
   style="max-width: 40rem; margin: 0 auto; padding: 0 1.25rem"
 >
   <h1>Heading Level 1</h1>
@@ -18,6 +18,7 @@
   <pre><code>.code-block { color: hotpink; }</code></pre>
   <blockquote>
     <p>Here’s a blockquote</p>
+    <cite>with a citation</cite>
   </blockquote>
   <ul>
     <li>Alpha</li>

--- a/src/vendor/wordpress/demo/compare-html.twig
+++ b/src/vendor/wordpress/demo/compare-html.twig
@@ -1,0 +1,71 @@
+<div
+  class="demo-container o-rhythm"
+  style="max-width: 40rem; margin: 0 auto; padding: 0 1.25rem"
+>
+  <h1>Heading Level 1</h1>
+  <h2>Heading Level 2</h2>
+  <h3>Heading Level 3</h3>
+  <h4>Heading Level 4</h4>
+  <h5>Heading Level 5</h5>
+  <h6>Heading Level 6</h6>
+  <p>
+    This is a paragraph. It contains some <em>italic text</em>, some
+    <strong>bold text</strong>, some
+    <em><strong>bold and italic text</strong></em
+    >, and some inline <code>code</code>, and a
+    <a href="https://example.com">link</a>.
+  </p>
+  <pre><code>.code-block { color: hotpink; }</code></pre>
+  <blockquote>
+    <p>Here’s a blockquote</p>
+  </blockquote>
+  <ul>
+    <li>Alpha</li>
+    <li>
+      Beta
+      <ul>
+        <li>Beta A</li>
+        <li>Beta B</li>
+      </ul>
+    </li>
+    <li>Gamma</li>
+  </ul>
+  <ol>
+    <li>Alpha</li>
+    <li>
+      Beta
+      <ol>
+        <li>Beta A</li>
+        <li>Beta B</li>
+      </ol>
+    </li>
+    <li>Gamma</li>
+  </ol>
+  <table>
+    <thead>
+      <tr>
+        <th>First Header</th>
+        <th>Second Header</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Content Cell</td>
+        <td>Content Cell</td>
+      </tr>
+      <tr>
+        <td>Content Cell</td>
+        <td>Content Cell</td>
+      </tr>
+    </tbody>
+  </table>
+  <p>Here’s an image:</p>
+  <p>
+    <img
+      src="https://api.lorem.space/image/movie?w=150&amp;h=220&amp;t=2"
+      alt="Movie Poster"
+    />
+  </p>
+  <p>And to wrap it all up, here’s a horizontal rule:</p>
+  <hr />
+</div>

--- a/src/vendor/wordpress/demo/compare-markdown.twig
+++ b/src/vendor/wordpress/demo/compare-markdown.twig
@@ -20,6 +20,7 @@
   ><code class="language-css">.code-block { color: hotpink; }</code></pre>
   <blockquote>
     <p>Here’s a blockquote</p>
+    <cite>with a citation</cite>
   </blockquote>
   <ul>
     <li>Alpha</li>

--- a/src/vendor/wordpress/demo/compare-markdown.twig
+++ b/src/vendor/wordpress/demo/compare-markdown.twig
@@ -1,0 +1,73 @@
+<div
+  class="demo-container o-rhythm wp-block-jetpack-markdown"
+  style="max-width: 40rem; margin: 0 auto; padding: 0 1.25rem"
+>
+  <h1>Heading Level 1</h1>
+  <h2>Heading Level 2</h2>
+  <h3>Heading Level 3</h3>
+  <h4>Heading Level 4</h4>
+  <h5>Heading Level 5</h5>
+  <h6>Heading Level 6</h6>
+  <p>
+    This is a paragraph. It contains some <em>italic text</em>, some
+    <strong>bold text</strong>, some
+    <em><strong>bold and italic text</strong></em
+    >, and some inline <code>code</code>, and a
+    <a href="https://example.com">link</a>.
+  </p>
+  <pre
+    class="language-css"
+  ><code class="language-css">.code-block { color: hotpink; }</code></pre>
+  <blockquote>
+    <p>Here’s a blockquote</p>
+  </blockquote>
+  <ul>
+    <li>Alpha</li>
+    <li>
+      Beta
+      <ul>
+        <li>Beta A</li>
+        <li>Beta B</li>
+      </ul>
+    </li>
+    <li>Gamma</li>
+  </ul>
+  <ol>
+    <li>Alpha</li>
+    <li>
+      Beta
+      <ol>
+        <li>Beta A</li>
+        <li>Beta B</li>
+      </ol>
+    </li>
+    <li>Gamma</li>
+  </ol>
+  <table>
+    <thead>
+      <tr>
+        <th>First Header</th>
+        <th>Second Header</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Content Cell</td>
+        <td>Content Cell</td>
+      </tr>
+      <tr>
+        <td>Content Cell</td>
+        <td>Content Cell</td>
+      </tr>
+    </tbody>
+  </table>
+  <p>Here’s an image:</p>
+  <p>
+    <img
+      src="https://api.lorem.space/image/movie?w=150&amp;h=220&amp;t=1"
+      alt="Movie Poster"
+    />
+  </p>
+  <p>And to wrap it all up, here’s a horizontal rule:</p>
+  <hr />
+</div>

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -105,7 +105,8 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
  *    to use overflow to scroll.
  */
 .wp-block-code,
-.wp-block-jetpack-markdown pre {
+.wp-block-jetpack-markdown pre,
+.legacy-post pre {
   @include spacing.fluid-margin-inline-negative; // 1
   @include spacing.fluid-padding-inline; // 1
 

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -150,26 +150,34 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
 
 /**
  * Default table
+ *
+ * Note that this only targets tables in the Table block, the Markdown block,
+ * and in legacy post content. If you add a table manually in an HTML block,
+ * you should add the `c-table` class, which will apply the same styles.
  */
-.wp-block-table table td,
-.wp-block-table table th {
-  @include table.t-container;
-}
+.wp-block-table,
+.wp-block-jetpack-markdown,
+.legacy-post {
+  table td,
+  table th {
+    @include table.t-container;
+  }
 
-.wp-block-table table th {
-  @include table.t-heading;
-}
+  table th {
+    @include table.t-heading;
+  }
 
-.wp-block-table table thead {
-  @include table.t-head;
-}
+  table thead {
+    @include table.t-head;
+  }
 
-.wp-block-table table tfoot {
-  @include table.t-foot;
-}
+  table tfoot {
+    @include table.t-foot;
+  }
 
-.wp-block-table table caption {
-  @include table.t-caption;
+  table caption {
+    @include table.t-caption;
+  }
 }
 
 /**
@@ -197,10 +205,16 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
 /**
  * Quote and Pull-quote
  * Styles for quotes and pull-quotes
+ *
+ * Note the `:not(.wp-block-pullquote) > blockquote` selectors are to
+ * target vanilla `blockquote` elements in Markdown and HTML blocks.
+ * We need to ensure they're not in a Pull Quote block so the standard
+ * blockquote styles don't collide with the Pull Quote styles.
  */
 
 .wp-block-pullquote,
-.wp-block-quote {
+.wp-block-quote,
+:not(.wp-block-pullquote) > blockquote {
   color: var(--theme-color-text-muted);
 }
 
@@ -233,7 +247,8 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
  */
 
 .wp-block-pullquote cite,
-.wp-block-quote cite {
+.wp-block-quote cite,
+:not(.wp-block-pullquote) > blockquote cite {
   display: block; /* 1 */
   font-style: normal;
 }
@@ -243,7 +258,8 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
  */
 
 .wp-block-pullquote cite::before,
-.wp-block-quote cite::before {
+.wp-block-quote cite::before,
+:not(.wp-block-pullquote) > blockquote cite::before {
   @include emdash.content;
 }
 
@@ -276,7 +292,8 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
   }
 }
 
-.wp-block-quote {
+.wp-block-quote,
+:not(.wp-block-pullquote) > blockquote {
   border-inline-start: size.$border-width-blockquote solid
     var(--theme-color-border-text-group);
 }


### PR DESCRIPTION
## Overview

This PR adds a new "Core Element Comparison" set of stories to the
WordPress section. These stories compare how we style core HTML
elements added via Markdown blocks, HTML blocks, and Gutenberg blocks.
We want them to have the same (or very comparable) styles.

Next steps: I will create a followup PR for the WordPress theme to tweak a few editor styles (notably, the Blockquote block has no styles applied to it, and is indistinguishable from plain text).

## Testing

On the preview deploy, visit the new "WordPress > Core Element Comparison" page, and verify that the styles for all the elements show matches.

Known issue: The image block is center aligned by default, while standard images are not. This is fine, since most images in our blocks use alignment utility classes as needed.

---

- Fixes #1522