### PR TITLE
Fix twig syntax to be PHP-compatable

### DIFF
--- a/src/components/subscribe/subscribe.twig
+++ b/src/components/subscribe/subscribe.twig
@@ -54,7 +54,7 @@
     {% if weekly_digests_heading %}
       {% include '@cloudfour/components/heading/heading.twig' with {
         content: weekly_digests_heading,
-        id: "get-weekly-digests-" + form_id,
+        id: "get-weekly-digests-#{form_id}",
         class: 'c-subscribe__heading',
         level: heading_level|default(2),
         tag_name: heading_tag,


### PR DESCRIPTION
Twig for PHP is not into using `+` for concatenation.

I changed it to a syntax that works in both twing and PHP twig.