### PR TITLE
Add z-index design token

### DIFF
--- a/.changeset/quick-bikes-shop.md
+++ b/.changeset/quick-bikes-shop.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add z-index `alert` design token and use in Page object for Alert placement

--- a/.style-dictionary/config.js
+++ b/.style-dictionary/config.js
@@ -110,6 +110,13 @@ module.exports = {
             attributes: { category: 'time', type: 'transition' },
           },
         },
+        {
+          destination: '_z-index.scss',
+          format: 'scss/variables',
+          filter: {
+            attributes: { category: 'number', type: 'z_index' },
+          },
+        },
       ],
     },
     js: {

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -1,4 +1,5 @@
 @use '../../compiled/tokens/scss/size';
+// @use '../../compiled/tokens/scss/z-index'; // TODO fix this, it's broken
 @use '../../mixins/spacing';
 
 /**
@@ -41,6 +42,7 @@
   inset-block-start: calc(size.$overlap-large * -1); // 1
   justify-content: center;
   position: relative;
+  z-index: z_;
 }
 
 .o-page__content {

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -1,5 +1,5 @@
 @use '../../compiled/tokens/scss/size';
-// @use '../../compiled/tokens/scss/z-index'; // TODO fix this, it's broken
+@use '../../compiled/tokens/scss/z-index'; // TODO fix this, it's broken
 @use '../../mixins/spacing';
 
 /**
@@ -42,7 +42,7 @@
   inset-block-start: calc(size.$overlap-large * -1); // 1
   justify-content: center;
   position: relative;
-  z-index: z_;
+  z-index: z-index.$alert;
 }
 
 .o-page__content {

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -1,5 +1,5 @@
 @use '../../compiled/tokens/scss/size';
-@use '../../compiled/tokens/scss/z-index'; // TODO fix this, it's broken
+@use '../../compiled/tokens/scss/z-index';
 @use '../../mixins/spacing';
 
 /**

--- a/src/tokens/number/z-index.json
+++ b/src/tokens/number/z-index.json
@@ -2,7 +2,7 @@
   "number": {
     "z_index": {
       "alert": {
-        "value": "999",
+        "value": 999,
         "comment": "Intended to be used for alert messages that float above page content."
       }
     }

--- a/src/tokens/number/z-index.json
+++ b/src/tokens/number/z-index.json
@@ -1,0 +1,10 @@
+{
+  "number": {
+    "z_index": {
+      "alert": {
+        "value": "999",
+        "comment": "Intended to be used for alert messages that float above page content."
+      }
+    }
+  }
+}

--- a/src/tokens/z-index.stories.mdx
+++ b/src/tokens/z-index.stories.mdx
@@ -1,0 +1,40 @@
+import { Meta } from '@storybook/addon-docs';
+import tokens from '../compiled/tokens/js/tokens.js';
+const zIndexRows = Object.entries(tokens.number.z_index).map(
+  ([key, { name, value, comment, attributes }]) => (
+    <tr key={name}>
+      <td>
+        <code>z-index.${attributes.item}</code>
+      </td>
+      <td>
+        <code>{value}</code>
+      </td>
+      <td>{comment}</td>
+    </tr>
+  )
+);
+
+<Meta title="Design/Tokens/Z-index" />
+
+# Z-index
+
+```scss
+@use '../../compiled/tokens/scss/z-index';
+$example: z-index.$alert; // => 999
+```
+
+```javascript
+import tokens from '../../compiled/tokens/js/tokens';
+console.log(tokens.number.line_height.z_index.value); // => 999
+```
+
+<table>
+  <thead>
+    <tr>
+      <th style={{ width: '10%' }}>Name</th>
+      <th>Value</th>
+      <th>Comment</th>
+    </tr>
+  </thead>
+  <tbody>{zIndexRows}</tbody>
+</table>


### PR DESCRIPTION
## Overview

- Add `alert` z-index design token
- Use design token in Page object for Alert placement

## Screenshots

<img width="1136" alt="Screen Shot 2022-07-11 at 10 18 56 AM" src="https://user-images.githubusercontent.com/459757/178321352-0e273e8b-6214-4f11-91e8-11478fecb7b9.png">


## Testing

1. Review new [`z-index` design token documentation](https://deploy-preview-1928--cloudfour-patterns.netlify.app/?path=/story/design-tokens-z-index--page) 
1. Review [example Page object with Alert story](https://deploy-preview-1928--cloudfour-patterns.netlify.app/?path=/story/objects-page--example-with-alert)

---

- Closes #1931 