### PR TITLE
Misc. layout adjustments

### DIFF
--- a/.changeset/fifty-terms-beg.md
+++ b/.changeset/fifty-terms-beg.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': major
+---
+
+Adjusted breakpoints, max-widths and padding sizes of all full-width patterns, most notably the Container object and Sky Nav component, to better compose actual site content.

--- a/.changeset/fifty-terms-beg.md
+++ b/.changeset/fifty-terms-beg.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': major
 ---
 
-Adjusted breakpoints, max-widths and padding sizes of all full-width patterns, most notably the Container object and Sky Nav component, to better compose actual site content.
+Adjusted breakpoints, max-widths and padding sizes of all full-width patterns (most notably the Container and Deck objects and the Sky Nav component) to better compose actual site content.

--- a/src/components/cloud-cover/cloud-cover.scss
+++ b/src/components/cloud-cover/cloud-cover.scss
@@ -24,12 +24,12 @@ $_gap: ms.step(1);
 /// crunch those numbers together.
 ///
 /// @param {Number} $amount [1] - Optional multiplier for default space.
-/// @param {Number} $vh [14vh] - Amount of horizontal space in the result.
-/// @param {Number} $vw [14vw] - Amount of vertical space in the result.
+/// @param {Number} $vh [12vh] - Amount of horizontal space in the result.
+/// @param {Number} $vw [3vw] - Amount of vertical space in the result.
 /// @return {Calc}
 /// @access private
 
-@function _cloud-space($amount: 1, $vh: 14vh, $vw: 4vw) {
+@function _cloud-space($amount: 1, $vh: 12vh, $vw: 3vw) {
   @if $amount == 1 {
     @return calc(#{$vh} + #{$vw});
   }

--- a/src/components/sky-nav/sky-nav.scss
+++ b/src/components/sky-nav/sky-nav.scss
@@ -153,7 +153,9 @@ $_masthead-height-sm: ms.step(7);
  * The logo link element.
  *
  * 1. We apply whitespace to this element directly so its hit area is larger
- *    than it would be if whitespace were applied to the parent element.
+ *    than it would be if whitespace were applied to the parent element. We use
+ *    a bit less space for the logo since it has circular edges that feels
+ *    misaligned when only the curves touch the edges.
  * 2. Prevents Flexbox squashing when menu items overflow.
  */
 .c-sky-nav__logo {
@@ -161,12 +163,12 @@ $_masthead-height-sm: ms.step(7);
   block-size: 100%; /* 1 */
   display: flex;
   flex: none; /* 2 */
-  padding: 0 $_space-horizontal; /* 1 */
+  padding: 0 math.div($_space-horizontal, 1.5); /* 1 */
 
   @media (min-width: $_breakpoint-wide) {
     block-size: auto;
     display: block;
-    padding: $_space-vertical $_space-horizontal; /* 1 */
+    padding: $_space-vertical math.div($_space-horizontal, 1.5); /* 1 */
   }
 }
 

--- a/src/components/sky-nav/sky-nav.scss
+++ b/src/components/sky-nav/sky-nav.scss
@@ -45,7 +45,7 @@ $_label-pad-vertical: ms.step(-9);
 
 // Use the widest standard layout `max-width` plus buffer for horizontal space
 $_max-width: #{unit.strip(size.$max-width-spread) +
-  unit.strip($_space-horizontal * 2)}em;
+  unit.strip($_space-horizontal * 3)}em;
 
 // Height of masthead on small screens.
 $_masthead-height-sm: ms.step(7);
@@ -168,7 +168,7 @@ $_masthead-height-sm: ms.step(7);
   @media (min-width: $_breakpoint-wide) {
     block-size: auto;
     display: block;
-    padding: $_space-vertical math.div($_space-horizontal, 1.5); /* 1 */
+    padding-block: $_space-vertical; /* 1 */
   }
 }
 

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -81,7 +81,7 @@
   @see https://github.com/twigjs/twig.js/issues/262
 #}
 {% if include_main_demo %}
-  <main class="o-container u-pad-1" id="{{ main_id }}">
+  <main class="o-container o-container--pad" id="{{ main_id }}">
     <div class="o-container__content">
       <p>Hello world! This is the main content.</p>
     </div>

--- a/src/prototypes/speaking-listing/example/example.twig
+++ b/src/prototypes/speaking-listing/example/example.twig
@@ -27,9 +27,7 @@
             tag_name: 'h2',
             content: 'Future Events',
           } only %}
