### PR TITLE
Icon title feature + related bug fixes

### DIFF
--- a/.changeset/cuddly-poems-hang.md
+++ b/.changeset/cuddly-poems-hang.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Add new `title` property to Icon component to make fallback text for semantic icons easier to specify.
+Add new `title` property to Icon component to make semantic fallback text much more straightforward

--- a/.changeset/cuddly-poems-hang.md
+++ b/.changeset/cuddly-poems-hang.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add new `title` property to Icon component to make fallback text for semantic icons easier to specify.

--- a/.changeset/curly-cameras-fix.md
+++ b/.changeset/curly-cameras-fix.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+The Ground Nav button's icon is no longer presented inconsistently with other button icons, and its `aria-hidden` value is no longer invalid.

--- a/.changeset/curly-cameras-fix.md
+++ b/.changeset/curly-cameras-fix.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': patch
 ---
 
-The Ground Nav button's icon is no longer presented inconsistently with other button icons, and its `aria-hidden` value is no longer invalid.
+The Ground Nav button's icon is no longer presented inconsistently with other button icons

--- a/.changeset/gold-pans-sin.md
+++ b/.changeset/gold-pans-sin.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+The default icon fallback now exists (oops)

--- a/.changeset/sixty-starfishes-nail.md
+++ b/.changeset/sixty-starfishes-nail.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Icons used in the Alert component no longer use invalid `aria-hidden` values

--- a/src/components/alert/alert.twig
+++ b/src/components/alert/alert.twig
@@ -5,7 +5,6 @@
     {% if icon %}
       {% include '@cloudfour/components/icon/icon.twig' with {
         name: icon,
-        aria_hidden: true
       } only %}
     {% endif %}
   {% endblock %}
@@ -30,7 +29,6 @@
         {% include '@cloudfour/components/icon/icon.twig' with {
           class: 'c-alert__dismiss-icon',
           name: 'x',
-          aria_hidden: true,
         } %}
         <span class="u-hidden-visually">Dismiss alert</span>
       </button>

--- a/src/components/badge/badge.twig
+++ b/src/components/badge/badge.twig
@@ -3,7 +3,6 @@
     {% if icon %}
       {% include '@cloudfour/components/icon/icon.twig' with {
         name: icon,
-        aria_hidden: 'true',
       } only %}
     {% endif %}
   {% endblock %}

--- a/src/components/cloud-cover/demo/extra.twig
+++ b/src/components/cloud-cover/demo/extra.twig
@@ -10,6 +10,7 @@
       We
       {% include '@cloudfour/components/icon/icon.twig' with {
         name: 'heart',
+        title: 'love',
         inline: true
       } only %}
       <span class="u-hidden-visually">love</span>

--- a/src/components/cloud-cover/demo/scene.twig
+++ b/src/components/cloud-cover/demo/scene.twig
@@ -10,6 +10,7 @@
       We
       {% include '@cloudfour/components/icon/icon.twig' with {
         name: 'heart',
+        title: 'love',
         inline: true
       } only %}
       <span class="u-hidden-visually">love</span>

--- a/src/components/comment/comment.twig
+++ b/src/components/comment/comment.twig
@@ -56,7 +56,6 @@
             {% include '@cloudfour/components/icon/icon.twig' with {
               name: 'link',
               inline: true,
-              aria_hidden: 'true',
             } only %}
           </span>
           <span class="u-hidden-visually">

--- a/src/components/footnote/footnote.twig
+++ b/src/components/footnote/footnote.twig
@@ -6,7 +6,6 @@
 
     {% include '@cloudfour/components/icon/icon.twig' with {
       name: 'arrow-hook-left',
-      aria_hidden: 'true',
     } only %}
   </a>
 </li>

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -18,23 +18,11 @@
         {{ lead_in }}
       </h2>
       <p class="c-ground-nav__action-title">
