### PR TITLE
Add active styles for Card and Event Summary

### DIFF
--- a/.changeset/thin-worms-whisper.md
+++ b/.changeset/thin-worms-whisper.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Make active states more consistent between Button, Card and Event Summary

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -262,14 +262,17 @@ $_focus-overflow: (size.$edge-large * -1);
 
 /**
  * Hover effect for when the card contains a link. The image appears to zoom in
- * a very slight amount.
+ * a very slight amount. We negate that zoom for the `:active` state for some
+ * subtle consistency with other scale interactions, such as buttons and event
+ * summary calendars, but we don't go quite a dramatic since these are larger
+ * elements that would feel a bit more jarring.
  */
 
 .c-card__cover > *,
 .c-card__cover > picture > img {
   transition: transform transition.$prompt ease.$out;
 
-  .c-card--with-link:hover & {
+  .c-card--with-link:hover:not(:active) & {
     transform: scale(1.025);
   }
 }

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -264,7 +264,7 @@ $_focus-overflow: (size.$edge-large * -1);
  * Hover effect for when the card contains a link. The image appears to zoom in
  * a very slight amount. We negate that zoom for the `:active` state for some
  * subtle consistency with other scale interactions, such as buttons and event
- * summary calendars, but we don't go quite a dramatic since these are larger
+ * summary calendars, but we don't go quite as dramatic since these are larger
  * elements that would feel a bit more jarring.
  */
 

--- a/src/components/event-summary/event-summary.scss
+++ b/src/components/event-summary/event-summary.scss
@@ -1,3 +1,4 @@
+@use '../../compiled/tokens/scss/brightness';
 @use '../../compiled/tokens/scss/color';
 @use '../../compiled/tokens/scss/ease';
 @use '../../compiled/tokens/scss/scale';
@@ -55,9 +56,16 @@ $_focus-overflow: (size.$edge-large * -1);
 }
 
 .c-event-summary__calendar-date {
-  transition: transform transition.$quick ease.$out;
+  transition: filter transition.$slow ease.$out,
+    transform transition.$quick ease.$out;
 
   .c-event-summary:hover & {
+    filter: brightness(brightness.$control-brighten);
     transform: scale(scale.$effect-grow);
+  }
+
+  .c-event-summary:active & {
+    filter: brightness(brightness.$control-dim);
+    transform: scale(scale.$effect-shrink);
   }
 }


### PR DESCRIPTION
## Overview

Previously, Button components had distinct hover and active states. But other interactive components with scale effects did not have `:active` states.

This PR adds the same Button `:active` effects to Event Summary calendars. Because card covers are a bit larger and would be jarring, the `:hover` state is simply negated on `:active`. This should make these interactive elements feel a bit more consistent across the site.

## Screenshots

Here is how the Button looks already for `:hover`, then `:active`:

![button-fx](https://user-images.githubusercontent.com/69633/172955516-476a2588-bb6f-4011-b757-5fabba7f1f54.gif)

And here's how the Event Summary and Card components look in this PR:

![event-summary-fx](https://user-images.githubusercontent.com/69633/173655363-300cbed9-ddae-4607-91a0-b4f1b53bfab1.gif)

![card-cover-fx](https://user-images.githubusercontent.com/69633/173656223-82693a09-0dee-4b72-813c-15942b552e00.gif)

## Testing

Test `:hover` and `:active` states in:

1. [Event summary](https://deploy-preview-1852--cloudfour-patterns.netlify.app/?path=/story/components-event-summary--default-story)
2. [Card with cover](https://deploy-preview-1852--cloudfour-patterns.netlify.app/?path=/story/components-card--cover-image)

---

- Fixes #1831