### PR TITLE
Add `stylelint-scss@4.0.1` as a devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "stylelint": "14.9.1",
         "stylelint-config-cloudfour": "5.1.0",
         "stylelint-config-prettier": "9.0.3",
+        "stylelint-scss": "^4.0.1",
         "stylelint-use-logical-spec": "4.1.0",
         "through2": "4.0.2",
         "tiny-glob": "0.2.9",
@@ -37478,12 +37479,12 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.0.0.tgz",
-      "integrity": "sha512-lIRhPqtI6I065EJ6aI4mWKsmQt8Krnu6aF9XSL9s8Nd2f/cDKImST0T9TfjnUul3ReKYWozkG9dlpNTZH2FB9w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.0.1.tgz",
+      "integrity": "sha512-Ea+KY7ZFsDhU6Ne9r84y7NvFSNA843w352MSdQeDmklar0pDbeQj9flKrVAuDIlK0pDDdhFtgBl/N0FrtWHq0g==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-selector-parser": "^6.0.6",
@@ -69672,12 +69673,12 @@
       "requires": {}
     },
     "stylelint-scss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.0.0.tgz",
-      "integrity": "sha512-lIRhPqtI6I065EJ6aI4mWKsmQt8Krnu6aF9XSL9s8Nd2f/cDKImST0T9TfjnUul3ReKYWozkG9dlpNTZH2FB9w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.0.1.tgz",
+      "integrity": "sha512-Ea+KY7ZFsDhU6Ne9r84y7NvFSNA843w352MSdQeDmklar0pDbeQj9flKrVAuDIlK0pDDdhFtgBl/N0FrtWHq0g==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-selector-parser": "^6.0.6",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "stylelint": "14.9.1",
     "stylelint-config-cloudfour": "5.1.0",
     "stylelint-config-prettier": "9.0.3",
+    "stylelint-scss": "^4.0.1",
     "stylelint-use-logical-spec": "4.1.0",
     "through2": "4.0.2",
     "tiny-glob": "0.2.9",

--- a/src/vendor/wordpress/styles/_utilities.scss
+++ b/src/vendor/wordpress/styles/_utilities.scss
@@ -19,10 +19,6 @@
 
 /// Wide alignment should max out at our default container width.
 .alignwide {
-  // False positive linting error because SCSS lint is confusing `sass:math`'s
-  // `max` function with the browser `max` function. May be removed once our
-  // lint config updates to `stylelint-scss` 4.0.1 or newer.
-  // stylelint-disable-next-line scss/no-global-function-names
   margin-inline: max(
     -50vw + 50%,
     math.div(size.$max-width-spread - size.$max-width-prose, -2)


### PR DESCRIPTION
## Overview

This PR adds `stylelint-scss@4.0.1` as a devDependency. Previously,
this was being implicitly added via the Cloud Four Stylelint config,
which specifies `stylelint-scss@^4.0.0` via Stylelint's recommended
SCSS config. However, there's a bug in v4.0.0 that was fixed in v4.0.1,
and we wanted that fix. Since v4.0.1 was released over 8 months ago
and the configs don't seem to be in a rush to bump the version, we're
doing it by hand. Someday when the recommended config bumps their
version, we could remove this devDependency.

## Testing

1. Confirm that checks pass on this PR.

---

- Fixes #1890