-        {% embed '@cloudfour/components/button/button.twig' with {
+        {% include '@cloudfour/components/button/button.twig' with {
           href: link,
           label: title,
-          _ground_nav_icon: icon
+          content_start_icon: icon ?? 'link'
         } only %}
-          {% block content %}
-            {% if _ground_nav_icon %}
-              {% include '@cloudfour/components/icon/icon.twig' with {
-                name: _ground_nav_icon,
-                fallback: 'link',
-                inline: true,
-                focusable: 'false'
-              } only %}
-            {% endif %}
-            {{ label }}
-          {% endblock %}
-        {% endembed %}
       </p>
       {% include '@cloudfour/assets/illustrations/portland.svg.twig' with {
         class: 'c-ground-nav__action-illustration'

--- a/src/components/heading/heading.twig
+++ b/src/components/heading/heading.twig
@@ -66,7 +66,6 @@
     <a class="c-heading__permalink" href="#{{ id }}">
       {% include '@cloudfour/components/icon/icon.twig' with {
         name: 'link',
-        aria_hidden: 'true'
       } only %}
       <span class="u-hidden-visually">Permalink to {{ _content }}</span>
     </a>

--- a/src/components/icon/demo/a11y.twig
+++ b/src/components/icon/demo/a11y.twig
@@ -1,0 +1,16 @@
+<p>
+  I
+  {% include '@cloudfour/components/icon/icon.twig' with {
+    name: 'heart',
+    title: 'love',
+    inline: true,
+  } %}
+  icons with semantic fallbacks.
+</p>
+<p>
+  {% include '@cloudfour/components/icon/icon.twig' with {
+    name: 'check',
+    inline: true
+  } %}
+  Decorative icons are nice, too!
+</p>

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -8,6 +8,9 @@ import template from './icon.twig';
 // within a Storybook docs page and not within an actual component).
 // This can be revisited in the future if Storybook no longer relies on Webpack.
 // eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import a11yDemoSource from '!!raw-loader!./demo/a11y.twig';
+import a11yDemo from './demo/a11y.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import inlineDemoSource from '!!raw-loader!./demo/inline.twig';
 import inlineDemo from './demo/inline.twig';
 const iconStory = (args) => {
@@ -38,9 +41,23 @@ For a list of available icons, visit [the Icons page](/docs/design-icons--page).
       fallback: { type: { name: 'string' } },
       inline: { type: { name: 'boolean' } },
       class: { type: { name: 'string' } },
+      title: { type: { name: 'string' } },
     }}
   >
     {(args) => iconStory(args)}
+  </Story>
+</Canvas>
+
+## Accessibility
+
+By default, an icon is assumed to be decorative and will have its `aria-hidden` attribute set to `true`. If the `title` property is provided, the `aria-hidden` attribute will be omitted and the contents of `title` will be prepended to the SVG source as its `title` element. ([More info](https://css-tricks.com/accessible-svgs/#aa-example-1-standalone-icon-meaningful))
+
+<Canvas>
+  <Story
+    name="Accessibility"
+    parameters={{ docs: { source: { code: a11yDemoSource } } }}
+  >
+    {a11yDemo}
   </Story>
 </Canvas>
 
@@ -65,10 +82,11 @@ Icons without a flex or grid container may appear [slightly low in comparison to
 
 The component template supports the following unique properties:
 
-- `name`: The name of the intended icon [in our library](/docs/design-icons--page).
-- `fallback`: The name of an icon to display if the first doesn't exist. Useful if you are displaying unique icons based on dynamic content. Defaults to `close`.
-- `inline`: When `true`, the inline modifier will be applied.
 - `class`: Will append to `c-icon` and any other modifier classes.
+- `fallback`: The name of an icon to display if the one specified by `name` doesn't exist. Useful if you are displaying unique icons based on dynamic content. Defaults to `x`.
+- `inline`: When `true`, the inline modifier will be applied.
+- `name`: The name of the intended icon [in our library](/docs/design-icons--page).
+- `title`: If provided, a `title` element will be prepended to the icon source with the contents of this property. This will also set the `role` to `img` unless it is already specified. ([More info](https://css-tricks.com/accessible-svgs/#aa-example-1-standalone-icon-meaningful))
 
 Additional SVG properties will be passed to the Twig template for the asset itself:
 

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -50,7 +50,7 @@ For a list of available icons, visit [the Icons page](/docs/design-icons--page).
 
 ## Accessibility
 
-By default, an icon is assumed to be decorative and will have its `aria-hidden` attribute set to `true`. If the `title` property is provided, the `aria-hidden` attribute will be omitted and the contents of `title` will be prepended to the SVG source as its `title` element. ([More info](https://css-tricks.com/accessible-svgs/#aa-example-1-standalone-icon-meaningful))
+By default, an icon is assumed to be decorative. If the `title` property is provided, it will be used as the icon's accessible fallback text. The default values for `aria-hidden` and `role` will be adjusted accordingly as well. ([More info](https://css-tricks.com/accessible-svgs/#aa-example-1-standalone-icon-meaningful))
 
 <Canvas>
   <Story

--- a/src/components/icon/icon.twig
+++ b/src/components/icon/icon.twig
@@ -1,4 +1,4 @@
-{% set fallback = fallback|default('close') %}
+{% set fallback = fallback|default('x') %}
 
 {% set _dir = '@cloudfour/assets/icons/' %}
 {% set _ext = '.svg.twig' %}
@@ -15,6 +15,20 @@
   {% set _class = _class ~ ' ' ~ class %}
 {% endif %}
 
-{% include [ _path, _fallback_path ] with {
-  class: _class,
-} %}
+{% if title %}
+  {% set _role = role ?? 'img' %}
+  {% embed [ _path, _fallback_path ] with {
+    class: _class,
+    role: _role,
+  } %}
+    {% block before %}
+      <title>{{title}}</title>
+    {% endblock %}
+  {% endembed %}
+{% else %}
+  {% set _aria_hidden = aria_hidden ?? 'true' %}
+  {% include [ _path, _fallback_path ] with {
+    class: _class,
+    aria_hidden: _aria_hidden,
+  } %}
+{% endif %}

--- a/src/objects/rhythm/demo/article.twig
+++ b/src/objects/rhythm/demo/article.twig
@@ -43,17 +43,11 @@
         <p>This is similar to <a href="http://sonspring.com/">Nathan Smith’s</a> <a href="http://adapt.960.gs/">Adaptive.js</a> library which puts breakpoints in JavaScript instead of CSS.</p>
         <p>So by definition, Google Plus is not a responsive web design. It may look like one, but it doesn’t contain the three technical pieces necessary to be a responsive web design.</p>
         <p>
-          {% embed '@cloudfour/components/button/button.twig' with {
-            href: 'https://cloudfour.com/thinks/defining-responsiveness/'
+          {% include '@cloudfour/components/button/button.twig' with {
+            href: 'https://cloudfour.com/thinks/defining-responsiveness/',
+            label: 'Full article',
+            content_end_icon: 'arrow-right'
           } only %}
-            {% block content %}
-              Full article
-              {% include '@cloudfour/components/icon/icon.twig' with {
-                name: 'arrow-right',
-                inline: true
-              } only %}
-            {% endblock %}
-          {% endembed %}
         </p>
       {% endblock %}
     {% endembed %}


### PR DESCRIPTION
## Overview

Adds an optional `title` property to the Icon component.

If omitted, icons will now have their `aria_hidden` property set to `"true"`.

If provided, the contents of `title` will be prepended to the SVG contents as `<title>{{title}}</title>` and the `role` will be set to `"img"`. (I started to also add support for specifying a title ID, but that apparently was addressing a Chrome-specific bug that was fixed [more than six years ago](https://bugs.chromium.org/p/chromium/issues/detail?id=566252).)

Based on this, I was able to update a lot of our existing icon usage to no longer specify `aria_hidden` manually. Along the way, I found and fixed a few small bugs:

- The Alert component's icons were setting `aria-hidden` to `1` (easy mistake to make with booleans instead of strings, a good example of why this PR's feature will be helpful)
- Some older iconographic buttons were not using the `content_start_icon` or `content_end_icon` properties, resulting in icons that looked a bit off compared to other buttons
- The default icon fallback used an outdated name

## Screenshots

<img width="1076" alt="Screen Shot 2022-06-16 at 1 25 16 PM" src="https://user-images.githubusercontent.com/69633/174157713-d3251363-c0e3-4565-9405-b8f1628b476e.png">

## Testing

On [the deploy preview](https://deploy-preview-1858--cloudfour-patterns.netlify.app/)...

1. In the canvas view of the icon component, confirm that accessibility tests are passing. Also confirm using the HTML tab that decorative icons display with `aria-hidden="true"` while non-decorative icons use `role="img"` and include a `title` element.
2. In the canvas view of the Icon ▸ Basic story, delete the value of `name` in the "Controls" tab. The icon should change from its previous value to `x`.
3. Confirm using the HTML tab of the canvas view of each Alert story that any icons have `aria-hidden="true"` (not `aria-hidden="1"`).
4. Confirm using the HTML tab of the canvas view of each Ground Nav story that the button icon is now within a `c-button__extra` element (rather than being included alongside label content).
5. Open [the accessibility example story](https://deploy-preview-1858--cloudfour-patterns.netlify.app/iframe.html?id=components-icon--accessibility&args=&viewMode=story) in Safari and toggle VoiceOver on. Confirm that the text is read aloud...
    - The first line's icon should read aloud as "love" or "love image."
    - The second line should completely ignore the icon.

---

- Fixes #1857
- Fixes #1856 