### PR TITLE
Bugfix: Prevent Embedded Video Clipping in Safari

### DIFF
--- a/.changeset/fuzzy-stingrays-begin.md
+++ b/.changeset/fuzzy-stingrays-begin.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": patch
+---
+
+Bugfix: Prevent Embed videos from clipping in Safari

--- a/src/mixins/_ratio-box.scss
+++ b/src/mixins/_ratio-box.scss
@@ -39,9 +39,13 @@ $aspect-ratio-map: meta.module-variables('aspect-ratio');
     inline-size: 100%;
     inset-block-start: 0;
     inset-inline-start: 0;
+    position: absolute;
+  }
+
+  > img,
+  > picture > img {
     object-fit: cover;
     object-position: center;
-    position: absolute;
   }
 }
 


### PR DESCRIPTION
## Overview

This PR addresses a bug where iframe video players like YouTube or
Vimeo used in an Embed object would offset to the left when playing
in Safari, resulting in the left side of the player being cut off.

## Testing

1. On the deploy environment, visit the Embed > Video story in Safari and play the video. The player should not shift to the right.

---

- Fixes https://github.com/cloudfour/cloudfour.com-wp/issues/828