### PR TITLE
Replace `u-inline-block` with `u-rescue-orphan`, include `text-decoration` inheritance

### DIFF
--- a/.changeset/giant-otters-grab.md
+++ b/.changeset/giant-otters-grab.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Prevent `u-inline-block` from unintentionally disrupting `text-decoration` styles

--- a/.changeset/giant-otters-grab.md
+++ b/.changeset/giant-otters-grab.md
@@ -1,5 +1,0 @@
----
-'@cloudfour/patterns': patch
----
-
-Prevent `u-inline-block` from unintentionally disrupting `text-decoration` styles

--- a/.changeset/strange-toys-bake.md
+++ b/.changeset/strange-toys-bake.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Add `u-inline-block` utility
+Add `u-rescue-orphan` utility to fine-tune where text breaks occur as space allows

--- a/src/utilities/display/demo/inline-block.twig
+++ b/src/utilities/display/demo/inline-block.twig
@@ -1,3 +1,5 @@
 <div class="u-border-md u-pad-1" style="max-width: 11em;">
-  Look how the last two words <span class="u-inline-block">stay together</span>
+  <a href="#">
+    Look how the last two words <span class="u-inline-block">stay together</span>
+  </a>
 </div>

--- a/src/utilities/display/demo/rescue-orphan.twig
+++ b/src/utilities/display/demo/rescue-orphan.twig
@@ -1,5 +1,5 @@
 <div class="u-border-md u-pad-1" style="max-width: 11em;">
   <a href="#">
-    Look how the last two words <span class="u-inline-block">stay together</span>
+    Look how the last two words <span class="u-rescue-orphan">stay together</span>
   </a>
 </div>

--- a/src/utilities/display/display.scss
+++ b/src/utilities/display/display.scss
@@ -17,3 +17,8 @@
 .u-inline-block {
   display: inline-block;
 }
+
+/// Prevent unintentional loss of `text-decoration`
+:where(.u-inline-block) {
+  text-decoration: inherit;
+}

--- a/src/utilities/display/display.scss
+++ b/src/utilities/display/display.scss
@@ -13,12 +13,8 @@
   display: block;
 }
 
-/// Set `display` to `inline-block`
-.u-inline-block {
+/// Attempt to keep chunks of text together as space allows
+.u-rescue-orphan {
   display: inline-block;
-}
-
-/// Prevent unintentional loss of `text-decoration`
-:where(.u-inline-block) {
   text-decoration: inherit;
 }

--- a/src/utilities/display/display.stories.mdx
+++ b/src/utilities/display/display.stories.mdx
@@ -1,7 +1,7 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import hiddenVisuallyDemo from './demo/hidden-visually.twig';
 import clearfixDemo from './demo/clearfix.twig';
-import inlineBlockDemo from './demo/inline-block.twig';
+import rescueOrphanDemo from './demo/rescue-orphan.twig';
 
 <Meta title="Utilities/Display" />
 
@@ -32,10 +32,10 @@ The `u-clearfix` class forces a container to expand to fit floated children.
   <Story name="Clearfix">{clearfixDemo}</Story>
 </Canvas>
 
-## Inline Block
+## Rescue Orphan
 
-The `u-inline-block` class sets the `display` property to `inline-block`. This can be used to discourage inline elements from breaking across multiple lines. If no `text-decoration` is set, it will `inherit` that of its parent to prevent unintentional disruption of link styles.
+The `u-rescue-orphan` class can wrap the last few words of a chunk of text, attempting to keep them together unless space limitations force a break. This can help reduce the chance of [a typographic orphan](https://en.wikipedia.org/wiki/Widows_and_orphans) in some situations.
 
 <Canvas>
-  <Story name="Inline Block">{inlineBlockDemo}</Story>
+  <Story name="Rescue Orphan">{rescueOrphanDemo}</Story>
 </Canvas>

--- a/src/utilities/display/display.stories.mdx
+++ b/src/utilities/display/display.stories.mdx
@@ -34,7 +34,7 @@ The `u-clearfix` class forces a container to expand to fit floated children.
 
 ## Inline Block
 
-The `u-inline-block` class sets the `display` property to `inline-block`. This can be used to discourage inline elements from breaking across multiple lines.
+The `u-inline-block` class sets the `display` property to `inline-block`. This can be used to discourage inline elements from breaking across multiple lines. If no `text-decoration` is set, it will `inherit` that of its parent to prevent unintentional disruption of link styles.
 
 <Canvas>
   <Story name="Inline Block">{inlineBlockDemo}</Story>


### PR DESCRIPTION
## Overview

The `u-inline-block` utility was added for a "rescue orphan" function, but it failed to accomplish this very well within links because it would disrupt `text-decoration`. ~This adds a soft default using the `:where` selector so if _anything_ else is setting `text-decoration` on the element, it will take precedence, but otherwise it will inherit from the parent.~ This renames the utility to `u-rescue-orphan` and adds `text-decoration: inherit`.

## Screenshots

Before | After
--- | ---
<img width="242" alt="Screen Shot 2022-07-25 at 2 21 59 PM" src="https://user-images.githubusercontent.com/69633/180876455-9bcf8cd1-dcd5-4a55-9ad8-eb527edf6582.png"> | <img width="240" alt="Screen Shot 2022-07-25 at 2 22 11 PM" src="https://user-images.githubusercontent.com/69633/180876457-2672761e-d2df-492d-9c69-ee7d43206c1a.png">


## Testing

[Deploy preview](https://deploy-preview-1976--cloudfour-patterns.netlify.app/?path=/story/utilities-display--rescue-orphan)
