### PR TITLE
Don't allow line breaks in author names

### DIFF
--- a/.changeset/tall-socks-train.md
+++ b/.changeset/tall-socks-train.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Don't allow line breaks in author names

--- a/src/components/author/author.scss
+++ b/src/components/author/author.scss
@@ -7,3 +7,10 @@
 .c-author {
   color: var(--theme-color-text-muted);
 }
+
+/**
+ * 1. Prevent breaking inside author names
+ */
+.c-author__author {
+  display: inline-block; /* 1 */
+}

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -62,16 +62,16 @@
   {# Author content #}
   <div class="c-author__content-container o-media__content">
     {# Author links #}
-    <p class="c-author__author">
+    <p>
       <span class="u-hidden-visually">{{ author_prefix|default("By") }}</span>
       {% block authors %}
         {% for author in authors %}
           {% if loop.last and loop.length > 1 %}and {% endif %}
-            {%- if author.link and not unlink -%}
-              <a href="{{ author.link }}">{{ author.name }}</a>
-            {%- else -%}
-              <span>{{ author.name }}</span>
-            {%- endif -%}
+          {%- if author.link and not unlink -%}
+            <a class="c-author__author" href="{{ author.link }}">{{ author.name }}</a>
+          {%- else -%}
+            <span class="c-author__author">{{ author.name }}</span>
+          {%- endif -%}
           {%- if not loop.last and loop.length > 2 %},{% endif %}
         {% endfor %}
       {% endblock %}


### PR DESCRIPTION
Closes #1967

Before:

<img width="531" alt="Screen Shot 2022-07-25 at 9 30 01 AM" src="https://user-images.githubusercontent.com/13206945/180829516-7575f940-cc6f-4425-ab86-f2678ef64f4e.png">

After:
<img width="531" alt="Screen Shot 2022-07-25 at 9 29 39 AM" src="https://user-images.githubusercontent.com/13206945/180829554-b58db751-b040-430e-82e0-44fe41b46f8d.png">

https://deploy-preview-1973--cloudfour-patterns.netlify.app/?path=/docs/components-author--basic-usage