### PR TITLE
Add Alert block to Page object

### DIFF
--- a/.changeset/dirty-snails-impress.md
+++ b/.changeset/dirty-snails-impress.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Adds an Alert block to Page object
+Adds an optional Alert block to the Page object

--- a/.changeset/dirty-snails-impress.md
+++ b/.changeset/dirty-snails-impress.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Adds an Alert block to Page object

--- a/src/components/alert/alert.stories.mdx
+++ b/src/components/alert/alert.stories.mdx
@@ -185,3 +185,7 @@ When more contrast is desired, you may also attach a theme class to the the floa
 ## Template Blocks
 
 - `content`
+
+## Alert within a Page object
+
+The Page object has an `alert` block that was designed to accept an Alert component. See the [Page with Alert example](/?path=/docs/objects-page--example-with-alert) for more details.

--- a/src/objects/page/demo/example-with-alert.twig
+++ b/src/objects/page/demo/example-with-alert.twig
@@ -1,0 +1,28 @@
+{% embed '@cloudfour/objects/page/page.twig' only %}
+  {% block alert %}
+    {% include '@cloudfour/components/alert/alert.twig' with {
+      dismissable: true,
+      floating: true,
+      icon: 'cloud-slash',
+      message: 'You appear to be offline, some content or features may be unavailable.'
+    } only %}
+  {% endblock %}
+  {% block header %}
+    <p class="u-pad-1 t-dark">
+      Header content.
+    </p>
+  {% endblock %}
+  {% block content %}
+    <p class="u-pad-1">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu ex
+      enim. Nunc efficitur scelerisque dolor et sollicitudin. Donec finibus
+      lorem elit, eu consectetur quam pellentesque sed. Pellentesque habitant
+      morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+    </p>
+  {% endblock %}
+  {% block footer %}
+    <p class="u-pad-1 t-dark">
+      Footer content.
+    </p>
+  {% endblock %}
+{% endembed %}

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -27,6 +27,18 @@
 
 .o-page__content {
   grid-row: 2;
+  position: relative;
+}
+
+.o-page__content-alert {
+  display: flex;
+  inline-size: 100%;
+  inset-block-start: -1.5em;
+  inset-inline-start: 50%;
+  justify-content: center;
+  position: absolute;
+  transform: translateX(-50%);
+  z-index: 99;
 }
 
 .o-page__footer {

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -39,7 +39,7 @@
  * styles position the Alert to match design intent.
  */
 
-.o-page__content-alert {
+.o-page__alert {
   display: flex;
   inline-size: 100%;
   inset-block-start: -1.5em;

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -1,3 +1,5 @@
+@use '../../mixins/spacing';
+
 /**
  * Page container
  *
@@ -32,6 +34,7 @@
  */
 
 .o-page__alert {
+  @include spacing.fluid-padding-inline;
   display: grid;
   grid-row: 2;
   inset-block-start: -1.5em; // 1

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -26,7 +26,7 @@
 }
 
 /**
- * An optional `alert` block can be used to pass an Alert component.
+ * An optional `alert` block can be used to pass an Alert component
  *
  * 1. The alert should overlap the content above slightly
  */

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -30,6 +30,15 @@
   position: relative;
 }
 
+.o-page__footer {
+  grid-row: 3;
+}
+
+/**
+ * An optional `alert` block can be used to pass an Alert component. The following
+ * styles position the Alert to match design intent.
+ */
+
 .o-page__content-alert {
   display: flex;
   inline-size: 100%;
@@ -39,8 +48,4 @@
   position: absolute;
   transform: translateX(-50%);
   z-index: 99;
-}
-
-.o-page__footer {
-  grid-row: 3;
 }

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -1,3 +1,4 @@
+@use '../../compiled/tokens/scss/size';
 @use '../../mixins/spacing';
 
 /**
@@ -37,7 +38,7 @@
   @include spacing.fluid-padding-inline;
   display: grid;
   grid-row: 2;
-  inset-block-start: -1.5em; // 1
+  inset-block-start: calc(size.$overlap-large * -1); // 1
   justify-content: center;
   position: relative;
 }

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -11,7 +11,7 @@
 .o-page {
   display: grid;
   grid-template-columns: minmax(0, 1fr); // 1
-  grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto); // 2
+  grid-template-rows: minmax(0, auto) 0 minmax(0, 1fr) minmax(0, auto); // 2
   min-block-size: 100%;
 }
 
@@ -25,27 +25,24 @@
   grid-row: 1;
 }
 
-.o-page__content {
-  grid-row: 2;
-  position: relative;
-}
-
-.o-page__footer {
-  grid-row: 3;
-}
-
 /**
- * An optional `alert` block can be used to pass an Alert component. The following
- * styles position the Alert to match design intent.
+ * An optional `alert` block can be used to pass an Alert component.
+ *
+ * 1. The alert should overlap the content above slightly
  */
 
 .o-page__alert {
-  display: flex;
-  inline-size: 100%;
-  inset-block-start: -1.5em;
-  inset-inline-start: 50%;
+  display: grid;
+  grid-row: 2;
+  inset-block-start: -1.5em; // 1
   justify-content: center;
-  position: absolute;
-  transform: translateX(-50%);
-  z-index: 99;
+  position: relative;
+}
+
+.o-page__content {
+  grid-row: 3;
+}
+
+.o-page__footer {
+  grid-row: 4;
 }

--- a/src/objects/page/page.stories.mdx
+++ b/src/objects/page/page.stories.mdx
@@ -11,6 +11,9 @@ import { useEffect } from '@storybook/client-api';
 // eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import exampleDemoSource from '!!raw-loader!./demo/example.twig';
 import exampleDemo from './demo/example.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import exampleDemoWithAlertSource from '!!raw-loader!./demo/example-with-alert.twig';
+import exampleDemoWithAlert from './demo/example-with-alert.twig';
 
 <Meta
   title="Objects/Page"
@@ -42,6 +45,27 @@ The header block is optional.
         document.querySelector('#root').style.display = 'contents';
       });
       return exampleDemo();
