### PR TITLE
Add Comment Explaining CSS Dependencies

### DIFF
--- a/src/index-with-dependencies.scss
+++ b/src/index-with-dependencies.scss
@@ -1,3 +1,7 @@
+///
+/// This file is only for use in Storybook, where we need to manually add
+/// CSS dependencies that WordPress handles, such as the block library.
+///
 // stylelint-disable at-rule-disallowed-list
 @import '../node_modules/@wordpress/block-library/build-style/style';
 @import './index';


### PR DESCRIPTION
## Overview

This PR adds a comment to `index-with-dependencies.scss` to explain how the file and used and why the dependencies are needed.