-          {% embed '@cloudfour/objects/deck/deck.twig' with {
-            class: 'o-deck--3-column@l'
-          } %}
+          {% embed '@cloudfour/objects/deck/deck.twig' %}
             {% block content %}
               {% for item in future %}
                 <a href="#" class="media-link">
@@ -55,9 +53,7 @@
             tag_name: 'h2',
             content: 'Our Talks',
           } only %}
-          {% embed '@cloudfour/objects/deck/deck.twig' with {
-            class: 'o-deck--3-column@l'
-          } %}
+          {% embed '@cloudfour/objects/deck/deck.twig' %}
             {% block content %}
               {% for item in speaking %}
                 {% embed '@cloudfour/components/card/card.twig' with {

--- a/src/tokens/size/padding.js
+++ b/src/tokens/size/padding.js
@@ -20,12 +20,12 @@ module.exports = {
       container: {
         horizontal: {
           min: {
-            value: modularRem(-1),
+            value: modularRem(0),
             comment:
               'Minimum inline (horizontal) fluid padding for container objects.',
           },
           max: {
-            value: modularRem(3),
+            value: modularRem(6),
             comment:
               'Maximum inline (horizontal) padding for container objects.',
           },

--- a/src/tokens/size/padding.js
+++ b/src/tokens/size/padding.js
@@ -25,7 +25,7 @@ module.exports = {
               'Minimum inline (horizontal) fluid padding for container objects.',
           },
           max: {
-            value: modularRem(6),
+            value: modularRem(5),
             comment:
               'Maximum inline (horizontal) padding for container objects.',
           },

--- a/src/tokens/size/padding.js
+++ b/src/tokens/size/padding.js
@@ -20,7 +20,7 @@ module.exports = {
       container: {
         horizontal: {
           min: {
-            value: modularRem(0),
+            value: modularRem(1),
             comment:
               'Minimum inline (horizontal) fluid padding for container objects.',
           },

--- a/src/tokens/size/shirts.json
+++ b/src/tokens/size/shirts.json
@@ -4,8 +4,8 @@
     "s": { "value": "30em" },
     "m": { "value": "40em" },
     "l": { "value": "60em" },
-    "xl": { "value": "70em" },
-    "xxl": { "value": "80em" },
-    "xxxl": { "value": "90em" }
+    "xl": { "value": "72em" },
+    "xxl": { "value": "84em" },
+    "xxxl": { "value": "96em" }
   }
 }

--- a/src/tokens/size/shirts.json
+++ b/src/tokens/size/shirts.json
@@ -4,8 +4,8 @@
     "s": { "value": "30em" },
     "m": { "value": "40em" },
     "l": { "value": "60em" },
-    "xl": { "value": "80em" },
-    "xxl": { "value": "100em" },
-    "xxxl": { "value": "120em" }
+    "xl": { "value": "70em" },
+    "xxl": { "value": "80em" },
+    "xxxl": { "value": "90em" }
   }
 }

--- a/src/tokens/size/sizing.js
+++ b/src/tokens/size/sizing.js
@@ -25,7 +25,7 @@ module.exports = {
     width: {
       card_column: {
         min: {
-          value: '15em',
+          value: '16em',
           comment: 'The minimum space to display a default card in a grid.',
         },
       },


### PR DESCRIPTION
## Overview

Makes a handful of sizing and spacing tweaks based on actual site content. Specifically:

- Lowered the "shirt size" widths starting with `xl`. Previously, content was widening to a size that made it difficult to compose imagery without it filling most of the viewport.
- Increased the Sky Nav max width and adjusted the Sky Nav logo padding so that it won't appear indented too far right.
- Reduced the size of the "cloud space" for the Cloud Cover component so these items won't be _quite_ so tall.
- Increased the minimum size of Deck object columns. In combination with the shirt size change, this means Deck objects will naturally limit themselves to three columns, which may eliminate the need for classes within our templates.
- Increased the amount of horizontal fluid padding (both minimum and maximum). This was feeling a little tight on some pages.

I have marked this as a `major` change, as changes to things like container widths can result in regressions.

## Screenshots

Although these are visual changes, it's kind of tough to show any one screenshot within the pattern library that will be noticeable on its own.

## Testing

The best way to test this would probably be to use `npm link` somehow to try this out locally in our WordPress theme. I've been having a lot of trouble doing so successfully... when I attempt to, the fonts stop working locally. Not sure what I'm doing wrong... or maybe now that this branch exists I could somehow install this version? Open to suggestions!

---

- Fixes #1829 
