### PR TITLE
Use theme color for Ground Nav borders

### DIFF
--- a/.changeset/thin-bats-dress.md
+++ b/.changeset/thin-bats-dress.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Ground Nav menu border colors now respect the current theme

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -193,7 +193,7 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
     }
 
     @media (min-width: breakpoint.$l) {
-      border-block-end: none;
+      border-block-end-width: 0;
       grid-column: 3/4;
       grid-row: 1/2;
       justify-self: end;

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -13,7 +13,8 @@ $_ground-nav-space: ms.step(3, 1rem);
 $_ground-nav-negative-space: ($_ground-nav-space * -1);
 $_ground-nav-border-width: size.$edge-medium;
 $_ground-nav-border-style: solid;
-$_ground-nav-border-color: color.$base-gray-light;
+$_ground-nav-border-color: var(--theme-color-border-base);
+$_ground-nav-border-color-fallback: color.$base-gray-light;
 
 /**
  * 1. We establish vertical whitespace for the action to simplify alignment of
@@ -107,10 +108,10 @@ $_ground-nav-border-color: color.$base-gray-light;
 }
 
 .c-ground-nav__menu {
-  border-block-end: $_ground-nav-border-width $_ground-nav-border-style
-    $_ground-nav-border-color;
-  border-block-start: $_ground-nav-border-width $_ground-nav-border-style
-    $_ground-nav-border-color;
+  border-color: $_ground-nav-border-color-fallback;
+  border-color: $_ground-nav-border-color;
+  border-style: $_ground-nav-border-style;
+  border-width: $_ground-nav-border-width 0;
   padding: $_ground-nav-space 0;
 }
 
@@ -182,9 +183,11 @@ $_ground-nav-border-color: color.$base-gray-light;
   }
 
   .c-ground-nav__social {
+    border: 0 $_ground-nav-border-style $_ground-nav-border-color-fallback;
+    border-color: $_ground-nav-border-color;
+
     @media (min-width: breakpoint.$m) {
-      border-block-end: $_ground-nav-border-width $_ground-nav-border-style
-        $_ground-nav-border-color;
+      border-block-end-width: $_ground-nav-border-width;
       grid-column: 1/3;
       padding-block-end: $_ground-nav-space;
     }


### PR DESCRIPTION
## Overview

Our new error patterns now use the dark theme Ground Nav (see #1886). This worked great except for the border colors, which did not use our theme values. This fixes that.

## Screenshots

### Narrow screens

Before | After
--- | ---
![Screenshot 2022-07-01 at 09-44-34 components-ground-nav--cloud-four](https://user-images.githubusercontent.com/69633/176936590-43ff17d3-f919-4228-8a47-9973446894ba.png) | ![Screenshot 2022-07-01 at 09-44-58 components-ground-nav--cloud-four](https://user-images.githubusercontent.com/69633/176936593-4ff9b9c8-22c1-4fc6-af2d-0ad2a825727a.png)

### Medium screens

Before | After
--- | ---
![Screen Shot 2022-07-01 at 09 45 35](https://user-images.githubusercontent.com/69633/176936622-c7590fac-16f6-4038-b352-76ae52290f19.png) | ![Screen Shot 2022-07-01 at 09 45 24](https://user-images.githubusercontent.com/69633/176936642-87cb03dc-d80e-4d75-aa39-a5ae0797d2f5.png)

## Testing

1. [Open any Ground Nav story in the deploy preview](https://deploy-preview-1894--cloudfour-patterns.netlify.app/?path=/story/components-ground-nav--cloud-four)
2. Observe the usual border color displays at smaller viewport widths
3. Use the "theme" switcher in Storybook to switch to the Dark theme
4. Observe the border color has now changed (should be our darkest blue, same as the outline on the CTA button)

---

- Fixes #1893