+    }}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="Example with Alert"
+    height="400px"
+    parameters={{
+      layout: 'fullscreen',
+      docs: { source: { code: exampleDemoWithAlertSource } },
+    }}
+  >
+    {() => {
+      useEffect(() => {
+        // Set this story's `body` element to full-height
+        document.body.style.height = '100%';
+        // Prevent Storybook's container from affecting this layout
+        document.querySelector('#root').style.display = 'contents';
+      });
+      return exampleDemoWithAlert();
     }}
   </Story>
 </Canvas>

--- a/src/objects/page/page.stories.mdx
+++ b/src/objects/page/page.stories.mdx
@@ -49,6 +49,10 @@ The header block is optional.
   </Story>
 </Canvas>
 
+## Page with Alert
+
+The Page object also has an optional `alert` block that can be used to pass an [Alert component](/?path=/docs/components-alert--basic).
+
 <Canvas>
   <Story
     name="Example with Alert"

--- a/src/objects/page/page.stories.mdx
+++ b/src/objects/page/page.stories.mdx
@@ -18,6 +18,17 @@ import exampleDemoWithAlert from './demo/example-with-alert.twig';
 <Meta
   title="Objects/Page"
   parameters={{ docs: { inlineStories: false }, layout: 'fullscreen' }}
+  decorators={[
+    (story) => {
+      useEffect(() => {
+        // Set this story's `body` element to full-height
+        document.body.style.height = '100%';
+        // Prevent Storybook's container from affecting this layout
+        document.querySelector('#root').style.display = 'contents';
+      });
+      return story();
+    },
+  ]}
 />
 
 # Page
@@ -37,15 +48,7 @@ The header block is optional.
       docs: { source: { code: exampleDemoSource } },
     }}
   >
-    {() => {
-      useEffect(() => {
-        // Set this story's `body` element to full-height
-        document.body.style.height = '100%';
-        // Prevent Storybook's container from affecting this layout
-        document.querySelector('#root').style.display = 'contents';
-      });
-      return exampleDemo();
-    }}
+    {exampleDemo()}
   </Story>
 </Canvas>
 
