### PR TITLE
Content below Sky Nav animates again

### DIFF
--- a/.changeset/flat-points-smoke.md
+++ b/.changeset/flat-points-smoke.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix bug where content below Sky Nav was not animating open/closed

--- a/src/components/sky-nav/sky-nav.ts
+++ b/src/components/sky-nav/sky-nav.ts
@@ -57,21 +57,6 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
       return;
     }
 
-    // We need to keep track of the siblings after the menu,
-    // because we will push them down for the animation
-    const elementsToShift: HTMLElement[] = [
-      navWrapper.parentElement as HTMLElement,
-    ];
-    let sibling: HTMLElement | null = elementsToShift[0];
-    // eslint-disable-next-line no-unmodified-loop-condition
-    while ((sibling = sibling.nextElementSibling as HTMLElement | null)) {
-      if (sibling.tagName !== 'SCRIPT') {
-        elementsToShift.push(sibling);
-      }
-    }
-
-    console.log({ elementsToShift });
-
     const duration = Number.parseFloat(tokens.time.transition.slow.value);
     const transition = `transform ${duration}s ${tokens.ease.in_out.value}`;
     clearTimeout(timeoutId);
@@ -80,34 +65,25 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
     const heightDiff = menu.getBoundingClientRect().height;
     if (isExpanded) {
       // Closing menu: slide the elements up before hiding the menu
-      for (const el of elementsToShift) {
-        el.style.transition = transition;
-        el.style.transform = `translateY(${-heightDiff}px)`;
-      }
+      document.body.style.transition = transition;
+      document.body.style.transform = `translateY(${-heightDiff}px)`;
 
       timeoutId = setTimeout(() => {
         menu.hidden = true;
-        for (const el of elementsToShift) {
-          el.style.transition = '';
-          el.style.transform = '';
-        }
+        document.body.style.transition = '';
+        document.body.style.transform = '';
       }, duration * 1000) as any as number;
     } else {
       // Opening menu: start the elements higher than their "resting position" and then slide them down
-      for (const el of elementsToShift)
-        el.style.transform = `translateY(${-heightDiff}px)`;
+      document.body.style.transform = `translateY(${-heightDiff}px)`;
 
       // Flush changes to the DOM
       // eslint-disable-next-line @cloudfour/typescript-eslint/no-unused-expressions, mdx/no-unused-expressions
       navWrapper.offsetWidth;
-      for (const el of elementsToShift) {
-        el.style.transition = transition;
-        el.style.transform = '';
-      }
+      document.body.style.transition = transition;
+      document.body.style.transform = '';
       timeoutId = setTimeout(() => {
-        for (const el of elementsToShift) {
-          el.style.transition = '';
-        }
+        document.body.style.transition = '';
       }, duration * 1000) as any as number;
     }
   };

--- a/src/components/sky-nav/sky-nav.ts
+++ b/src/components/sky-nav/sky-nav.ts
@@ -59,12 +59,18 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
 
     // We need to keep track of the siblings after the menu,
     // because we will push them down for the animation
-    const elementsToShift: HTMLElement[] = [navWrapper];
-    let sibling: HTMLElement | null = navWrapper;
+    const elementsToShift: HTMLElement[] = [
+      navWrapper.parentElement as HTMLElement,
+    ];
+    let sibling: HTMLElement | null = elementsToShift[0];
     // eslint-disable-next-line no-unmodified-loop-condition
     while ((sibling = sibling.nextElementSibling as HTMLElement | null)) {
-      elementsToShift.push(sibling);
+      if (sibling.tagName !== 'SCRIPT') {
+        elementsToShift.push(sibling);
+      }
     }
+
+    console.log({ elementsToShift });
 
     const duration = Number.parseFloat(tokens.time.transition.slow.value);
     const transition = `transform ${duration}s ${tokens.ease.in_out.value}`;

