### PR TITLE
Responsively grow comment reply buttons

### DIFF
--- a/.changeset/empty-lemons-knock.md
+++ b/.changeset/empty-lemons-knock.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Responsively grow comment reply buttons

--- a/src/components/comment-form/comment-form.scss
+++ b/src/components/comment-form/comment-form.scss
@@ -18,3 +18,9 @@
     grid-column: span 1;
   }
 }
+
+@media (min-width: size.$breakpoint-m) {
+  .c-comment-form__reply-buttons {
+    justify-self: start;
+  }
+}

--- a/src/components/comment-form/comment-form.twig
+++ b/src/components/comment-form/comment-form.twig
@@ -62,7 +62,7 @@
     <span class="o-media__content">Notify me of follow-up comments by email.</span>
   </label>
   {% if is_reply %}
-    {% embed '@cloudfour/objects/button-group/button-group.twig' only %}
+    {% embed '@cloudfour/objects/button-group/button-group.twig' with { grow: true, class: 'c-comment-form__reply-buttons' } only %}
       {% block content %}
         {% include '@cloudfour/components/button/button.twig' with { label: 'Submit Reply' } only %}
         {% include '@cloudfour/components/button/button.twig' with { label: 'Cancel', class: 'c-button--secondary js-cancel-reply', type: 'button' } only %}


### PR DESCRIPTION
## Overview

Closes #1312

## Screenshots

Smaller screens:
<img width="496" alt="Screen Shot 2022-05-25 at 4 06 33 PM" src="https://user-images.githubusercontent.com/13206945/170383690-5752cc11-e6c4-490b-9072-d00bcccf968e.png">

Larger screens:
<img width="720" alt="Screen Shot 2022-05-25 at 4 07 10 PM" src="https://user-images.githubusercontent.com/13206945/170383737-0d0b7c36-57c5-4167-9c2a-afb3d21f26c7.png">


## Testing