@@ -62,14 +65,6 @@ The Page object also has an optional `alert` block that can be used to pass an [
       docs: { source: { code: exampleDemoWithAlertSource } },
     }}
   >
-    {() => {
-      useEffect(() => {
-        // Set this story's `body` element to full-height
-        document.body.style.height = '100%';
-        // Prevent Storybook's container from affecting this layout
-        document.querySelector('#root').style.display = 'contents';
-      });
-      return exampleDemoWithAlert();
-    }}
+    {exampleDemoWithAlert()}
   </Story>
 </Canvas>

--- a/src/objects/page/page.twig
+++ b/src/objects/page/page.twig
@@ -4,12 +4,12 @@
       {% block header %}{% endblock %}
     </div>
   {% endif %}
+  {% if block('alert') %}
+    <div class="o-page__alert">
+      {% block alert %}{% endblock %}
+    </div>
+  {% endif %}
   <div class="o-page__content{% if content_class %} {{ content_class }}{% endif %}">
-    {% if block('alert') %}
-      <div class="o-page__alert">
-        {% block alert %}{% endblock %}
-      </div>
-    {% endif %}
     {% block content %}{% endblock %}
   </div>
   <div class="o-page__footer{% if footer_class %} {{ footer_class }}{% endif %}">

--- a/src/objects/page/page.twig
+++ b/src/objects/page/page.twig
@@ -6,7 +6,7 @@
   {% endif %}
   <div class="o-page__content{% if content_class %} {{ content_class }}{% endif %}">
     {% if block('alert') %}
-      <div class="o-page__content-alert">
+      <div class="o-page__alert">
         {% block alert %}{% endblock %}
       </div>
     {% endif %}

--- a/src/objects/page/page.twig
+++ b/src/objects/page/page.twig
@@ -5,6 +5,11 @@
     </div>
   {% endif %}
   <div class="o-page__content{% if content_class %} {{ content_class }}{% endif %}">
+    {% if block('alert') %}
+      <div class="o-page__content-alert">
+        {% block alert %}{% endblock %}
+      </div>
+    {% endif %}
     {% block content %}{% endblock %}
   </div>
   <div class="o-page__footer{% if footer_class %} {{ footer_class }}{% endif %}">

--- a/src/tokens/size/sizing.js
+++ b/src/tokens/size/sizing.js
@@ -59,6 +59,10 @@ module.exports = {
         comment:
           'Small amount of overlap between adjacent items organized in a visual bunch.',
       },
+      large: {
+        value: modularEm(1),
+        comment: 'Larger amount of overlap between adjacent items.',
+      },
     },
   },
 };


### PR DESCRIPTION
## Overview

This PR adds an `alert` block intended for an Alert component to be passed in.

There are styles in the Page object CSS that are applied to the `alert` block wrapper to position the Alert per [design intent](https://v-next--cloudfour-patterns.netlify.app/iframe.html?args=&id=prototypes-single-page--example&viewMode=story).

## Screenshots

Smaller viewports | Larger viewports
--- | ---
![localhost_6006_iframe html_id=objects-page--example-with-alert args= viewMode=story(iPhone 5_SE)](https://user-images.githubusercontent.com/459757/178068777-74cdc6b8-9cb1-4a72-83c5-0edae4712b09.png) | <img width="1103" alt="Screen Shot 2022-07-07 at 3 22 35 PM" src="https://user-images.githubusercontent.com/459757/177881337-82cd992f-3b88-425f-94ab-b8a92208a959.png">





## Testing

Preview: https://deploy-preview-1921--cloudfour-patterns.netlify.app/?path=/story/objects-page--example-with-alert

1. Confirm 
    - [ ] the layout matches the [design intent](https://v-next--cloudfour-patterns.netlify.app/iframe.html?args=&id=prototypes-single-page--example&viewMode=story)
    - [ ] the layout works across small and wide viewports
    - [ ] Safari, Firefox, Edge, Chrome

---

- Closes #1922 
