### PR TITLE
More o-deck column modifiers

### DIFF
--- a/.changeset/dirty-vans-wonder.md
+++ b/.changeset/dirty-vans-wonder.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Increase the supported column modifiers from 4 to 6 for the Deck layout object to support smaller content chunks

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -38,7 +38,7 @@
  * maximum or to coordinate with adjacent elements.
  */
 
-@for $i from 1 through 4 {
+@for $i from 1 through 6 {
   .o-deck--#{$i}-column {
     @include media-query.breakpoint-classes($from: s, $to: xl) {
       grid-template-columns: repeat(#{$i}, 1fr);

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -54,7 +54,7 @@ const alignmentClasses = {
       control: {
         type: 'range',
         min: 1,
-        max: 4,
+        max: 6,
         step: 1,
       },
     },
@@ -144,7 +144,7 @@ When used in WordPress, the `alignwide` and `alignfull` block alignment styles h
 
 While automatic columns are convenient, there are times when a specific column count is desired. For example, you may want to limit a design to three columns at larger breakpoints to align with adjacent elements.
 
-To do this, add a modifier class in the format of `o-deck--X-column@Y`, where `X` is the desired column count (from 1 to 4) and `Y` is the desired [breakpoint](/docs/design-tokens-breakpoint--page) (from `s` to `xl`). In this example, we force the grid to display three columns starting from the `m` breakpoint.
+To do this, add a modifier class in the format of `o-deck--X-column@Y`, where `X` is the desired column count (from 1 to 6) and `Y` is the desired [breakpoint](/docs/design-tokens-breakpoint--page) (from `s` to `xl`). In this example, we force the grid to display three columns starting from the `m` breakpoint.
 
 <Canvas>
   <Story


### PR DESCRIPTION
## Overview

We found at least one case where we needed a Deck with 5 columns, but our layout object maxed out at 4.

It felt weird to max out at an odd number, so I increased the maximum columns to 6 just to future-proof a bit.

## Testing

Open [this story](https://deploy-preview-1929--cloudfour-patterns.netlify.app/?path=/story/objects-deck--columns) and try a column count of 5 and 6, confirm it works as expected.

---

- Fixes #1923 