### PR TITLE
Remove Block Alignment Override Styles for Deck

### DIFF
--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -53,22 +53,3 @@
 .o-deck--align-start {
   align-items: start;
 }
-
-/**
- * Block alignment adjustments
- *
- * 1. Set inline padding since we don't want the deck to touch the viewport
- *    edges even when it's full bleed.
- * 2. Remove padding once `alignwide` is no longer full-bleed.
- */
-
-.o-deck.alignfull,
-.o-deck.alignwide {
-  @include spacing.fluid-padding-inline; // 1
-}
-
-.o-deck.alignwide {
-  @media (width >= breakpoint.$l) {
-    padding-inline: 0; // 2
-  }
-}

--- a/src/objects/deck/deck.stories.mdx
+++ b/src/objects/deck/deck.stories.mdx
@@ -122,24 +122,6 @@ The `o-deck--align-start` modifier can be used to top-align deck items. This mod
   </Story>
 </Canvas>
 
-## Block Alignment
-
-When used in WordPress, the `alignwide` and `alignfull` block alignment styles have been updated for use with the Deck.
-
-<Canvas>
-  <Story
-    name="Block Alignment"
-    height="400px"
-    args={{
-      columns: 3,
-      columnsBreakpoint: '@m',
-      alignment: 'alignfull',
-    }}
-  >
-    {articlesStory.bind({})}
-  </Story>
-</Canvas>
-
 ## Specifying Columns
 
 While automatic columns are convenient, there are times when a specific column count is desired. For example, you may want to limit a design to three columns at larger breakpoints to align with adjacent elements.


### PR DESCRIPTION
## Overview

This PR removes the custom block alignment styles for the Deck object.
These weren't working quite as intended, and we're removing them in
favor of editors adding the `o-container__pad` class as needed.