### PR TITLE
Add responsive inline size utilities

### DIFF
--- a/.changeset/perfect-seahorses-knock.md
+++ b/.changeset/perfect-seahorses-knock.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add responsive inline size utilities

--- a/src/utilities/size/demo/inline-size.twig
+++ b/src/utilities/size/demo/inline-size.twig
@@ -1,0 +1,22 @@
+<div class="demo-u-size-inline">
+  {% for columns in 2..6 %}
+    <div>
+      <div class="u-size-inline-1/{{columns}} u-pad-n1 u-rounded t-dark t-alternate u-text-center">
+        1/{{columns}}
+      </div>
+      <div class="u-size-inline-{{columns - 1}}/{{columns}} u-pad-n1 u-rounded t-dark t-alternate u-text-center">
+        {{columns - 1}}/{{columns}}
+      </div>
+    </div>
+  {% endfor %}
+  <div>
+    <div class="u-size-inline-full u-pad-n1 u-rounded t-dark t-alternate u-text-center">
+      full
+    </div>
+  </div>
+  <div>
+    <div class="u-size-inline-auto u-pad-n1 u-rounded t-dark t-alternate u-text-center">
+      auto
+    </div>
+  </div>
+</div>

--- a/src/utilities/size/demo/responsive.twig
+++ b/src/utilities/size/demo/responsive.twig
@@ -1,0 +1,16 @@
+<div class="demo-u-size-responsive">
+  <div class="u-size-inline-1/2 u-size-inline-2/3@s u-size-inline-3/4@m u-size-inline-4/5@l u-size-inline-5/6@xl t-dark t-alternate u-rounded u-pad-n1">
+    <div>1/2</div>
+    <div>2/3@s</div>
+    <div>3/4@m</div>
+    <div>4/5@l</div>
+    <div>5/6@xl</div>
+  </div>
+  <div class="u-size-inline-1/2 u-size-inline-1/3@s u-size-inline-1/4@m u-size-inline-1/5@l u-size-inline-1/6@xl t-dark t-alternate u-rounded u-pad-n1">
+    <div>1/2</div>
+    <div>1/3@s</div>
+    <div>1/4@m</div>
+    <div>1/5@l</div>
+    <div>1/6@xl</div>
+  </div>
+</div>

--- a/src/utilities/size/demo/styles.scss
+++ b/src/utilities/size/demo/styles.scss
@@ -1,0 +1,14 @@
+.demo-u-size-inline {
+  display: grid;
+  gap: 1em;
+
+  > * {
+    display: flex;
+    gap: inherit;
+  }
+}
+
+.demo-u-size-responsive {
+  display: flex;
+  gap: 1em;
+}

--- a/src/utilities/size/size.scss
+++ b/src/utilities/size/size.scss
@@ -1,0 +1,34 @@
+@use 'sass:math';
+@use '../../mixins/media-query';
+
+// Set the inline size styles in a mixin. The suffix will let us easily append
+// breakpoint suffixes.
+@mixin _inline-size-utilities($suffix: '') {
+  @for $columns from 2 through 6 {
+    @for $column from 1 through $columns {
+      .u-size-inline-#{$column}\/#{$columns}#{$suffix} {
+        inline-size: math.div($column, $columns) * 100% !important;
+      }
+    }
+  }
+
+  .u-size-inline-full#{$suffix} {
+    inline-size: 100% !important;
+  }
+
+  .u-size-inline-auto#{$suffix} {
+    inline-size: auto !important;
+  }
+}
+
+// Include the default versions (no media queries)
+@include _inline-size-utilities;
+
+// Include responsive versions. This would be simpler if we could use the
+// `breakpoint-classes` mixin instead, but in this case we want all of the
+// responsive versions to be grouped by breakpoint so larger breakpoints will
+// naturally override smaller ones.
+@include media-query.breakpoint-loop using ($key) {
+  $suffix: \@#{$key};
+  @include _inline-size-utilities($suffix);
+}

--- a/src/utilities/size/size.stories.mdx
+++ b/src/utilities/size/size.stories.mdx
@@ -1,0 +1,43 @@
+import { Story, Canvas, Meta } from '@storybook/addon-docs';
+import inlineSizeDemo from './demo/inline-size.twig';
+import responsiveDemo from './demo/responsive.twig';
+import './demo/styles.scss';
+
+<Meta title="Utilities/Size" />
+
+# Size
+
+Utilities for specifying the size occupied by an element. While largely unnecessary in objects and components thanks to [CSS Grid Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout), these utilities can still be useful for fine-tuning one-off elements in page content.
+
+## Logical Properties
+
+All of our utilities use [logical properties](https://www.w3.org/TR/css-logical-1/) instead of specific directions [in supported browsers](https://caniuse.com/#feat=css-logical-props) to simplify potential localization projects.
+
+The following table maps the traditional physical property for `direction: ltr` and `writing-mode: horizontal-tb` to its equivalent logical property:
+
+| Physical Property | Logical Property |
+| ----------------- | ---------------- |
+| `height`          | `block-size`     |
+| `width`           | `inline-size`    |
+
+You can observe how utilities respond to various `direction` and `writing-mode` values by selecting a different "Text flow" in this project's toolbar.
+
+## Inline size
+
+Utilities beginning with `u-size-inline-` specify the `inline-size` of an element:
+
+- `u-size-inline-{fraction}` for percentage widths, where `{fraction}` represents the desired ratio. For example, `u-size-inline-2/5` would set `inline-size` to `40%`. Fractions with denominators of `2` through `6` are supported.
+- `u-size-inline-full` sets the `inline-size` to `100%` of the container.
+- `u-size-inline-auto` sets the `inline-size` to the natural value for the element.
+
+<Canvas>
+  <Story name="Inline size (Width)">{() => inlineSizeDemo()}</Story>
+</Canvas>
+
+## Responsive
+
+All of these utilities include responsive variations. Appending `@{breakpoint}` to the end of the class name will cause the utility to change for the given breakpoint.
+
+<Canvas>
+  <Story name="Responsive">{() => responsiveDemo()}</Story>
+</Canvas>


### PR DESCRIPTION
## Overview

Adds a set of responsive `u-size-inline-*` utilities to allow for percentage-based sizing of one-off content elements.

Similar to [the previous version](https://cloudfour-patterns.netlify.app/patterns/utilities.html#size) except for these differences:

- Allows the fraction to be expressed directly (`1/3`) instead of requiring an spelled out variation (`1-of-3`).
- Specifies `u-size-inline` instead of simply `u-size`. This is in support of our embracing logical properties and also to avoid the headaches associated with adding height utilities later on (see the `u-limitHeight*` utilities we had to add last time around).
- Fewer denominators. Previously, we supported 2, 3, 4, 5, 6, 8, 10 and 12. This time I capped it at 6 because I think in the context of articles and pages those will be the most common ratios.
- No Flex-specific utilities. This was a necessity when these utilities were our main method of defining grids, but given their purpose within the new library, they felt unnecessary.

## Screenshots

![Screenshot 2022-06-14 at 14-49-46 Webpack App](https://user-images.githubusercontent.com/69633/173695881-8c080d77-da06-43cf-af2e-69dc6be7769f.png)

## Testing

[Check out the deploy preview](https://deploy-preview-1854--cloudfour-patterns.netlify.app/?path=/docs/utilities-size--inline-size-width)

---

- Fixes #1826 