### PR TITLE
Brighten card covers in alternate theme

### DIFF
--- a/.changeset/cuddly-hairs-compare.md
+++ b/.changeset/cuddly-hairs-compare.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Card covers within an alternate theme container will be brightened slightly to better offset covers with similar backgrounds to the container

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -1,5 +1,6 @@
 @use '../../compiled/tokens/scss/aspect-ratio';
 @use '../../compiled/tokens/scss/breakpoint';
+@use '../../compiled/tokens/scss/brightness';
 @use '../../compiled/tokens/scss/color';
 @use '../../compiled/tokens/scss/ease';
 @use '../../compiled/tokens/scss/size';
@@ -227,6 +228,17 @@ $_focus-overflow: (size.$edge-large * -1);
   border-radius: size.$border-radius-medium;
   grid-area: cover;
   transform: translate(0, 0); /* 3 */
+
+  /**
+   * Subtly brighten covers within our alternate theme containers to help offset
+   * imagery with light backgrounds from the surrounding container. We could
+   * also do this for contained cards, but since those are a less common
+   * occurrence we'll keep this simple for now.
+   */
+
+  @include theme.styles(alternate) {
+    filter: brightness(brightness.$image-brighten);
+  }
 
   /**
    * Square aspect ratio + fully rounded corners = circular cover image

--- a/src/tokens/number/brightness.json
+++ b/src/tokens/number/brightness.json
@@ -4,6 +4,9 @@
       "control": {
         "brighten": { "value": "110%" },
         "dim": { "value": "80%" }
+      },
+      "image": {
+        "brighten": { "value": "102.5%" }
       }
     }
   }


### PR DESCRIPTION
## Overview

A lot of our feature images include a light silver background. This is an issue in `t-alternate` containers where that is the background.

This PR implements a suggestion from @Paul-Hebert to use a brightness filter to subtly offset imagery within these containers.

The "pros" of this approach are that it does not require changes to actual assets or any specific action on the part of the developer or content author. The potential con is that it does result in a slight color shift for some images, but I think the shift is subtle enough to be acceptable for secondary content containers (which `t-alternate` is, by nature, intended for).

## Screenshots

Note how the left and right edges blend in a _little_ less with the background than before:

Before | After
--- | ---
<img width="430" alt="Screen Shot 2022-06-14 at 10 02 56 AM" src="https://user-images.githubusercontent.com/69633/173635817-b4d9e16a-c549-4fc8-ad9b-4be295f8a800.png"> | <img width="432" alt="Screen Shot 2022-06-14 at 10 02 31 AM" src="https://user-images.githubusercontent.com/69633/173635841-a7a61a85-7b43-464b-9f1f-e0c540328251.png">

## Testing

1. [Open up the deck story](https://deploy-preview-1851--cloudfour-patterns.netlify.app/?path=/story/objects-deck--basic)
2. Observe a cover image with a silver background
3. Use the "theme" switcher in Storybook to switch to the `.t-light.t-alternate` theme
4. Observe that the cover image is still slightly offset from the background

---

- Fixes #1830 
