### PR TITLE
Fix for focus outline overlap in input group

### DIFF
--- a/.changeset/twenty-otters-remain.md
+++ b/.changeset/twenty-otters-remain.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Prevent focused input outlines from being cut off by adjacent elements inside of Input Group objects

--- a/src/objects/input-group/input-group.scss
+++ b/src/objects/input-group/input-group.scss
@@ -3,6 +3,11 @@
 .o-input-group {
   display: flex;
 
+  // Keeps focus styles from being cut off by adjacent, un-focused elements
+  > :focus {
+    z-index: 1;
+  }
+
   > :not(:first-child) {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;


### PR DESCRIPTION
## Overview

When focusing an input in an Input Group, the focus outline would often be cut off by adjacent elements. This sets a `z-index` value of `1` on children with `:focus` to prevent that from happening.

My first choice for the visual appearance of this state would be a focus outline covering the entire focus group. But looking into methods of doing that would really push this from the realm of _layout object_ to the realm of _component_. There is also some complexity to manage between that and buttons that will be reduced when we move away from our focus visible polyfill (which should be possible in the very near future). So for now I'm settling for just fixing the immediate bug. 

## Screenshots

Before | After
--- | ---
<img width="467" alt="Screen Shot 2022-07-15 at 2 26 26 PM" src="https://user-images.githubusercontent.com/69633/179313307-4e84c08b-a1f5-4235-824f-db0c293cf105.png"> | <img width="468" alt="Screen Shot 2022-07-15 at 2 26 07 PM" src="https://user-images.githubusercontent.com/69633/179313321-12e93069-f1b1-4c41-b36e-b8bd8ef7d4ce.png">

## Testing

[Deploy preview](https://deploy-preview-1955--cloudfour-patterns.netlify.app/?path=/story/objects-input-group--example)

---

- Fixes #1944 
