### PR TITLE
Use custom property for social icon size

### DIFF
--- a/.changeset/rich-jobs-fold.md
+++ b/.changeset/rich-jobs-fold.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Corrected the size of the social icons in the Ground Nav component

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -103,7 +103,7 @@ $_ground-nav-border-color: color.$base-gray-light;
 }
 
 .c-ground-nav__social-icon {
-  font-size: ms.step(2);
+  --icon-size: #{size.$icon-large};
 }
 
 .c-ground-nav__menu {


### PR DESCRIPTION
## Overview

Switches from using `font-size` to `--icon-size` to define the social icon size. This fixes an issue where the `font-size` was not respected because Ground Nav's CSS include is alphabetically before the Icon component's.

Alternatively I could have moved the sizing to another element, but I think I may create a second issue for cleaning up this component's structure a bit in general (there seem to be some unused classes and such as well).

I also replaced the use of a mixin to generate the size with a design token (which did not exist at the time).

## Screenshots

### Before

<img width="1012" alt="Screen Shot 2022-06-09 at 3 41 43 PM" src="https://user-images.githubusercontent.com/69633/172957498-61e06c9f-9863-4e6e-8bbb-49c16399405a.png">

### After

<img width="1006" alt="Screen Shot 2022-06-09 at 3 41 19 PM" src="https://user-images.githubusercontent.com/69633/172957516-a73ff33d-6f37-4e8a-adcd-cedc586ca48d.png">

---

- Fixes #1821 