### PR TITLE
Add `u-inline-block` utility

### DIFF
--- a/.changeset/strange-toys-bake.md
+++ b/.changeset/strange-toys-bake.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add `u-inline-block` utility

--- a/src/utilities/display/demo/clearfix.twig
+++ b/src/utilities/display/demo/clearfix.twig
@@ -1,3 +1,3 @@
-<div class="u-clearfix" style="border: 3px solid black; padding: 15px">
-  <div style="width: 500px; height: 500px; background: green; float: right">I'm floating!</div>
+<div class="u-clearfix u-border-medium u-pad-1">
+  <div class="u-border-medium u-pad-1 u-size-inline-1/2" style="float: right;">I’m floating!</div>
 </div>

--- a/src/utilities/display/demo/inline-block.twig
+++ b/src/utilities/display/demo/inline-block.twig
@@ -1,0 +1,3 @@
+<div class="u-border-md u-pad-1" style="max-width: 11em;">
+  Look how the last two words <span class="u-inline-block">stay together</span>
+</div>

--- a/src/utilities/display/display.scss
+++ b/src/utilities/display/display.scss
@@ -1,19 +1,19 @@
 @use '../../mixins/a11y';
 
-/**
- * Hide from everything but assistive devices.
- */
-
+/// Hide from everything but assistive devices.
 .u-hidden-visually {
   @include a11y.sr-only($important: true);
 }
 
-/**
- * Clearfix: forces a container to expand to fit floated children
- * https://www.cssmojo.com/latest-new-clearfix-so-far/
- */
+/// Clearfix: forces a container to expand to fit floated children
+/// @link https://www.cssmojo.com/latest-new-clearfix-so-far/
 .u-clearfix::after {
   clear: both;
   content: '';
   display: block;
+}
+
+/// Set `display` to `inline-block`
+.u-inline-block {
+  display: inline-block;
 }

--- a/src/utilities/display/display.stories.mdx
+++ b/src/utilities/display/display.stories.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import hiddenVisuallyDemo from './demo/hidden-visually.twig';
 import clearfixDemo from './demo/clearfix.twig';
+import inlineBlockDemo from './demo/inline-block.twig';
 
 <Meta title="Utilities/Display" />
 
@@ -29,4 +30,12 @@ The `u-clearfix` class forces a container to expand to fit floated children.
 
 <Canvas>
   <Story name="Clearfix">{clearfixDemo}</Story>
+</Canvas>
+
+## Inline Block
+
+The `u-inline-block` class sets the `display` property to `inline-block`. This can be used to discourage inline elements from breaking across multiple lines.
+
+<Canvas>
+  <Story name="Inline Block">{inlineBlockDemo}</Story>
 </Canvas>


### PR DESCRIPTION
## Overview

Adds a `u-inline-block` utility class that will be used to make orphan-rescuing in our new website theme more flexible than the current `&nbsp;` solution.

(Also updates the `u-clearfix` story for visual consistency with this one.)

## Screenshots

<img width="1038" alt="Screen Shot 2022-07-25 at 2 00 12 PM" src="https://user-images.githubusercontent.com/69633/180873214-584f9837-bd24-4f1a-898b-5e448feadd45.png">

## Testing

1. [Open this story in deploy preview](https://deploy-preview-1974--cloudfour-patterns.netlify.app/?path=/story/utilities-display--inline-block)
2. Observe that the words "stay together" do stay together unless there is not enough space for both to display on one line
