### PR TITLE
Node 16 in release workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           # Fetch all git history for correct changelog commits
           fetch-depth: 0
-      - name: Use Node.js 12
+      - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
       - name: Update npm
         run: npm i -g npm@7
       - name: Install Dependencies


### PR DESCRIPTION
This switches the release workflow to use node 16. The CI workflow already does.