### PR TITLE
Add `wp-block-video` alignment options

### DIFF
--- a/.changeset/smooth-owls-try.md
+++ b/.changeset/smooth-owls-try.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Make default, center, full and wide alignment options consistent between WordPress image and video blocks

--- a/src/vendor/wordpress/demo/alignment.twig
+++ b/src/vendor/wordpress/demo/alignment.twig
@@ -36,6 +36,13 @@
       </div>
     {% endif %}
     <p>
+      Another ordinary paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at sapien porttitor risus blandit posuere. Sed in malesuada ligula. Nam vulputate metus sed nibh vulputate, sed varius neque tincidunt.
+    </p>
+    <figure class="wp-block-video {{alignment}}">
+      <video controls src="/media/waterfall_edit.mp4"></video>
+      <figcaption>This WordPress Video Block with a caption has <b>{{alignment|default('no')|replace({'align': ''})}} alignment</b>!</figcaption>
+    </figure>
+    <p>
       One more ordinary paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse at sapien porttitor risus blandit posuere. Sed in malesuada ligula. Nam vulputate metus sed nibh vulputate, sed varius neque tincidunt.
     </p>
   {% endblock %}

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -174,6 +174,20 @@ figure.wp-block-image {
   }
 }
 
+/// Gutenberg block: Video
+/// Styles for videos inserted via Gutenberg blocks.
+.wp-block-video {
+  &:not(.alignwide, .alignfull, .aligncenter) {
+    @include spacing.fluid-margin-inline-negative;
+  }
+
+  &:not(.aligncenter) {
+    figcaption {
+      @include spacing.fluid-padding-inline;
+    }
+  }
+}
+
 /**
  * Gutenberg block: Table
  * Applies our pattern library styles to tables generated via Gutenberg blocks.

--- a/src/vendor/wordpress/utilities.stories.mdx
+++ b/src/vendor/wordpress/utilities.stories.mdx
@@ -87,14 +87,14 @@ We include `has-{font-size}-font-size` classes for our `big`, `small` and headin
 
 By default, blocks with backgrounds and image blocks will attempt to fill the available inline padding of [our containers](/docs/objects-container--basic). You can opt into different alignment options for certain blocks.
 
-| WordPress Class | Behavior                                  | Blocks                                     |
-| --------------- | ----------------------------------------- | ------------------------------------------ |
-| (None)          | Fill available inline padding             | Code, Image, blocks with background colors |
-| `aligncenter`   | Stay within the container (do not fill)   | Image, blocks with background colors       |
-| `alignleft`     | Float left, constrain inline size         | Image                                      |
-| `alignright`    | Float right, constrain inline size        | Image                                      |
-| `alignfull`     | Fill viewport inline size                 | Blocks with alignment options              |
-| `alignwide`     | Fill viewport inline size up to a maximum | Blocks with alignment options              |
+| WordPress Class | Behavior                                  | Blocks                                            |
+| --------------- | ----------------------------------------- | ------------------------------------------------- |
+| (None)          | Fill available inline padding             | Code, Image, Video, blocks with background colors |
+| `aligncenter`   | Stay within the container (do not fill)   | Image, Video, blocks with background colors       |
+| `alignleft`     | Float left, constrain inline size         | Image                                             |
+| `alignright`    | Float right, constrain inline size        | Image                                             |
+| `alignfull`     | Fill viewport inline size                 | Blocks with alignment options                     |
+| `alignwide`     | Fill viewport inline size up to a maximum | Blocks with alignment options                     |
 
 <Canvas>
   <Story


### PR DESCRIPTION
## Overview

Adds styles for `.wp-block-video` class so the default, center, full and wide alignment options are consistent between WordPress image and video blocks.

## Screenshots

<img width="514" alt="Screen Shot 2022-07-11 at 10 04 23 AM" src="https://user-images.githubusercontent.com/69633/178319293-fc97fa51-d3a0-413b-bf42-35cc260d0aab.png">
<img width="510" alt="Screen Shot 2022-07-11 at 10 04 36 AM" src="https://user-images.githubusercontent.com/69633/178319310-05b0b278-82ef-4cbf-bb25-62c335416815.png">

## Testing

[In this story](https://deploy-preview-1930--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-utilities--alignment), mess with the controls and confirm that alignment between the image and video examples are consistent for all alignment options other than left and right.

---

- Fixes #1920