### PR TITLE
Use `initialArgs` as Fallback for `args`

### DIFF
--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -56,7 +56,7 @@ import demo from './demo/demo.twig';
       transformSource: (_src, storyContext) =>
         makeTwigEmbedIfHtml(
           '@cloudfour/components/heading/heading.twig',
-          storyContext.args || {},
+          storyContext.args || storyContext.initialArgs || {},
           ['content', 'subheading']
         ),
     },

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -6,7 +6,7 @@ const articlesStory = (args) => articlesDemo({ items: articles, ...args });
 const alignmentStory = (args) => alignmentDemo({ items: articles, ...args });
 // Custom function for generating story source from args given
 const articlesTemplateSource = (_src, storyContext) => {
-  const args = storyContext.args || {};
+  const args = storyContext.args || storyContext.initialArgs || {};
   let twigArgs = '';
   if (
     args.columns &&

--- a/src/objects/embed/embed.stories.mdx
+++ b/src/objects/embed/embed.stories.mdx
@@ -26,7 +26,7 @@ const defaultArgs = {
 };
 // Custom embed source function to preserve args in source code examples
 const embedTransformSource = (_src, storyContext) => {
-  const args = storyContext.args || {};
+  const args = storyContext.args || storyContext.initialArgs || {};
   const argsString =
     Object.keys(args).length > 0
       ? ` with ${JSON.stringify(args, null, 2)}`


### PR DESCRIPTION
## Overview

Some of our source code previews stopped displaying args passed to the
template recently. That seems to be due to the fact that the
`transformSource` function is called repeatedly, and `args` is not
always populated. It looks like `initialArgs` is a safe fallback, and
we already had several spots in the code doing so. This PR updates
a few stories to include the fallback that were missing it.

See https://github.com/storybookjs/storybook/issues/17341#issuecomment-1170922626 for more info.

## Screenshots

<img width="500" alt="Screen Shot 2022-07-01 at 1 51 36 PM" src="https://user-images.githubusercontent.com/257309/176966469-a8192869-db13-4104-96bb-827d8ac9d49f.png">

## Testing

On the preview deploy, review the following stories and confirm the args are displayed in the source:

- [ ] Card
- [ ] Deck
- [ ] Heading
- [ ] Embed
- [ ] Rhythm

---

- Fixes #1883