### PR TITLE
Add `role="text"` to Author `span` elements

### DIFF
--- a/.changeset/tall-boxes-invent.md
+++ b/.changeset/tall-boxes-invent.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Add `role="text"` to `span` elements inside of the Author component, increasing the likelihood that its contents will be read aloud seamlessly

--- a/src/components/author/author.test.ts
+++ b/src/components/author/author.test.ts
@@ -33,8 +33,7 @@ test(
         text "By"
       link "Shakira Isabel Mebarak Ripoll"
         text "Shakira Isabel Mebarak Ripoll"
-      text
-        text "Presented on March 31st, 2021"
+      text "Presented on March 31st, 2021"
     `);
   })
 );

--- a/src/components/author/author.test.ts
+++ b/src/components/author/author.test.ts
@@ -29,10 +29,12 @@ test(
 
     const body = await page.evaluateHandle<ElementHandle>(() => document.body);
     expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      text "By"
+      text
+        text "By"
       link "Shakira Isabel Mebarak Ripoll"
         text "Shakira Isabel Mebarak Ripoll"
-      text "Presented on March 31st, 2021"
+      text
+        text "Presented on March 31st, 2021"
     `);
   })
 );
@@ -85,7 +87,8 @@ test(
 
     // Confirm the meta value is rendered and the date is not rendered
     expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      text "By"
+      text
+        text "By"
       link "Shakira Isabel Mebarak Ripoll"
         text "Shakira Isabel Mebarak Ripoll"
       text "Singer and songwriter"
@@ -113,8 +116,10 @@ test(
 
     // Confirm the author name is "text" and not a link
     expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      text "By"
-      text "Shakira Isabel Mebarak Ripoll"
+      text
+        text "By"
+      text
+        text "Shakira Isabel Mebarak Ripoll"
     `);
   })
 );
@@ -141,8 +146,10 @@ test(
 
     // Confirm the author name is "text" and not a link
     expect(await getAccessibilityTree(body)).toMatchInlineSnapshot(`
-      text "By"
-      text "Shakira Isabel Mebarak Ripoll"
+      text
+        text "By"
+      text
+        text "Shakira Isabel Mebarak Ripoll"
     `);
   })
 );

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -68,8 +68,8 @@
       </span>
       {% block authors %}
         {% for author in authors %}
-          {% if loop.last and loop.length > 1 %}and {% endif %}
-          {%- if author.link and not unlink -%}
+          {% if loop.last and loop.length > 1 %}and{% endif %}
+          {% if author.link and not unlink -%}
             <a class="c-author__author" href="{{ author.link }}">{{ author.name }}</a>
           {%- else -%}
             <span class="c-author__author" role="text">{{ author.name }}</span>

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -12,7 +12,7 @@
     {% elseif date %}
       <p>
         {# This creates a more accessible, and less confusing, user experience #}
-        <span class="u-hidden-visually">
+        <span class="u-hidden-visually" role="text">
           {{ date_prefix|default('Published on') }} {{ date|date('F jS, Y') }}
         </span>
         {#
@@ -63,14 +63,16 @@
   <div class="c-author__content-container o-media__content">
     {# Author links #}
     <p>
-      <span class="u-hidden-visually">{{ author_prefix|default("By") }}</span>
+      <span class="u-hidden-visually" role="text">
+        {{ author_prefix|default("By") }}
+      </span>
       {% block authors %}
         {% for author in authors %}
           {% if loop.last and loop.length > 1 %}and {% endif %}
           {%- if author.link and not unlink -%}
             <a class="c-author__author" href="{{ author.link }}">{{ author.name }}</a>
           {%- else -%}
-            <span class="c-author__author">{{ author.name }}</span>
+            <span class="c-author__author" role="text">{{ author.name }}</span>
           {%- endif -%}
           {%- if not loop.last and loop.length > 2 %},{% endif %}
         {% endfor %}

--- a/src/components/author/author.twig
+++ b/src/components/author/author.twig
@@ -12,7 +12,7 @@
     {% elseif date %}
       <p>
         {# This creates a more accessible, and less confusing, user experience #}
-        <span class="u-hidden-visually" role="text">
+        <span class="u-hidden-visually">
           {{ date_prefix|default('Published on') }} {{ date|date('F jS, Y') }}
         </span>
         {#
@@ -63,6 +63,18 @@
   <div class="c-author__content-container o-media__content">
     {# Author links #}
     <p>
+      {#
+        We're adding `role="text"` to these elements to avoid a Safari issue
+        where the text won't be read together as intended. This may be an
+        overreach: `role="text"` is non-standard, and there's an argument to be
+        made that this contradicts the expected VoiceOver user experience. In
+        this case, it feels reasonable because the spans exist to enhance the
+        visual experience and do not add any valuable meaningful delineation
+        between elements. But maybe later we'll change our mind!
+
+        @see https://www.tpgi.com/using-the-text-role/
+        @see https://github.com/dequelabs/axe-core/issues/1597
+      #}
       <span class="u-hidden-visually" role="text">
         {{ author_prefix|default("By") }}
       </span>


### PR DESCRIPTION
## Overview

> Add `role="text"` to `span` elements inside of the Author component, increasing the likelihood that its contents will be read aloud seamlessly

## Testing

[On deploy preview](https://deploy-preview-1982--cloudfour-patterns.netlify.app/?path=/docs/components-author--basic-usage), test VO experience

---

- Fixes #1981 