### PR TITLE
Sky Nav: Remove layout shift caused by progressive enhancement

### DIFF
--- a/.changeset/stale-donuts-retire.md
+++ b/.changeset/stale-donuts-retire.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Remove the Sky Nav layout shift

--- a/.changeset/stale-donuts-retire.md
+++ b/.changeset/stale-donuts-retire.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Remove the Sky Nav layout shift
+Remove layout shift caused by progressive enhancement

--- a/.changeset/stale-donuts-retire.md
+++ b/.changeset/stale-donuts-retire.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Remove layout shift caused by progressive enhancement
+Remove small viewport Sky Nav layout shift caused by progressive enhancement

--- a/src/components/sky-nav/sky-nav.scss
+++ b/src/components/sky-nav/sky-nav.scss
@@ -362,8 +362,10 @@ $_masthead-height-sm: ms.step(7);
    * we hide the menu items during the "loading" state. The "loading" state
    * happens after the UI renders and before the Sky Nav JS is loaded.
    */
-  .is-loading & {
-    display: none;
+  @media (width < $_breakpoint-wide) {
+    .is-loading & {
+      display: none;
+    }
   }
 
   /**
@@ -378,14 +380,6 @@ $_masthead-height-sm: ms.step(7);
     display: flex; /* 1 */
     flex: 1; /* 2 */
     justify-content: flex-end; /* 3 */
-
-    /**
-     * For larger viewports, we do the opposite of smaller viewports and show
-     * the menu items during the "loading" state.
-     */
-    .is-loading & {
-      display: flex;
-    }
   }
 
   /**

--- a/src/components/sky-nav/sky-nav.scss
+++ b/src/components/sky-nav/sky-nav.scss
@@ -265,6 +265,10 @@ $_masthead-height-sm: ms.step(7);
   @media (min-width: $_breakpoint-wide) {
     display: none;
   }
+
+  .no-js & {
+    display: none;
+  }
 }
 
 /**
@@ -365,6 +369,10 @@ $_masthead-height-sm: ms.step(7);
    */
   @media (min-width: $_breakpoint-wide) and (max-width: $_breakpoint-wide-max) {
     flex-wrap: wrap;
+  }
+
+  .is-loading & {
+    display: none;
   }
 }
 

--- a/src/components/sky-nav/sky-nav.scss
+++ b/src/components/sky-nav/sky-nav.scss
@@ -266,6 +266,9 @@ $_masthead-height-sm: ms.step(7);
     display: none;
   }
 
+  /**
+   * There is no need to show the menu toggle if JS is not available.
+   */
   .no-js & {
     display: none;
   }

--- a/src/components/sky-nav/sky-nav.scss
+++ b/src/components/sky-nav/sky-nav.scss
@@ -350,6 +350,20 @@ $_masthead-height-sm: ms.step(7);
   padding-inline-start: 0; /* 1 */
 
   /**
+   * The Sky Nav is progressively enhanced with JS at smaller viewports. By default
+   * it is open for when JS is not available. In cases where JS _is_ available,
+   * this causes a poor loading UX where the menu jumps from open to closed
+   * causing a large layout shift.
+   *
+   * To keep the progressive enhancement in place _and_ not have the layout shift,
+   * we hide the menu items during the "loading" state. The "loading" state
+   * happens after the UI renders and before the Sky Nav JS is loaded.
+   */
+  .is-loading & {
+    display: none;
+  }
+
+  /**
    * When the layout is wide enough to expose these items…
    *
    * 1. Display them horizontally.
@@ -361,6 +375,14 @@ $_masthead-height-sm: ms.step(7);
     display: flex; /* 1 */
     flex: 1; /* 2 */
     justify-content: flex-end; /* 3 */
+
+    /**
+     * For larger viewports, we do the opposite of smaller viewports and show
+     * the menu items during the "loading" state.
+     */
+    .is-loading & {
+      display: flex;
+    }
   }
 
   /**
@@ -369,10 +391,6 @@ $_masthead-height-sm: ms.step(7);
    */
   @media (min-width: $_breakpoint-wide) and (max-width: $_breakpoint-wide-max) {
     flex-wrap: wrap;
-  }
-
-  .is-loading & {
-    display: none;
   }
 }
 

--- a/src/components/sky-nav/sky-nav.test.ts
+++ b/src/components/sky-nav/sky-nav.test.ts
@@ -29,6 +29,7 @@ test(
     });
     // Pleasantest uses `document.innerHTML` to inject the markup into the DOM,
     // but that means inline scripts are not executed.
