### PR TITLE
Add `o-container__pad` class

### DIFF
--- a/.changeset/cyan-lies-arrive.md
+++ b/.changeset/cyan-lies-arrive.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": minor
+---
+
+Add `o-container__pad` class

--- a/src/objects/container/container.scss
+++ b/src/objects/container/container.scss
@@ -41,6 +41,17 @@
 }
 
 /**
+ * Child elements that need a bit of inline padding to avoid the viewport edge.
+ */
+
+.o-container__pad {
+  .o-container--pad &,
+  .o-container--pad-inline & {
+    @include spacing.fluid-padding-inline;
+  }
+}
+
+/**
  * Child elements intended to "fill" the container width. This negates any
  * inline padding and border radii.
  */

--- a/src/objects/container/container.stories.mdx
+++ b/src/objects/container/container.stories.mdx
@@ -136,6 +136,7 @@ There are times when a child element should attempt to fill the container conten
 
 Two child element classes exist for this purpose:
 
+- `o-container__pad`: Adds the standard container padding to a child element.
 - `o-container__fill`: Negates any inline padding so the element will reach the edges of the content container's padding.
 - `o-container__fill-pad`: Also applies padding to the element so its content will align with that of the container.
 

--- a/src/objects/container/demo/fill.twig
+++ b/src/objects/container/demo/fill.twig
@@ -12,6 +12,14 @@
             <p>.c-card.c-card--contained</p>
           {% endblock %}
         {% endembed %}
+        <p>This card gains the default container padding:</p>
+        {% embed '@cloudfour/components/card/card.twig' with {
+          class: 'c-card--contained o-container__pad'
+        } only %}
+          {% block content %}
+            <p>.c-card.c-card--contained</p>
+          {% endblock %}
+        {% endembed %}
         <p>This card attempts to fill the container, padding included:</p>
         {% embed '@cloudfour/components/card/card.twig' with {
           class: 'c-card--contained o-container__fill'

--- a/src/objects/container/demo/fill.twig
+++ b/src/objects/container/demo/fill.twig
@@ -17,7 +17,7 @@
           class: 'c-card--contained o-container__pad'
         } only %}
           {% block content %}
-            <p>.c-card.c-card--contained</p>
+            <p>.c-card.c-card--contained.o-container__pad</p>
           {% endblock %}
         {% endembed %}
         <p>This card attempts to fill the container, padding included:</p>


### PR DESCRIPTION
## Overview

This PR adds the new `o-container__pad` class, which behaves similarly
to the existing `o-container__fill` & `o-container__fill-pad` classes,
adding the standard container inline padding to a container child.

## Screenshots

<img width="600" alt="Screen Shot 2022-07-12 at 3 10 38 PM" src="https://user-images.githubusercontent.com/257309/178604159-dffa5663-aea0-409d-a9ab-511c8070dafd.png">

## Testing

1. Review the Container > Fill story on the preview deploy

---

- Fixes #1935