### PR TITLE
Update Markup Structure for Cloud Cover

### DIFF
--- a/src/components/cloud-cover/cloud-cover.stories.mdx
+++ b/src/components/cloud-cover/cloud-cover.stories.mdx
@@ -25,23 +25,19 @@ A containing element for introductory page content, for example a heading and su
     parameters={{
       docs: {
         source: {
-          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
-  {% block content %}
-    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
-      class: 'o-rhythm--condensed'
+          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
+  {% block heading %}
+    {% include '@cloudfour/components/heading/heading.twig' with {
+      level: -2,
+      content: 'Our Team'
     } only %}
-      {% block content %}
-        {% include '@cloudfour/components/heading/heading.twig' with {
-          level: -2,
-          content: 'Our Team'
-        } only %}
-        <p>
-          We are a small, versatile team who care passionately about the web.
-          We’re full of what our industry considers unicorns. Our designers
-          code. Our developers went to art school.
-        </p>
-      {% endblock %}
-    {% endembed %}
+  {% endblock %}
+  {% block content %}
+    <p>
+      We are a small, versatile team who care passionately about the web.
+      We’re full of what our industry considers unicorns. Our designers
+      code. Our developers went to art school.
+    </p>
   {% endblock %}
 {% endembed %}`,
         },
@@ -63,27 +59,23 @@ The cloud cover may optionally contain a "scene" containing a visual object, mos
     parameters={{
       docs: {
         source: {
-          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
-  {% block content %}
-    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
-      class: 'o-rhythm--condensed'
+          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
+  {% block heading %}
+    {% include '@cloudfour/components/heading/heading.twig' with {
+      level: -2,
+      content: 'What We Do'
     } only %}
-      {% block content %}
-        {% include '@cloudfour/components/heading/heading.twig' with {
-          level: -2,
-          content: 'What We Do'
-        } only %}
-        <p>
-          We
-          {% include '@cloudfour/components/icon/icon.twig' with {
-            name: 'heart',
-            inline: true
-          } only %}
-          <span class="u-hidden-visually">love</span>
-          solving tough puzzles through design and&nbsp;code.
-        </p>
-      {% endblock %}
-    {% endembed %}
+  {% endblock %}
+  {% block content %}
+    <p>
+      We
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'heart',
+        inline: true
+      } only %}
+      <span class="u-hidden-visually">love</span>
+      solving tough puzzles through design and&nbsp;code.
+    </p>
   {% endblock %}
   {% block scene %}
     <img class="c-cloud-cover__scene-object" src="./path/robot.svg" alt="">
@@ -106,29 +98,23 @@ The `c-cloud-cover--horizon-scene` modifier applies an alternate composition ide
     parameters={{
       docs: {
         source: {
-          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' with {
-  class: 'c-cloud-cover--horizon-scene'
-} only %}
-  {% block content %}
-    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
-      class: 'o-rhythm--condensed'
+          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
+  {% block heading %}
+    {% include '@cloudfour/components/heading/heading.twig' with {
+      level: -2,
+      content: 'What We Do'
     } only %}
-      {% block content %}
-        {% include '@cloudfour/components/heading/heading.twig' with {
-          level: -2,
-          content: 'What We Do'
-        } only %}
-        <p>
-          We
-          {% include '@cloudfour/components/icon/icon.twig' with {
-            name: 'heart',
-            inline: true
-          } only %}
-          <span class="u-hidden-visually">love</span>
-          solving tough puzzles through design and&nbsp;code.
-        </p>
-      {% endblock %}
-    {% endembed %}
+  {% endblock %}
+  {% block content %}
+    <p>
+      We
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'heart',
+        inline: true
+      } only %}
+      <span class="u-hidden-visually">love</span>
+      solving tough puzzles through design and&nbsp;code.
+    </p>
   {% endblock %}
   {% block scene %}
     <img class="c-cloud-cover__scene-object" src="./path/flag.svg" alt="">
@@ -153,27 +139,23 @@ You can also include supporting elements like newsletter sign-up forms, notifica
     parameters={{
       docs: {
         source: {
-          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' only %}
-  {% block content %}
-    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
-      class: 'o-rhythm--condensed'
+          code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
+  {% block heading %}
+    {% include '@cloudfour/components/heading/heading.twig' with {
+      level: -2,
+      content: 'What We Do'
     } only %}
-      {% block content %}
-        {% include '@cloudfour/components/heading/heading.twig' with {
-          level: -2,
-          content: 'What We Do'
-        } only %}
-        <p>
-          We
-          {% include '@cloudfour/components/icon/icon.twig' with {
-            name: 'heart',
-            inline: true
-          } only %}
-          <span class="u-hidden-visually">love</span>
-          solving tough puzzles through design and&nbsp;code.
-        </p>
-      {% endblock %}
-    {% endembed %}
+  {% endblock %}
+  {% block content %}
+    <p>
+      We
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'heart',
+        inline: true
+      } only %}
+      <span class="u-hidden-visually">love</span>
+      solving tough puzzles through design and&nbsp;code.
+    </p>
   {% endblock %}
   {% block extra %}
     <p>(Imagine a nifty newsletter signup form here 👀)</p>

--- a/src/components/cloud-cover/cloud-cover.twig
+++ b/src/components/cloud-cover/cloud-cover.twig
@@ -5,8 +5,14 @@
   <div class="o-container o-container--pad-inline">
     <div class="o-container__content c-cloud-cover__inner">
       <div class="c-cloud-cover__content">
-        {% block content %}
-        {% endblock %}
+        <div class="o-rhythm o-rhythm--condensed">
+          <div class="c-cloud-cover__heading">
+            {% block heading %}{% endblock %}
+          </div>
+          <div class="c-cloud-cover__copy">
+            {% block content %}{% endblock %}
+          </div>
+        </div>
       </div>
       {% if _extra_block is not empty %}
         <div class="c-cloud-cover__extra">

--- a/src/components/cloud-cover/cloud-cover.twig
+++ b/src/components/cloud-cover/cloud-cover.twig
@@ -1,3 +1,5 @@
+{% set _heading_block %}{% block heading %}{% endblock %}{% endset %}
+{% set _content_block %}{% block content %}{% endblock %}{% endset %}
 {% set _extra_block %}{% block extra %}{% endblock %}{% endset %}
 {% set _scene_block %}{% block scene %}{% endblock %}{% endset %}
 
@@ -5,14 +7,20 @@
   <div class="o-container o-container--pad-inline">
     <div class="o-container__content c-cloud-cover__inner">
       <div class="c-cloud-cover__content">
-        <div class="o-rhythm o-rhythm--condensed">
-          <div class="c-cloud-cover__heading">
-            {% block heading %}{% endblock %}
-          </div>
-          <div class="c-cloud-cover__copy">
-            {% block content %}{% endblock %}
-          </div>
-        </div>
+        {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
+          class: 'o-rhythm--condensed',
+          _heading_block: _heading_block,
+          _content_block: _content_block
+        } only %}
+          {% block content %}
+            <div class="c-cloud-cover__heading">
+             {{ _heading_block }}
+            </div>
+            <div class="c-cloud-cover__copy">
+             {{ _content_block }}
+            </div>
+          {% endblock %}
+        {% endembed %}
       </div>
       {% if _extra_block is not empty %}
         <div class="c-cloud-cover__extra">

--- a/src/components/cloud-cover/demo/content.twig
+++ b/src/components/cloud-cover/demo/content.twig
@@ -1,19 +1,15 @@
 {% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
-  {% block content %}
-    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
-      class: 'o-rhythm--condensed'
+  {% block heading %}
+    {% include '@cloudfour/components/heading/heading.twig' with {
+      level: -2,
+      content: 'Our Team'
     } only %}
-      {% block content %}
-        {% include '@cloudfour/components/heading/heading.twig' with {
-          level: -2,
-          content: 'Our Team'
-        } only %}
-        <p class="cloud-cover__description">
-          We are a small, versatile team who care passionately about the web.
-          We’re full of what our industry considers unicorns. Our designers
-          code. Our developers went to art school.
-        </p>
-      {% endblock %}
-    {% endembed %}
+  {% endblock %}
+  {% block content %}
+    <p>
+      We are a small, versatile team who care passionately about the web.
+      We’re full of what our industry considers unicorns. Our designers
+      code. Our developers went to art school.
+    </p>
   {% endblock %}
 {% endembed %}

--- a/src/components/cloud-cover/demo/extra.twig
+++ b/src/components/cloud-cover/demo/extra.twig
@@ -1,24 +1,20 @@
 {% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
-  {% block content %}
-    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
-      class: 'o-rhythm--condensed'
+  {% block heading %}
+    {% include '@cloudfour/components/heading/heading.twig' with {
+      level: -2,
+      content: 'What We Do'
     } only %}
-      {% block content %}
-        {% include '@cloudfour/components/heading/heading.twig' with {
-          level: -2,
-          content: 'What We Do'
-        } only %}
-        <p>
-          We
-          {% include '@cloudfour/components/icon/icon.twig' with {
-            name: 'heart',
-            inline: true
-          } only %}
-          <span class="u-hidden-visually">love</span>
-          solving tough puzzles through design and&nbsp;code.
-        </p>
-      {% endblock %}
-    {% endembed %}
+  {% endblock %}
+  {% block content %}
+    <p>
+      We
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'heart',
+        inline: true
+      } only %}
+      <span class="u-hidden-visually">love</span>
+      solving tough puzzles through design and&nbsp;code.
+    </p>
   {% endblock %}
   {% block extra %}
     <p>(Imagine a nifty newsletter signup form here 👀)</p>

--- a/src/components/cloud-cover/demo/scene.twig
+++ b/src/components/cloud-cover/demo/scene.twig
@@ -1,24 +1,20 @@
 {% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
-  {% block content %}
-    {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
-      class: 'o-rhythm--condensed'
+  {% block heading %}
+    {% include '@cloudfour/components/heading/heading.twig' with {
+      level: -2,
+      content: 'What We Do'
     } only %}
-      {% block content %}
-        {% include '@cloudfour/components/heading/heading.twig' with {
-          level: -2,
-          content: 'What We Do'
-        } only %}
-        <p>
-          We
-          {% include '@cloudfour/components/icon/icon.twig' with {
-            name: 'heart',
-            inline: true
-          } only %}
-          <span class="u-hidden-visually">love</span>
-          solving tough puzzles through design and&nbsp;code.
-        </p>
-      {% endblock %}
-    {% endembed %}
+  {% endblock %}
+  {% block content %}
+    <p>
+      We
+      {% include '@cloudfour/components/icon/icon.twig' with {
+        name: 'heart',
+        inline: true
+      } only %}
+      <span class="u-hidden-visually">love</span>
+      solving tough puzzles through design and&nbsp;code.
+    </p>
   {% endblock %}
   {% block scene %}
     <img class="c-cloud-cover__scene-object" src="{{image}}" alt="Example">


### PR DESCRIPTION
Here's the changes we were trying to make:

- Cloud Cover now has both a `content` and a `heading` block
- ~Moved the rhythm block to the component, and used HTML rather than an embed because the nested blocks were causing problems (maybe @tylersticka knows how to fix that?)~
- Updated the source code in the MDX file

You'll want to [hide whitespace changes](https://github.com/cloudfour/cloudfour.com-patterns/pull/1834/files?diff=unified&w=1) when reviewing this…