### PR TITLE
Use aria-hidden for Pagination component ellipsis

### DIFF
--- a/.changeset/spotty-owls-pay.md
+++ b/.changeset/spotty-owls-pay.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add aria-hidden to Pagination component ellipsis

--- a/src/components/pagination/pagination.twig
+++ b/src/components/pagination/pagination.twig
@@ -28,7 +28,12 @@
           </a>
         {% else %}
           {# Fallback for non-link pages like ellipsis gaps for first/last pages #}
-          <span class="c-pagination__action">
+          <span
+            class="c-pagination__action"
+            {% if page.title == '&hellip;' or page.title == '…' %}
+              aria-hidden="true"
+            {% endif %}
+          >
             {{ page.title }}
           </span>
         {% endif %}

--- a/src/components/pagination/pagination.twig
+++ b/src/components/pagination/pagination.twig
@@ -5,7 +5,12 @@
   <{{ label_tag_name }} id="{{ label_id }}" class="u-hidden-visually">Pagination</{{ label_tag_name }}>
   <ul class="c-pagination__items" role="list">
     {% for page in pagination.pages %}
-      <li class="c-pagination__item">
+      <li
+        class="c-pagination__item"
+        {% if page.title == '&hellip;' or page.title == '…' %}
+          aria-hidden="true"
+        {% endif %}
+      >
         {% if page.current %}
           <a class="c-pagination__action" href="{{ page.link }}" aria-current="page">
             <span class="u-hidden-visually">Page</span>
@@ -28,12 +33,7 @@
           </a>
         {% else %}
           {# Fallback for non-link pages like ellipsis gaps for first/last pages #}
-          <span
-            class="c-pagination__action"
-            {% if page.title == '&hellip;' or page.title == '…' %}
-              aria-hidden="true"
-            {% endif %}
-          >
+          <span class="c-pagination__action">
             {{ page.title }}
           </span>
         {% endif %}

--- a/src/components/pagination/pagination.twig
+++ b/src/components/pagination/pagination.twig
@@ -5,39 +5,47 @@
   <{{ label_tag_name }} id="{{ label_id }}" class="u-hidden-visually">Pagination</{{ label_tag_name }}>
   <ul class="c-pagination__items" role="list">
     {% for page in pagination.pages %}
-      <li
-        class="c-pagination__item"
-        {% if page.title == '&hellip;' or page.title == '…' %}
-          aria-hidden="true"
-        {% endif %}
-      >
-        {% if page.current %}
+      {% if page.current %}
+        <li class="c-pagination__item">
           <a class="c-pagination__action" href="{{ page.link }}" aria-current="page">
             <span class="u-hidden-visually">Page</span>
             <span class="c-pagination__number">{{ page.title }}</span>
           </a>
-        {% elseif page.link and page.link == pagination.prev.link %}
+        </li>
+      {% elseif page.link and page.link == pagination.prev.link %}
+        <li class="c-pagination__item">
           <a class="c-pagination__action is-previous" href="{{ page.link }}">
             <span class="u-hidden-visually">Previous: Page</span>
             <span class="c-pagination__number">{{ page.title }}</span>
           </a>
-        {% elseif page.link and page.link == pagination.next.link %}
+        </li>
+      {% elseif page.link and page.link == pagination.next.link %}
+        <li class="c-pagination__item">
           <a class="c-pagination__action is-next" href="{{ page.link }}">
             <span class="u-hidden-visually">Next: Page</span>
             <span class="c-pagination__number">{{ page.title }}</span>
           </a>
-        {% elseif page.link %}
+        </li>
+      {% elseif page.link %}
+        <li class="c-pagination__item">
           <a class="c-pagination__action" href="{{ page.link }}">
             <span class="u-hidden-visually">Page</span>
             <span class="c-pagination__number">{{ page.title }}</span>
           </a>
-        {% else %}
-          {# Fallback for non-link pages like ellipsis gaps for first/last pages #}
+        </li>
+      {% else %}
+        {# Fallback for non-link pages like ellipsis gaps for first/last pages #}
+        <li
+          class="c-pagination__item"
+          {% if page.title == '&hellip;' or page.title == '…' %}
+            aria-hidden="true"
+          {% endif %}
+        >
           <span class="c-pagination__action">
             {{ page.title }}
           </span>
-        {% endif %}
-      </li>
+        </li>
+      {% endif %}
     {% endfor %}
   </ul>
 </nav>


### PR DESCRIPTION
## Overview

This PR conditionally adds `aria-hidden="true"` for when an ellipsis is rendered in the Pagination component.

## Screenshots

<img width="1392" alt="Screen Shot 2022-07-27 at 11 38 13 AM" src="https://user-images.githubusercontent.com/459757/181348204-5c865edc-860e-4a5b-aac3-a4689cfc44b0.png">


## Testing

The best test method will be using your local Cloud Four WordPress site. We can use `npm link` to link to this patterns version. 

### Checkout both repos

1. Checkout out the `cloudfour.com-wp` `main` branch locally
2. Checkout this `cloudfour.com-patterns` branch locally

### In the `cloudfour.com-patterns` repo

1. `npm ci && npm run build && npm link`

### In the `cloudfour.com-wp` repo

1. In the theme directory: `npm ci && npm link @cloudfour/patterns && npm run build` 

### Confirm

-  [ ] On the `/thinks`, the Pagination component ellipsis should have `aria-hidden"true"`

## Undo `npm link`

1. In the WP repo: `npm uninstall --no-save @cloudfour/patterns && npm i`
2. In the Patterns repo (delete global symlink): `npm uninstall`


---

- Closes #1977