### PR TITLE
Fix comment permalinks

### DIFF
--- a/.changeset/smart-windows-buy.md
+++ b/.changeset/smart-windows-buy.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Comment permalinks now resolve to the hash URL of the comment ID rather than a nonexistent Timber `comment.link` property

--- a/src/components/comment/comment.test.ts
+++ b/src/components/comment/comment.test.ts
@@ -20,7 +20,6 @@ test(
       await commentMarkup({
         comment: {
           ID: 1,
-          link: '#comment-1',
           date: new Date('January 1 2000'),
           avatar: '',
           author: {

--- a/src/components/comment/comment.twig
+++ b/src/components/comment/comment.twig
@@ -51,7 +51,7 @@
     <div class="c-comment__meta">
       <div class="c-comment__meta-detail">
         <a class="c-comment__meta-link"
-          href="{{comment.link}}">
+          href="#comment-{{comment.ID}}">
           <span class="c-comment__meta-icon">
             {% include '@cloudfour/components/icon/icon.twig' with {
               name: 'link',

--- a/src/components/comment/demo/data.ts
+++ b/src/components/comment/demo/data.ts
@@ -90,7 +90,6 @@ export const makeComment = ({
 
   const result = {
     ID: id,
-    link: `#comment-${id}`,
     date: new Date(),
     avatar: `https://placeimg.com/92/92/${sample(placeImgCategories)}`,
     author: {


### PR DESCRIPTION
## Overview

The comment component assumed that Timber `comment` objects contain a `link` property. They do not.

This removes references to that and uses the hash ID of the comment instead.

## Testing

[In this story](https://deploy-preview-1952--cloudfour-patterns.netlify.app/?path=/story/components-comment--single), confirm that the permalink (date with a 🔗 icon next to it) links to the comment itself.

---

- Fixes #1948 
