### PR TITLE
`pre { tab-size: 2; }` 🎉

### DIFF
--- a/.changeset/lazy-rockets-swim.md
+++ b/.changeset/lazy-rockets-swim.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Set the `tab-size` for `pre` elements to `2` to encourage more accessible code samples without compromising horizontal real estate

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -129,6 +129,8 @@ audio {
  * Code blocks
  *
  * 1. Don't allow code blocks to overflow willy-nilly.
+ * 2. Set a shallower tab size to encourage accessible code samples without
+ *    compromising horizontal real estate.
  */
 
 pre {
@@ -137,6 +139,7 @@ pre {
   color: color.$text-light;
   overflow: auto; /* 1 */
   padding: ms.step(1);
+  tab-size: 2; /* 2 */
 }
 
 /**

--- a/src/design/defaults.stories.mdx
+++ b/src/design/defaults.stories.mdx
@@ -106,7 +106,7 @@ For syntax highlighting, see [our Prism theme](/docs/vendor-prism--bash-shell).
   <Story name="Code block">
     {() => {
       const example = `* {
-  box-sizing: border-box;
+	box-sizing: border-box;
 }`;
       return `<pre><code>${example}</code></pre>`;
     }}


### PR DESCRIPTION
## Overview

Sets the default `tab-size` for `pre` elements to `2` instead of the baffling browser default of `8`. Should encourage more accessible code samples without compromising horizontal real estate.

## Screenshots

<img width="540" alt="Screen Shot 2022-07-06 at 2 05 31 PM" src="https://user-images.githubusercontent.com/69633/177643077-2cec81a1-b6be-4b5b-ba76-536aa0c543d0.png">

## Testing

1. Open [the code block story](https://deploy-preview-1910--cloudfour-patterns.netlify.app/?path=/story/design-defaults--code-block)
2. Observe that the tab character is occupying the same width as two space characters

---

- Fixes #1907 