+    // @see https://github.com/cloudfour/pleasantest/issues/526
     //
     // > HTML5 specifies that a <script> tag inserted with innerHTML should not execute.
     // @see https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations

--- a/src/components/sky-nav/sky-nav.test.ts
+++ b/src/components/sky-nav/sky-nav.test.ts
@@ -42,6 +42,7 @@ test(
           heading "Main Menu" (level=2)
             text "Main Menu"
           button "Toggle Main Menu" (expanded=false)
+          text "<style> @media (max-width: 40em) { .c-sky-nav__menu-items { display: block; /* 2 */ } } </style>"
     `);
 
     await user.click(navButton);
@@ -81,6 +82,7 @@ test(
             listitem
               link "Team"
                 text "Team"
+          text "<style> @media (max-width: 40em) { .c-sky-nav__menu-items { display: block; /* 2 */ } } </style>"
     `);
   })
 );
@@ -129,6 +131,7 @@ test(
             listitem
               link "Team"
                 text "Team"
+          text "<style> @media (max-width: 40em) { .c-sky-nav__menu-items { display: block; /* 2 */ } } </style>"
     `);
   })
 );

--- a/src/components/sky-nav/sky-nav.test.ts
+++ b/src/components/sky-nav/sky-nav.test.ts
@@ -21,7 +21,30 @@ const initSkyNavJS = (utils: PleasantestUtils, navButton: ElementHandle) =>
 test(
   'can be opened on small screens',
   withBrowser({ device: iPhone }, async ({ utils, screen, user, page }) => {
-    await utils.injectHTML(await skyNavMarkup({ includeMainDemo: true, menu }));
+    // The rendered markup needs to be captured so we can pass it into the
+    // `page.evaluate` function below
+    const renderedMarkup = await skyNavMarkup({
+      includeMainDemo: true,
+      menu,
+    });
+    // Pleasantest uses `document.innerHTML` to inject the markup into the DOM,
+    // but that means inline scripts are not executed.
+    //
+    // > HTML5 specifies that a <script> tag inserted with innerHTML should not execute.
+    // @see https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#security_considerations
+    //
+    // This causes this test to fail because the Sky Nav template has an inline
+    // script. To get around that, the code below uses `document.write` instead
+    // which _will_ execute the inline script.
+    //
+    // Using `document.write` is discouraged. For the purposes of this test,
+    // though, it is okay.
+    // @see https://developer.mozilla.org/en-US/docs/Web/API/Document/write
+    await page.evaluate((renderedMarkup) => {
+      document.body.innerHTML = '';
+      document.write(renderedMarkup);
+    }, renderedMarkup);
+
     await loadGlobalCSS(utils);
     const navButton = await screen.getByRole('button', {
       name: /toggle main menu/i,

--- a/src/components/sky-nav/sky-nav.test.ts
+++ b/src/components/sky-nav/sky-nav.test.ts
@@ -42,7 +42,6 @@ test(
           heading "Main Menu" (level=2)
             text "Main Menu"
           button "Toggle Main Menu" (expanded=false)
-          text "<style> @media (max-width: 40em) { .c-sky-nav__menu-items { display: block; /* 2 */ } } </style>"
     `);
 
     await user.click(navButton);
@@ -82,7 +81,6 @@ test(
             listitem
               link "Team"
                 text "Team"
-          text "<style> @media (max-width: 40em) { .c-sky-nav__menu-items { display: block; /* 2 */ } } </style>"
     `);
   })
 );
@@ -131,7 +129,6 @@ test(
             listitem
               link "Team"
                 text "Team"
-          text "<style> @media (max-width: 40em) { .c-sky-nav__menu-items { display: block; /* 2 */ } } </style>"
     `);
   })
 );

--- a/src/components/sky-nav/sky-nav.ts
+++ b/src/components/sky-nav/sky-nav.ts
@@ -31,6 +31,11 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
       navButton.removeAttribute('aria-expanded');
       menu.hidden = false;
     } else {
+      // The menu begins with `display: none` (via an inline style) to avoid
+      // a large layout shift. The code needs to make sure it sets the display
+      // back to `block` (it's default) so that it can be toggled opened/closed
+      // via the `hidden` attribute.
+      menu.style.display = 'block';
       navButton.setAttribute('aria-expanded', 'false');
       menu.hidden = true;
     }

