### PR TITLE
Revise WordPress alignment styles

### DIFF
--- a/.changeset/large-eggs-guess.md
+++ b/.changeset/large-eggs-guess.md
@@ -1,0 +1,10 @@
+---
+'@cloudfour/patterns': major
+---
+
+Revised WordPress alignment styles based on actual content needs. Changes include:
+
+- Some blocks that previously required `alignwide` to fill container padding now do so by default.
+- `aligncenter` may be used to prevent a block from filling container padding.
+- `alignwide` now maxes out at the size of our default Container component `max-width` rather than an arbitrary value.
+- Margin, padding and inline size tweaks have been made to the Image and Group block styles as well as paragraphs with background colors.

--- a/src/vendor/wordpress/demo/alignment.twig
+++ b/src/vendor/wordpress/demo/alignment.twig
@@ -1,0 +1,42 @@
+{#
+  We enclose this demo in a standard container to accurately demonstrate the
+  layout effects of blocks with background colors. When displaying this demo
+  in Storybook, be sure to set its layout to `fullscreen`.
+#}
+{% embed '@cloudfour/objects/container/container.twig' with {
+  class: 'o-container--prose o-container--pad',
+  content_class: 'o-rhythm',
+} %}
+  {% block content %}
+    <p>
+      This paragraph has no alignment.
+    </p>
+    <p class="
+      {{alignment}}
+      has-text-color
+      has-fuchsia-lighter-color
+      has-background
+      has-purple-darker-background-color">
+      This paragraph has
+      <b>{{alignment|default('no')|replace({'align': ''})}} alignment</b> and
+      custom colors.
+    </p>
+    <p>
+      Here’s another ordinary paragraph with no alignment. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </p>
+    {% set extra_div = alignment in ['alignleft', 'alignright', 'aligncenter'] %}
+    {% if extra_div %}
+      <div class="wp-block-image">
+    {% endif %}
+    <figure class="{% if not extra_div %}wp-block-image {% endif %}{{alignment}}">
+      <img src="/media/MtBlanc1.jpg" alt="Mont Blanc">
+      <figcaption>This WordPress Image Block with a caption has <b>{{alignment|default('no')|replace({'align': ''})}} alignment</b>!</figcaption>
+    </figure>
+    {% if extra_div %}
+      </div>
+    {% endif %}
+    <p>
+      One more ordinary paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at sapien porttitor risus blandit posuere. Sed in malesuada ligula. Nam vulputate metus sed nibh vulputate, sed varius neque tincidunt.
+    </p>
+  {% endblock %}
+{% endembed %}

--- a/src/vendor/wordpress/demo/color.twig
+++ b/src/vendor/wordpress/demo/color.twig
@@ -1,12 +1,23 @@
-<h2 class="
-  {% if color %}
-    has-{{color}}-color
-    has-text-color
-  {% endif %}
-  {% if background_color %}
-    has-{{background_color}}-background-color
-    has-background
-  {% endif %}
-">
-  We share enthusiastically
-</h2>
+{#
+  We enclose this demo in a standard container to accurately demonstrate the
+  layout effects of blocks with background colors. When displaying this demo
+  in Storybook, be sure to set its layout to `fullscreen`.
+#}
+{% embed '@cloudfour/objects/container/container.twig' with {
+  class: 'o-container--prose o-container--pad'
+} %}
+  {% block content %}
+    <h2 class="
+      {% if color %}
+        has-{{color}}-color
+        has-text-color
+      {% endif %}
+      {% if background_color %}
+        has-{{background_color}}-background-color
+        has-background
+      {% endif %}
+    ">
+      We share enthusiastically
+    </h2>
+  {% endblock %}
+{% endembed %}

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -105,20 +105,6 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
 }
 
 /**
- * Gutenberg Block: Group
- * Styles for Gutenberg group blocks
- *
- * 1. For groups with a background color set, add standard block padding,
- *    then set inline margins and padding to outdent the block out a bit,
- *    while keeping the group content aligned with the page content.
- */
-.wp-block-group.has-background {
-  @include spacing.fluid-margin-inline-negative; // 1
-  @include spacing.fluid-padding-inline; // 1
-  padding-block: size.$rhythm-default; // 1
-}
-
-/**
  * Gutenberg Block: Code
  * Styles for Gutenberg code blocks (and code inside Markdown blocks)
  *
@@ -138,32 +124,53 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
   }
 }
 
-/**
- * Gutenberg block: Image
- * Styles for images inserted via Gutenberg blocks.
- *
- * 1. Since we are applying `margin-top` to CMS content via our o-rhythm
- *    pattern, the default `margin-bottom` value on Gutenberg image blocks is
- *    unnecessary, so we remove it here.
- */
+/// Gutenberg block: Image
+/// Styles for images inserted via Gutenberg blocks.
+
 .wp-block-image {
-  margin-block-end: 0; /* 1 */
   position: relative;
 
-  /**
-   * Setting a width of `100%` prevents resized and centered images from
-   * breaking layout when placed after a right-aligned image in a post.
-   */
-  &.aligncenter {
-    inline-size: 100%;
-  }
-
-  /* Since we are applying `margin-top` to CMS content via our o-rhythm
-   * pattern, the default `margin-bottom` value on Gutenberg figcaption
-   * elements is unnecessary, so we remove it here.
-   */
+  /// Since we are applying `margin-top` to CMS content via our o-rhythm
+  /// pattern, the default `margin-bottom` value on Gutenberg figcaption
+  /// elements is unnecessary, so we remove it here.
+  &,
   figcaption {
     margin-block-end: 0;
+  }
+
+  /// When some alignment options are selected, WordPress nests the figure with
+  /// the alignment class within the `wp-block-image` element.
+  ///
+  /// 1. The default top margin makes these alignment options appear misaligned
+  ///    unless they are floating midway through text, which is extremely
+  ///    uncommon.
+  /// 2. We constrain the width to 50% minus half of WordPress's default gutter
+  ///    size. This makes the adjacent content feel visually balanced.
+  .alignleft,
+  .alignright {
+    margin-block-start: 0; // 1
+    max-inline-size: calc(50% - 0.5em); // 2
+  }
+}
+
+/// Because WordPress changes the structure of the Image block markup depending
+/// on the alignment option but does not append the alignment class to the
+/// parent element in all cases, this was the only solution I could find for
+/// targeting its _default_ state. We may be able to simplify once the `:has`
+/// selector is better supported!
+figure.wp-block-image {
+  /// When this element has no alignment option set, attempt to fill the
+  /// container padding.
+  &:not(.alignwide):not(.alignfull) {
+    @include spacing.fluid-margin-inline-negative;
+  }
+
+  /// The `figure.wp-block-image` selector will only be valid if there is no
+  /// alignment, wide alignment or full alignment. In all three cases, any
+  /// caption is in danger of meeting the viewport edge unless we add in some
+  /// padding.
+  figcaption {
+    @include spacing.fluid-padding-inline;
   }
 }
 

--- a/src/vendor/wordpress/styles/_utilities.scss
+++ b/src/vendor/wordpress/styles/_utilities.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @use 'sass:meta';
 @use '../../../compiled/tokens/scss/breakpoint';
 @use '../../../compiled/tokens/scss/color-base';
@@ -5,24 +6,27 @@
 @use '../../../mixins/border-radius';
 @use '../../../mixins/headings';
 @use '../../../mixins/ms';
+@use '../../../mixins/spacing';
 
 // These utility classes may apply to anything created within the Gutenberg
 // editor (but not necessarily Gutenberg blocks).
 
 /// Releases a full-width child element from its limited-width container.
 /// @link https://cloudfour.com/thinks/breaking-out-with-viewport-units-and-calc/#flipping-the-script
-.alignfull,
-.alignwide {
+.alignfull {
   margin-inline: calc(-50vw + 50%);
 }
 
-/// Applies an opinionated wide-image width that allows an image element to
-/// spill slightly outsides its container at larger viewports. This assumes
-/// a certain container size in its current form.
+/// Wide alignment should max out at our default container width.
 .alignwide {
-  @media (width >= breakpoint.$l) {
-    margin-inline: -6vw;
-  }
+  // False positive linting error because SCSS lint is confusing `sass:math`'s
+  // `max` function with the browser `max` function. May be removed once our
+  // lint config updates to `stylelint-scss` 4.0.1 or newer.
+  // stylelint-disable-next-line scss/no-global-function-names
+  margin-inline: max(
+    -50vw + 50%,
+    math.div(size.$max-width-spread - size.$max-width-prose, -2)
+  );
 }
 
 /// When a custom background color is applied, we round the corners of the
@@ -30,6 +34,31 @@
 /// viewport edge.
 .has-background {
   @include border-radius.conditional;
+
+  /// Set inline margins unless the element's alignment has been set.
+  &:not(.alignfull):not(.alignwide):not(.aligncenter) {
+    @include spacing.fluid-margin-inline-negative;
+  }
+}
+
+/// Apply consistent padding to certain patterns and elements with a background.
+/// Some of these violate our selector rules to overcome WordPress's default
+/// styles. Some of these used to be located in our Core Block CSS, but once I
+/// discovered that `p.has-background` had styles I needed to override, it made
+/// me queasy to manage these styles in three separate places.
+///
+/// 1. Default padding is consistent with block rhythm on both edges…
+/// 2. …but if the alignment is not center, we use fluid inline padding instead
+///    so that the inner content will align with its siblings.
+p,
+.wp-block-group {
+  &.has-background {
+    padding: size.$rhythm-default; // 1
+
+    &:not(.aligncenter) {
+      @include spacing.fluid-padding-inline; // 2
+    }
+  }
 }
 
 /// Utilities for Block Color Palettes

--- a/src/vendor/wordpress/utilities.stories.mdx
+++ b/src/vendor/wordpress/utilities.stories.mdx
@@ -1,6 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { kebabCase } from 'lodash';
 import tokens from '../../compiled/tokens/js/tokens.js';
+import alignmentDemo from './demo/alignment.twig';
 import colorDemo from './demo/color.twig';
 import fontSizeDemo from './demo/font-size.twig';
 const baseColorTokenKeys = Object.keys(tokens.color.base).map(kebabCase);
@@ -44,6 +45,9 @@ When a background color is chosen, rounded corners and padding may be added (dep
 <Canvas>
   <Story
     name="Color"
+    parameters={{
+      layout: 'fullscreen',
+    }}
     argTypes={{
       color: colorControlConfig,
       background_color: colorControlConfig,
@@ -81,12 +85,42 @@ We include `has-{font-size}-font-size` classes for our `big`, `small` and headin
 
 ## Alignment
 
-The Gutenberg editor supports various alignment options for many blocks:
+By default, blocks with backgrounds and image blocks will attempt to fill the available inline padding of [our containers](/docs/objects-container--basic). You can opt into different alignment options for certain blocks.
 
-- `alignleft`
-- `aligncenter`
-- `alignright`
-- `alignfull`: Meet the viewport edge
-- `alignwide`: Meet the viewport edge up to a maximum width
+| WordPress Class | Behavior                                  | Blocks                                     |
+| --------------- | ----------------------------------------- | ------------------------------------------ |
+| (None)          | Fill available inline padding             | Code, Image, blocks with background colors |
+| `aligncenter`   | Stay within the container (do not fill)   | Image, blocks with background colors       |
+| `alignleft`     | Float left, constrain inline size         | Image                                      |
+| `alignright`    | Float right, constrain inline size        | Image                                      |
+| `alignfull`     | Fill viewport inline size                 | Blocks with alignment options              |
+| `alignwide`     | Fill viewport inline size up to a maximum | Blocks with alignment options              |
 
-We'd like to better document this feature in the future. For now, you can preview some of its behavior via the controls on our [Core Image Block story](/story/vendor-wordpress-core-blocks--image).
+<Canvas>
+  <Story
+    name="Alignment"
+    height="320px"
+    parameters={{
+      layout: 'fullscreen',
+      docs: { inlineStories: false },
+    }}
+    argTypes={{
+      alignment: {
+        options: [
+          '',
+          'alignleft',
+          'aligncenter',
+          'alignright',
+          'alignfull',
+          'alignwide',
+        ],
+        control: { type: 'select' },
+      },
+    }}
+    args={{ alignment: 'alignwide' }}
+  >
+    {(args) => alignmentDemo(args)}
+  </Story>
+</Canvas>
+
+(Note: Storybook's `ArgsTable` does not seem to work with iframe stories at the time of this writing. To try out the different alignment options, [view this story in "Canvas" mode](/story/vendor-wordpress-utilities--alignment).)


### PR DESCRIPTION
## Overview

Revised WordPress alignment styles based on actual content needs. Changes include:

- Some blocks that previously required `alignwide` to fill container padding now do so by default.
- `aligncenter` may be used to prevent a block from filling container padding.
- `alignwide` now maxes out at the size of our default Container component `max-width` rather than an arbitrary value.
- Margin, padding and inline size tweaks have been made to the Image and Group block styles as well as paragraphs with background colors.
- New story for demonstrating these patterns.

## Screenshots

### Small Screens

Alignment | Screenshot
--- | ---
Default, `alignwide`, `alignfull` | <img src="https://user-images.githubusercontent.com/69633/176738507-24b7ed07-92b3-4a45-8cea-ab03f21e2c9c.png" width="375">
`aligncenter` | <img src="https://user-images.githubusercontent.com/69633/176738520-85fc7601-3e31-4cf6-9377-e8fa205977b5.png" width="375">
`alignleft` | <img src="https://user-images.githubusercontent.com/69633/176738716-e1bca91d-ef49-43ed-9e9d-703c53cdf3c9.png" width="375">
`alignright` | <img src="https://user-images.githubusercontent.com/69633/176738722-e976cb37-4a1d-48af-8ca4-7bdca3f488c6.png" width="375">

(On small screens, `alignwide` and `alignfull` are indistinguishable visually from the default alignment.)

### Large Screens

Note: Placeholder image is only `500px` wide to demonstrate behavior of narrow images in different layout options.

Alignment | Screenshot
--- | ---
Default | ![Screenshot 2022-06-30 at 10-25-13 vendor-wordpress-utilities--alignment](https://user-images.githubusercontent.com/69633/176740132-aaa60b37-4e25-49e3-9d7b-3e15be3fba75.png)
`aligncenter` | ![Screenshot 2022-06-30 at 10-25-27 vendor-wordpress-utilities--alignment](https://user-images.githubusercontent.com/69633/176740139-35b932ed-be7b-4241-a4a6-a2fb21dd40cc.png)
`alignleft` | ![Screenshot 2022-06-30 at 10-25-43 vendor-wordpress-utilities--alignment](https://user-images.githubusercontent.com/69633/176740143-66f5e348-e3d8-4cdf-b50a-f9e86f56e899.png)
`alignright` | ![Screenshot 2022-06-30 at 10-25-58 vendor-wordpress-utilities--alignment](https://user-images.githubusercontent.com/69633/176740150-54198852-43ea-4aed-aa9d-c590b6468913.png)
`alignfull` | ![Screenshot 2022-06-30 at 10-26-18 vendor-wordpress-utilities--alignment](https://user-images.githubusercontent.com/69633/176740156-59a90728-f636-406e-83c5-c48f7e66b9e5.png)
`alignwide` | ![Screenshot 2022-06-30 at 10-26-35 vendor-wordpress-utilities--alignment](https://user-images.githubusercontent.com/69633/176740166-d4b7a815-8a2d-43fc-a24b-c179c8ab0749.png)

### Docs

<img width="1058" alt="Screen Shot 2022-06-30 at 10 28 28 AM" src="https://user-images.githubusercontent.com/69633/176740437-96e6ae17-5027-428a-b7b6-bc13937c27ba.png">

## Testing

Try out various alignments in the deploy preview's story

---

- Fixes #1872 