### PR TITLE
Add is-loading and aria-disabled to Button

### DIFF
--- a/.changeset/cuddly-birds-march.md
+++ b/.changeset/cuddly-birds-march.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add `is-loading` state class to Buttons

--- a/.changeset/rare-wasps-fly.md
+++ b/.changeset/rare-wasps-fly.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add support for `aria-disabled` attribute to Buttons

--- a/src/base/_animation.scss
+++ b/src/base/_animation.scss
@@ -1,0 +1,5 @@
+@keyframes rotate-clockwise {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/base/_index.scss
+++ b/src/base/_index.scss
@@ -1,3 +1,4 @@
 @use './themes';
+@use './animation';
 @use './defaults';
 @use './typography';

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -144,9 +144,30 @@ The `content_start`/`content_end` blocks override the
   </Story>
 </Canvas>
 
-## Icon with slash
+## States
 
-To add a slash across the icon(s), use the `is-slashed` state modifier CSS class.
+Buttons with a `disabled` attribute or with `aria-disabled` set to `'true'` will appear less prominent. ([Which should you use?](https://css-tricks.com/making-disabled-buttons-more-inclusive/))
+
+Buttons with the `is-loading` class will display a spinner. This informs the user visually that the button is waiting for some sort of response.
+
+<Canvas>
+  <Story name="Disabled" args={{ label: 'Disabled', disabled: true }}>
+    {(args) => buttonStory(args)}
+  </Story>
+  <Story
+    name="ARIA Disabled"
+    args={{ label: 'ARIA Disabled', aria_disabled: 'true' }}
+  >
+    {(args) => buttonStory(args)}
+  </Story>
+  <Story name="Loading" args={{ label: 'Loading', class: 'is-loading' }}>
+    {(args) => buttonStory(args)}
+  </Story>
+</Canvas>
+
+### Icon with slash
+
+To add a slash across the icon(s), use the `is-slashed` state class.
 
 If no `content_start_icon`/`content_end_icon` or `content_start`/`content_end` block content is passed in, the `'bell'` icon will be used by default as the `content_start_icon` value.
 
@@ -189,6 +210,7 @@ You can override the `content_start_icon` value to a different icon.
 
 ## Template Properties
 
+- `aria_disabled` (string, `'true'`/`'false'`): Sets the button's `aria-disabled` attribute.
 - `aria_expanded` (string, `'true'`/`'false'`): Sets the button's `aria-expanded` attribute.
 - `class` (string): Append a class to the root element.
 - `content_start_icon` (string): The name of the [icon](/docs/design-icons--page) to render in the `content_start` block.

--- a/src/components/button/button.twig
+++ b/src/components/button/button.twig
@@ -15,6 +15,9 @@
 
 <{{ tag_name }}
   class="c-button{% if class %} {{ class }}{% endif %}"
+  {% if aria_disabled %}
+    aria-disabled="{{ aria_disabled }}"
+  {% endif %}
   {% if aria_expanded %}
     aria-expanded="{{ aria_expanded }}"
   {% endif %}

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -93,11 +93,53 @@
     transform: scale(scale.$effect-shrink);
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled='true'] {
     cursor: not-allowed;
     filter: grayscale(60%);
     opacity: 0.85;
     transform: none;
+  }
+
+  /**
+   * Loading state
+   */
+
+  &.is-loading {
+    /**
+     * Display a spinner. Static if the user prefers reduced motion, animated
+     * otherwise.
+     */
+
+    &::after {
+      animation: transition.$glacial rotate-clockwise linear infinite;
+      block-size: size.$icon-medium;
+      border: size.$edge-control solid currentColor;
+      border-block-start-color: transparent;
+      border-radius: size.$border-radius-full;
+      content: '';
+      inline-size: size.$icon-medium;
+      inset: 0;
+      margin: auto;
+      position: absolute;
+
+      @media (prefers-reduced-motion: reduce) {
+        animation: none;
+        border-block-start-color: currentColor;
+        border-style: dashed;
+      }
+    }
+
+    /**
+     * Hide child elements (content, extra). We use this technique because it is
+     * performant and will not negate any keyboard events.
+     *
+     * @link https: //stackoverflow.com/a/34529598
+     */
+
+    > * {
+      opacity: 0;
+    }
   }
 }
 
@@ -119,6 +161,16 @@
   background-color: transparent;
   border-color: transparent;
   color: var(--theme-color-text-button-tertiary);
+}
+
+/// Rules for content element, used to contain button label.
+@mixin content {
+  /// We use opacity because it will not paint but it also won't remove the
+  /// element's keyboard events (if any).
+  /// @link https: //stackoverflow.com/a/34529598
+  .is-loading & {
+    opacity: 0;
+  }
 }
 
 /// Rules for extra element. Used to contain icons or other visual affordances.


### PR DESCRIPTION
## Overview

- Adds a `aria_disabled` property to our Button component so the `aria-disabled` attribute may be set
- Extends the existing `:disabled` selector to also include `[aria-disabled="true"]`
- Adds styles for an `is-loading` state class to our button mixin

**Note:** This took longer than I thought because I fell down a rabbit hole. I initially wanted to add a `loading` boolean property to the Twig template, but then I noticed that `is-slashed` didn't work that way, then as I was untangling that I noticed some issues with the existing Storybook args, and eventually I found myself halfway into a complete refactor of the stories and template. This PR is an attempt to harvest _just_ the user-facing changes from that work instead.

## Screenshots

Animated loading state:

![c-button-is-loading](https://user-images.githubusercontent.com/69633/176013221-81734e93-ef29-4a72-9829-bd2864c62894.gif)

Loading state when the user prefers reduced motion:

<img width="136" alt="Screen Shot 2022-06-27 at 11 41 34 AM" src="https://user-images.githubusercontent.com/69633/176013307-ab02c3f2-d490-4062-b6a3-aa0ecffd60c2.png">

Docs:

<img width="1046" alt="Screen Shot 2022-06-27 at 11 45 27 AM" src="https://user-images.githubusercontent.com/69633/176013366-77baef00-5c2d-4eba-99d2-d0852b190509.png">

## Testing

[On the deploy preview...](https://deploy-preview-1879--cloudfour-patterns.netlify.app/?path=/docs/components-button--disabled)

- Observe that the `disabled` and `aria-disabled` stories are visually the same.
- Observe that the `is-loading` example animates as expected.
- Opt into preferred reduce motion (located in the Accessibility settings of your Mac's System Preferences), observe that the `is-loading` example is no longer animated and appears dashed instead (see screenshots).

---

- Fixes #1873 