--- a/src/components/sky-nav/sky-nav.ts
+++ b/src/components/sky-nav/sky-nav.ts
@@ -21,7 +21,9 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
     '(prefers-reduced-motion: reduce)'
   );
 
-  // No need for "no JS" styles to be applied
+  // The Sky Nav component has inline synchronous JS logic to add an `is-loading`
+  // state to remove the layout shift at smaller viewports. That state no longer
+  // applies at this point since the Sky Nav JS has loaded & is ready to take over.
   navWrapper.classList.remove('is-loading');
 
   /**

--- a/src/components/sky-nav/sky-nav.ts
+++ b/src/components/sky-nav/sky-nav.ts
@@ -21,6 +21,9 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
     '(prefers-reduced-motion: reduce)'
   );
 
+  // No need for "no JS" styles to be applied
+  navWrapper.classList.remove('is-loading');
+
   /**
    * Update Menu Layout
    * Sets visibility of menu & navButton for small vs large screen layouts.
@@ -35,7 +38,7 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
       // to avoid a large layout shift caused by progressive enhancement. The
       // logic below needs to make sure it sets the display back to `block` so
       // that it can be toggled opened/closed via the `hidden` attribute.
-      menu.style.display = 'block';
+      // menu.style.display = 'block';
       navButton.setAttribute('aria-expanded', 'false');
       menu.hidden = true;
     }

--- a/src/components/sky-nav/sky-nav.ts
+++ b/src/components/sky-nav/sky-nav.ts
@@ -36,11 +36,6 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
       navButton.removeAttribute('aria-expanded');
       menu.hidden = false;
     } else {
-      // The menu begins with `display: none` (see `sky-nav.twig` inline style)
-      // to avoid a large layout shift caused by progressive enhancement. The
-      // logic below needs to make sure it sets the display back to `block` so
-      // that it can be toggled opened/closed via the `hidden` attribute.
-      // menu.style.display = 'block';
       navButton.setAttribute('aria-expanded', 'false');
       menu.hidden = true;
     }

--- a/src/components/sky-nav/sky-nav.ts
+++ b/src/components/sky-nav/sky-nav.ts
@@ -31,10 +31,10 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
       navButton.removeAttribute('aria-expanded');
       menu.hidden = false;
     } else {
-      // The menu begins with `display: none` (via an inline style) to avoid
-      // a large layout shift. The code needs to make sure it sets the display
-      // back to `block` (it's default) so that it can be toggled opened/closed
-      // via the `hidden` attribute.
+      // The menu begins with `display: none` (see `sky-nav.twig` inline style)
+      // to avoid a large layout shift caused by progressive enhancement. The
+      // logic below needs to make sure it sets the display back to `block` so
+      // that it can be toggled opened/closed via the `hidden` attribute.
       menu.style.display = 'block';
       navButton.setAttribute('aria-expanded', 'false');
       menu.hidden = true;

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -82,8 +82,7 @@
         2. If JS is not available, make sure the menu is open so it can be used
 
         If JS _is_ available, the `sky-nav.ts` logic is responsible for setting
-        it back to `display: block`. This allows the menu to open/close via
-        changing it's `hidden` value as it was originally designed.
+        it back to `display: block`.
       #}
       <style>
         @media (max-width: 40em) {

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -1,7 +1,7 @@
 {% set main_id = main_id|default('main') %}
 {% set _main_href = '#' ~ main_id %}
 
-<div class="c-sky-nav js-sky-nav{% if class %} {{ class }}{% endif %}">
+<div class="c-sky-nav js-sky-nav no-js{% if class %} {{ class }}{% endif %}">
   {# https://webaim.org/techniques/skipnav/ #}
   {% embed '@cloudfour/components/button/button.twig' with {
     class: 'c-sky-nav__skip',
@@ -84,32 +84,15 @@
         If JS _is_ available, the `sky-nav.ts` logic is responsible for setting
         it back to `display: block`.
       #}
-      <style>
-        @media (max-width: 40em) {
-          .c-sky-nav__menu-items {
-            display: none; /* 1 */
-          }
-        }
-      </style>
-      <noscript>
-        <style>
-          @media (max-width: 40em) {
-            .c-sky-nav__menu-items {
-              display: block; /* 2 */
-            }
-          }
-
-          {#
-            1. If no JS, then no need for the menu toggle button
-          #}
-          .c-sky-nav__menu-toggle {
-            display: none; /* 1 */
-          }
-        </style>
-      </noscript>
     </nav>
   </header>
 </div>
+
+<script>
+  const skyNav = document.querySelector('.js-sky-nav');
+  skyNav.classList.remove('no-js');
+  skyNav.classList.add('is-loading');
+</script>
 
 {#
   For some reason Twig.js really doesn't like including this template in a demo,

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -1,6 +1,11 @@
 {% set main_id = main_id|default('main') %}
 {% set _main_href = '#' ~ main_id %}
 
+{#
+  The Sky Nav component uses progressive enhancement and assumes JS is not
+  available as the default. The `no-js` CSS class is the hook to style properly
+  in that use case.
+#}
 <div class="c-sky-nav js-sky-nav no-js{% if class %} {{ class }}{% endif %}">
   {# https://webaim.org/techniques/skipnav/ #}
   {% embed '@cloudfour/components/button/button.twig' with {

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -87,7 +87,7 @@
    * To keep the progressive enhancement in place _and_ not have the layout
    * shift, the Sky Nav component assumes `no-js` to begin with. If JS is enabled:
    *
-   * 1. Remove the `no-js` state (which removes non-JS menu styles)
+   * 1. Remove the `no-js` state (which removes no-JS menu styles)
    * 2. Add the `is-loading` state. This happens before the Sky Nav JS has loaded
    *    allowing us a hook to hide the menu items to remove the layout shift. Once
    *    the Sky Nav JS loads, it removes the `is-loading` state CSS class and the

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -78,21 +78,21 @@
   </header>
 </div>
 <script>
-  /**
-   * The Sky Nav is progressively enhanced with JS at smaller viewports.
-   * By default it is open for when JS is not available. In cases where JS
-   * _is_ available, this causes a poor loading UX where the menu jumps from
-   * open to closed causing a large layout shift.
-   *
-   * To keep the progressive enhancement in place _and_ not have the layout
-   * shift, the Sky Nav component assumes `no-js` to begin with. If JS is enabled:
-   *
-   * 1. Remove the `no-js` state (which removes no-JS menu styles)
-   * 2. Add the `is-loading` state. This happens before the Sky Nav JS has loaded
-   *    allowing us a hook to hide the menu items to remove the layout shift. Once
-   *    the Sky Nav JS loads, it removes the `is-loading` state CSS class and the
-   *    menu functions as was originally designed.
-   */
+  {#
+    The Sky Nav is progressively enhanced with JS at smaller viewports.
+    By default it is open for when JS is not available. In cases where JS
+    _is_ available, this causes a poor loading UX where the menu jumps from
+    open to closed causing a large layout shift.
+
+    To keep the progressive enhancement in place _and_ not have the layout
+    shift, the Sky Nav component assumes `no-js` to begin with. If JS is enabled:
+
+    1. Remove the `no-js` state (which removes no-JS menu styles)
+    2. Add the `is-loading` state. This happens before the Sky Nav JS has loaded
+       allowing us a hook to hide the menu items to remove the layout shift. Once
+       the Sky Nav JS loads, it removes the `is-loading` state CSS class and the
+       menu functions as was originally designed.
+  #}
   const skyNav = document.querySelector('.js-sky-nav');
   skyNav.classList.remove('no-js'); // 1
   skyNav.classList.add('is-loading'); // 2

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -77,23 +77,22 @@
     </nav>
   </header>
 </div>
-
-{#
-  The Sky Nav is progressively enhanced with JS at smaller viewports.
-  By default it is open for when JS is not available. In cases where JS
-  _is_ available, this causes a poor loading UX where the menu jumps from
-  open to closed causing a large layout shift.
-
-  To keep the progressive enhancement in place _and_ not have the layout
-  shift, the Sky Nav component assumes `no-js` to begin with. If JS is enabled:
-
-  1. Remove the `no-js` state (which removes non-JS menu styles)
-  2. Add the `is-loading` state. This happens before the Sky Nav JS has loaded
-     allowing us a hook to hide the menu items to remove the layout shift. Once
-     the Sky Nav JS loads, it removes the `is-loading` state CSS class and the
-     menu functions as was originally designed.
-#}
 <script>
+  /**
+   * The Sky Nav is progressively enhanced with JS at smaller viewports.
+   * By default it is open for when JS is not available. In cases where JS
+   * _is_ available, this causes a poor loading UX where the menu jumps from
+   * open to closed causing a large layout shift.
+   *
+   * To keep the progressive enhancement in place _and_ not have the layout
+   * shift, the Sky Nav component assumes `no-js` to begin with. If JS is enabled:
+   *
+   * 1. Remove the `no-js` state (which removes non-JS menu styles)
+   * 2. Add the `is-loading` state. This happens before the Sky Nav JS has loaded
+   *    allowing us a hook to hide the menu items to remove the layout shift. Once
+   *    the Sky Nav JS loads, it removes the `is-loading` state CSS class and the
+   *    menu functions as was originally designed.
+   */
   const skyNav = document.querySelector('.js-sky-nav');
   skyNav.classList.remove('no-js'); // 1
   skyNav.classList.add('is-loading'); // 2

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -69,6 +69,38 @@
           </li>
         {% endfor %}
       </ul>
+      {#
+        The Sky Nav is progressively enhanced with JS at smaller viewports.
+        By default it is open for when JS is not available. In cases where JS
+        _is_ available, this causes a poor loading UX where the menu jumps from
+        open to closed causing a large layout shift.
+
+        To keep the progressive enhancement in place _and_ not have the layout
+        shift, the inline styles below are in play.
+
+        1. Start with the menu not displayed to avoid a layout shift
+        2. If JS is not available, make sure the menu is open so it can be used
+
+        If JS _is_ available, the `sky-nav.ts` logic is responsible for setting
+        it back to `display: block`. This allows the menu to open/close via
+        changing it's `hidden` value as it was originally designed.
+      #}
+      <style>
+        @media (max-width: 40em) {
+          .c-sky-nav__menu-items {
+            display: none; /* 1 */
+          }
+        }
+      </style>
+      <noscript>
+        <style>
+          @media (max-width: 40em) {
+            .c-sky-nav__menu-items {
+              display: block; /* 2 */
+            }
+          }
+        </style>
+      </noscript>
     </nav>
   </header>
 </div>

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -98,6 +98,13 @@
               display: block; /* 2 */
             }
           }
+
+          {#
+            1. If no JS, then no need for the menu toggle button
+          #}
+          .c-sky-nav__menu-toggle {
+            display: none; /* 1 */
+          }
         </style>
       </noscript>
     </nav>

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -69,29 +69,29 @@
           </li>
         {% endfor %}
       </ul>
-      {#
-        The Sky Nav is progressively enhanced with JS at smaller viewports.
-        By default it is open for when JS is not available. In cases where JS
-        _is_ available, this causes a poor loading UX where the menu jumps from
-        open to closed causing a large layout shift.
-
-        To keep the progressive enhancement in place _and_ not have the layout
-        shift, the inline styles below are in play.
-
-        1. Start with the menu not displayed to avoid a layout shift
-        2. If JS is not available, make sure the menu is open so it can be used
-
-        If JS _is_ available, the `sky-nav.ts` logic is responsible for setting
-        it back to `display: block`.
-      #}
     </nav>
   </header>
 </div>
 
+{#
+  The Sky Nav is progressively enhanced with JS at smaller viewports.
+  By default it is open for when JS is not available. In cases where JS
+  _is_ available, this causes a poor loading UX where the menu jumps from
+  open to closed causing a large layout shift.
+
+  To keep the progressive enhancement in place _and_ not have the layout
+  shift, the Sky Nav component assumes `no-js` to begin with. If JS is enabled:
+
+  1. Remove the `no-js` state (which removes non-JS menu styles)
+  2. Add the `is-loading` state. This happens before the Sky Nav JS has loaded
+     allowing us a hook to hide the menu items to remove the layout shift. Once
+     the Sky Nav JS loads, it removes the `is-loading` state CSS class and the
+     menu functions as was originally designed.
+#}
 <script>
   const skyNav = document.querySelector('.js-sky-nav');
-  skyNav.classList.remove('no-js');
-  skyNav.classList.add('is-loading');
+  skyNav.classList.remove('no-js'); // 1
+  skyNav.classList.add('is-loading'); // 2
 </script>
 
 {#


### PR DESCRIPTION
## Overview

This PR adds logic to the Sky Nav component to keep progressive enhancement in place, while also avoiding a layout shift on smaller viewports.

## Screenshots

### Smaller viewports cumulative layout shift

BEFORE | AFTER
--- | ---
Cumulative layout shift: `0.441` | Cumulative layout shift: `0`
<img alt="sobbing" src="https://media.giphy.com/media/10tIjpzIu8fe0/giphy.gif"> | <img alt="Oh yeah" src="https://media.giphy.com/media/26uflnCMlbEeYZCQU/giphy.gif">
<img width="772" alt="Screen Shot 2022-07-14 at 9 50 44 AM" src="https://user-images.githubusercontent.com/459757/179072696-a45d1532-330a-4288-90a9-5dc7da6a8157.png"> | <img width="769" alt="Screen Shot 2022-07-14 at 9 50 56 AM" src="https://user-images.githubusercontent.com/459757/179072703-fd4057ef-d0a7-4a3c-8598-d0f91cfa3545.png">
![before-layout-shift](https://user-images.githubusercontent.com/459757/179045042-4fb44d01-16f5-46a6-a8ce-55296c93b0f5.gif) | ![after-layout-shift](https://user-images.githubusercontent.com/459757/179045306-a12f9dd2-45ef-4482-8551-3428944a1439.gif)

### Smaller viewports with JS disabled

Notice the menu toggle button is removed in the "After" since, without JS, it's not functional. 

Left: Before
Right: After 

<img width="819" alt="Screen Shot 2022-07-14 at 9 47 23 AM" src="https://user-images.githubusercontent.com/459757/179044074-d806f633-926f-4de2-8c00-aae0b35f528c.png">

### Larger viewports stay the same

Before | After
--- | ---
<img width="787" alt="Screen Shot 2022-07-14 at 9 48 51 AM" src="https://user-images.githubusercontent.com/459757/179055105-2f6e8bbf-66e1-46fb-81e9-8c16d3fc690c.png"> | <img width="775" alt="Screen Shot 2022-07-14 at 9 49 04 AM" src="https://user-images.githubusercontent.com/459757/179055120-e94072d0-df8d-4c73-9e07-7c046a8164f2.png">


## Testing

The best way to test will be using your local Cloud Four WordPress site. We can use `npm link` to link to this patterns version. 

### Checkout both repos

1. Checkout out the `cloudfour.com-wp` `main` branch locally
2. Checkout this `cloudfour.com-patterns` branch locally

### In the `cloudfour.com-patterns` repo

1. `npm ci && npm run build && npm link`

### In the `cloudfour.com-wp` repo

1. In the theme directory: `npm ci && npm link @cloudfour/patterns && npm run build` 

### Chrome dev tools Lighthouse report 

1. Open an incognito window in Chrome
2.  **Application** > **Storage**: Clear all site data
    <img width="1014" alt="Screen Shot 2022-07-14 at 1 28 48 PM" src="https://user-images.githubusercontent.com/459757/179077517-fad4922f-af5a-4485-9a87-58f8c4ddd3dc.png">
1.  **Application** > **Service Worker**: Check the "Bypass for network" option
    <img width="1014" alt="Screen Shot 2022-07-14 at 1 31 13 PM" src="https://user-images.githubusercontent.com/459757/179077866-31fe2680-6c4f-4e81-b487-e6a0780c25f5.png">
1.  **Network**: Check the "Disable cache" option
    <img width="1012" alt="Screen Shot 2022-07-14 at 1 32 32 PM" src="https://user-images.githubusercontent.com/459757/179078060-782d88c8-ac5f-4af7-b7c4-547a7c22b581.png">
4. Generate a Lighthouse report with the following settings:
    <img width="807" alt="Screen Shot 2022-07-14 at 1 36 28 PM" src="https://user-images.githubusercontent.com/459757/179078690-87f7a344-49b0-4eed-8d74-339457fcc0c2.png">
1. Confirm
    - [ ] The cumulative layout shift should report `0` (I also got `0.106` one time which was a bit confusing)

### Responsive behaviors

1. Load at a smaller viewport, confirm:
    - [ ] The menu toggles open/closed
1. Resize to a larger viewport, confirm:
    - [ ] The menu items render as expected
1. Reload the page at a larger viewport, confirm:
    - [ ] The menu items render as expected
1. Resize to a smaller viewport, confirm:
    - [ ] The menu toggles open/closed
    - [ ] The menu items render as expected

### Disable JavaScript

1. Disable JavaScript and reload the page, confirm:
    - [ ] The menu renders open
    - [ ] The menu toggle button is not rendered

## Undo `npm link`

1. In the WP repo: `npm uninstall --no-save @cloudfour/patterns && npm i`
2. In the Patterns repo (delete global symlink): `npm uninstall`

---

- Closes #1946 