### PR TITLE
Rename references of `v-next` to `main`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,6 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "v-next",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch"
 }

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - v-next
+      - main
 
 jobs:
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - v-next
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,28 +66,26 @@ Follow the [Symfony Twig Coding Standards](https://twig.symfony.com/doc/3.x/codi
 
 ## Publishing to npm
 
-This process happens automatically after any PR with a changeset is merged to v-next.
+This process happens automatically after any PR with a changeset is merged to `main`.
 
 ## Manually publishing to npm
 
 This is generally not necessary, but in case you need to manually publish a version:
 
-1. `git checkout v-next`
+1. `git checkout main`
 1. `git pull`
 1. Make sure you have a clean working tree (`git status` should show no changes)
 1. `git checkout -b release-X.Y.Z` - Create a new release branch, where `X.Y.Z` is the version number you're about to release.
 1. `npm version [major | minor | patch]` - This will bump the version number in `package.json` and `package-lock.json`. e.g., `npm version minor` to bump from `1.1.0` to `1.2.0`.
 1. `git push` your branch.
-1. Make a PR, get it approved, and merge your changes to `v-next`.
-1. `git checkout v-next`
+1. Make a PR, get it approved, and merge your changes to `main`.
+1. `git checkout main`
 1. `git pull`
 1. Make sure you have a clean working tree (`git status` should show no changes)
 1. Reinstall dependencies and run build: `npm ci && npm run preprocess && npm run build`
 1. `npm publish --access public` - This will automatically install and compile everything, run linting, and publish
 
 You can run `npm publish --dry-run` to see everything that _would_ happen during publish, without actually publishing to the npm registry.
-
-Note the branch is `v-next` for now. When we we merge this branch to `main`, these instructions should be updated.
 
 ## Overriding source code previews in Storybook
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 <p align="center"><img src="https://cloudfour.com/android-chrome-512x512.png" alt="" width="128" height="128"></p>
 
-# Cloud Four Patterns 🚧
+# Cloud Four Patterns
 
-[![NPM version](http://img.shields.io/npm/v/@cloudfour/patterns.svg)](https://www.npmjs.org/package/@cloudfour/patterns) [![Build Status](https://github.com/cloudfour/cloudfour.com-patterns/workflows/CI/badge.svg)](https://github.com/cloudfour/cloudfour.com-patterns/actions?query=workflow%3ACI) [![Netlify Status](https://api.netlify.com/api/v1/badges/1923e350-3172-409a-9361-b04d54d1c3b4/deploy-status)](https://app.netlify.com/sites/cloudfour-patterns/deploys?filter=v-next)
+[![NPM version](http://img.shields.io/npm/v/@cloudfour/patterns.svg)](https://www.npmjs.org/package/@cloudfour/patterns) [![Build Status](https://github.com/cloudfour/cloudfour.com-patterns/workflows/CI/badge.svg)](https://github.com/cloudfour/cloudfour.com-patterns/actions?query=workflow%3ACI) [![Netlify Status](https://api.netlify.com/api/v1/badges/1923e350-3172-409a-9361-b04d54d1c3b4/deploy-status?branch=main)](https://app.netlify.com/sites/cloudfour-patterns/deploys?filter=main)
 
-🚨 **You are currently viewing the `v-next` branch.** This represents a significant refactor of our environment and coding standards. It is a work in progress and not yet ready for use.
-
-If you’re looking for the most stable version of our pattern library, check out [the `main` branch](https://github.com/cloudfour/cloudfour.com-patterns/tree/main).
-
-[View Netlify Preview →](https://v-next--cloudfour-patterns.netlify.app/)
+[View Netlify Preview →](https://cloudfour-patterns.netlify.app)
 
 ## Installation
 

--- a/src/docs/intro.stories.mdx
+++ b/src/docs/intro.stories.mdx
@@ -6,7 +6,7 @@ import readme from '../../README.md';
 <Description>
   {readme
     .replace(
-      '[View Netlify Preview →](https://v-next--cloudfour-patterns.netlify.com/)',
+      '[View Netlify Preview →](https://cloudfour-patterns.netlify.app)',
       '[View GitHub Repository →](https://github.com/cloudfour/cloudfour.com-patterns)'
     )
     // Weird link path due to this issue:


### PR DESCRIPTION
I renamed the branch, this updates the code/documentation:
Closes https://github.com/cloudfour/cloudfour.com-wp/issues/789