--- a/src/components/sky-nav/sky-nav.ts
+++ b/src/components/sky-nav/sky-nav.ts
@@ -65,25 +65,31 @@ export const initSkyNav = (navButton: HTMLButtonElement) => {
     const heightDiff = menu.getBoundingClientRect().height;
     if (isExpanded) {
       // Closing menu: slide the elements up before hiding the menu
-      document.body.style.transition = transition;
-      document.body.style.transform = `translateY(${-heightDiff}px)`;
+      document.body.style.setProperty('transition', transition);
+      document.body.style.setProperty(
+        'transform',
+        `translateY(${-heightDiff}px)`
+      );
 
       timeoutId = setTimeout(() => {
         menu.hidden = true;
-        document.body.style.transition = '';
-        document.body.style.transform = '';
+        document.body.style.removeProperty('transition');
+        document.body.style.removeProperty('transform');
       }, duration * 1000) as any as number;
     } else {
       // Opening menu: start the elements higher than their "resting position" and then slide them down
-      document.body.style.transform = `translateY(${-heightDiff}px)`;
+      document.body.style.setProperty(
+        'transform',
+        `translateY(${-heightDiff}px)`
+      );
 
       // Flush changes to the DOM
       // eslint-disable-next-line @cloudfour/typescript-eslint/no-unused-expressions, mdx/no-unused-expressions
       navWrapper.offsetWidth;
-      document.body.style.transition = transition;
-      document.body.style.transform = '';
+      document.body.style.setProperty('transition', transition);
+      document.body.style.removeProperty('transform');
       timeoutId = setTimeout(() => {
-        document.body.style.transition = '';
+        document.body.style.removeProperty('transition');
       }, duration * 1000) as any as number;
     }
   };

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -1,6 +1,11 @@
 {% set main_id = main_id|default('main') %}
 {% set _main_href = '#' ~ main_id %}
 
+{% if include_main_demo %}
+<div class="o-page__header t-dark">
+{% endif %}
+
+
 {#
   The Sky Nav component uses progressive enhancement and assumes JS is not
   available as the default. The `no-js` CSS class is the hook to style properly
@@ -98,6 +103,10 @@
   skyNav.classList.add('is-loading'); // 2
 </script>
 
+{% if include_main_demo %}
+</div>
+{% endif %}
+
 {#
   For some reason Twig.js really doesn't like including this template in a demo,
   showing errors related to extending inline templates that don't make sense
@@ -106,9 +115,31 @@
   @see https://github.com/twigjs/twig.js/issues/262
 #}
 {% if include_main_demo %}
-  <main class="o-container o-container--pad" id="{{ main_id }}">
-    <div class="o-container__content">
-      <p>Hello world! This is the main content.</p>
+  <main id="main" class="o-page__content" style="">
+    <div class="c-cloud-cover t-dark">
+      <div class="o-container o-container--pad-inline">
+        <div class="o-container__content c-cloud-cover__inner">
+          <div class="c-cloud-cover__content">
+            <div class="o-rhythm o-rhythm--condensed">
+              <div class="c-cloud-cover__heading">
+                <h1 class="c-heading c-heading--level-n2">
+                  Team
+                </h1>
+              </div>
+              <div class="c-cloud-cover__copy">
+                <div class="o-rhythm">
+                  Teamwork makes the dream work
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="o-container o-container--pad">
+      <div class="o-container__content">
+        <p>This is some content.</p>
+      </div>
     </div>
   </main>
 {% endif %}

--- a/src/components/sky-nav/sky-nav.twig
+++ b/src/components/sky-nav/sky-nav.twig
@@ -1,11 +1,6 @@
 {% set main_id = main_id|default('main') %}
 {% set _main_href = '#' ~ main_id %}
 
-{% if include_main_demo %}
-<div class="o-page__header t-dark">
-{% endif %}
-
-
 {#
   The Sky Nav component uses progressive enhancement and assumes JS is not
   available as the default. The `no-js` CSS class is the hook to style properly
@@ -102,10 +97,6 @@
   skyNav.classList.remove('no-js'); // 1
   skyNav.classList.add('is-loading'); // 2
 </script>
-
-{% if include_main_demo %}
-</div>
-{% endif %}
 
 {#
   For some reason Twig.js really doesn't like including this template in a demo,


### PR DESCRIPTION
## Overview

This PR fixes a bug where the content below the Sky Nav menu was not animating open/closed.

Changes include:
- transition the `document.body` instead of all of the wrapper containers
- update demo with more up-to-date header markup

## Screenshots

![better](https://user-images.githubusercontent.com/459757/181614429-cdcbd66d-f369-46ca-a4cc-cc4c5dc457cc.gif)

## Testing

The best test method will be using your local Cloud Four WordPress site via `npm link`.

### Checkout both repos

1. Checkout out the `cloudfour.com-wp` `main` branch locally
2. Checkout this `cloudfour.com-patterns` branch locally

### In the `cloudfour.com-patterns` repo

1. `npm ci && npm run build && npm link`

### In the `cloudfour.com-wp` repo

1. In the theme directory: `npm ci && npm link @cloudfour/patterns && npm run build` 

### Confirm

-  [ ] At smaller viewports, the content below the Sky Nav should animate open/closed (try various pages)

## Undo `npm link`

1. In the WP repo: `npm uninstall --no-save @cloudfour/patterns && npm i`
2. In the Patterns repo (delete global symlink): `npm uninstall`


---

- Closes #1984 