### PR TITLE
Fix rhythm heading cascade issue

### DIFF
--- a/.changeset/cuddly-dryers-build.md
+++ b/.changeset/cuddly-dryers-build.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix headings in Rhythm objects not respecting cascade of `--rhythm` custom property

--- a/src/mixins/_spacing.scss
+++ b/src/mixins/_spacing.scss
@@ -71,7 +71,7 @@ $fluid-spacing-inline-negative: fluid.fluid-clamp(
     > * + h5,
     > * + h6,
     > * + [class*='heading'] {
-      margin-block-start: var(--rhythm-headings);
+      margin-block-start: var(--rhythm-headings, var(--rhythm));
     }
   }
 }

--- a/src/objects/rhythm/demo/sections.twig
+++ b/src/objects/rhythm/demo/sections.twig
@@ -7,6 +7,9 @@
     } only %}
       {% block content %}
         {% for i in 1..3 %}
+          {% if i == 2 %}
+            <h2>More Sections Below</h2>
+          {% endif %}
           <div>
             <h3>Section {{i}}</h3>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum quam tellus, auctor non faucibus consequat, dictum et dui. Praesent vitae magna sit amet odio egestas semper. Duis nec tellus ligula. Pellentesque mollis varius pulvinar. Suspendisse eu ultrices quam. In dignissim felis efficitur lorem porttitor porttitor. Aliquam maximus tempus erat ut sagittis.</p>

--- a/src/objects/rhythm/rhythm.scss
+++ b/src/objects/rhythm/rhythm.scss
@@ -3,7 +3,6 @@
 
 :root {
   --rhythm: #{size.$rhythm-default};
-  --rhythm-headings: var(--rhythm);
 }
 
 .o-rhythm {


### PR DESCRIPTION
## Overview

Our rhythm object supports setting different rhythm for headings than other elements. Previously, this was done by setting a default `--rhythm-headings` property that was set to `var(--rhythm)`. But this actually only cascades as deep as the initial `--rhythm` declaration, which means if you were to set `--rhythm` later on (like in a modifier), the headings won't update in lockstep.

This PR changes the approach. Instead of declaring a default `--rhythm-headings` value, we use `--rhythm` as the fallback in the heading styles (`var(--rhythm-headings, var(--rhythm))`). This works as intended, where headings always default to the value of `--rhythm` _unless_ `--rhythm-headings` is explicitly declared.

## Screenshots

Note how the "more sections below" heading does not have consistent rhythm with the sections before the change:

Before | After
--- | ---
<img width="782" alt="Screen Shot 2022-06-21 at 9 41 50 AM" src="https://user-images.githubusercontent.com/69633/174853303-1de34285-ff08-43ad-9965-aef8cd495b1d.png"> | <img width="774" alt="Screen Shot 2022-06-21 at 9 42 08 AM" src="https://user-images.githubusercontent.com/69633/174853309-31488073-d564-439f-a168-147038d8aaeb.png">

## Testing

On [the deploy preview](https://deploy-preview-1866--cloudfour-patterns.netlify.app/)...

1. View [the generous headings story](https://deploy-preview-1866--cloudfour-patterns.netlify.app/?path=/story/objects-rhythm--generous-headings). Confirm that the headings have more top margin than other elements.
2. View [the lavish story](https://deploy-preview-1866--cloudfour-patterns.netlify.app/?path=/story/objects-rhythm--lavish). Confirm that the margin above the "more sections" heading is the same as the space between sections.