### PR TITLE
Update dependency stylelint-config-cloudfour to v6.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "style-dictionary": "3.7.1",
         "style-loader": "2.0.0",
         "stylelint": "14.10.0",
-        "stylelint-config-cloudfour": "5.1.0",
+        "stylelint-config-cloudfour": "^6.1.0",
         "stylelint-config-prettier": "9.0.3",
         "stylelint-scss": "4.3.0",
         "stylelint-use-logical-spec": "4.1.0",
@@ -32379,9 +32379,9 @@
       }
     },
     "node_modules/postcss-scss": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.2.tgz",
-      "integrity": "sha512-xfdkU128CkKKKVAwkyt0M8OdnelJ3MRcIRAPPQkRpoPeuzWY3RIeg7piRCpZ79MK7Q16diLXMMAD9dN5mauPlQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
+      "integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
       "dev": true,
       "engines": {
         "node": ">=12.0"
@@ -32408,48 +32408,12 @@
       }
     },
     "node_modules/postcss-sorting": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
-      "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
+      "integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
       "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.14",
-        "postcss": "^7.0.17"
-      },
-      "engines": {
-        "node": ">=8.7.0"
-      }
-    },
-    "node_modules/postcss-sorting/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "dev": true
-    },
-    "node_modules/postcss-sorting/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dev": true,
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/postcss-sorting/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
+      "peerDependencies": {
+        "postcss": "^8.3.9"
       }
     },
     "node_modules/postcss-svgo": {
@@ -37364,17 +37328,17 @@
       }
     },
     "node_modules/stylelint-config-cloudfour": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-cloudfour/-/stylelint-config-cloudfour-5.1.0.tgz",
-      "integrity": "sha512-LWkX544n6HHe7C9ka8L2I0uUI79fJpkYcXcI/aXqPoy1I7Dx3VCi3wp5glWnx/3DTrchUVINY6KW/ANOSNQVAw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-cloudfour/-/stylelint-config-cloudfour-6.1.0.tgz",
+      "integrity": "sha512-YuT3wBnWMp2Arva9DbSQ/OvQTPvX+jZpMEjTmq3RIkUhLOBVAWyqWLiUiFQa5SftMMTGVfhDxOAJRRsUxeFYOQ==",
       "dev": true,
       "dependencies": {
-        "stylelint-config-standard-scss": "2.0.1",
-        "stylelint-config-suitcss": "^17.0.0",
+        "stylelint-config-standard-scss": "5.0.0",
+        "stylelint-config-suitcss": "^18.0.0",
         "stylelint-high-performance-animation": "1.6.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.0.0"
+        "stylelint": "^14.9.0"
       }
     },
     "node_modules/stylelint-config-prettier": {
@@ -37393,126 +37357,64 @@
       }
     },
     "node_modules/stylelint-config-recommended": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
-      "integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz",
+      "integrity": "sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==",
       "dev": true,
       "peerDependencies": {
-        "stylelint": "^14.0.0"
+        "stylelint": "^14.8.0"
       }
     },
     "node_modules/stylelint-config-recommended-scss": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
-      "integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-7.0.0.tgz",
+      "integrity": "sha512-rGz1J4rMAyJkvoJW4hZasuQBB7y9KIrShb20l9DVEKKZSEi1HAy0vuNlR8HyCKy/jveb/BdaQFcoiYnmx4HoiA==",
       "dev": true,
       "dependencies": {
         "postcss-scss": "^4.0.2",
-        "stylelint-config-recommended": "^6.0.0",
+        "stylelint-config-recommended": "^8.0.0",
         "stylelint-scss": "^4.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.0.0"
+        "stylelint": "^14.4.0"
       }
     },
     "node_modules/stylelint-config-standard": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-23.0.0.tgz",
-      "integrity": "sha512-8PDlk+nWuc1T66nVaODTdVodN0pjuE5TBlopi39Lt9EM36YJsRhqttMyUhnS78oc/59Q6n8iw2GJB4QcoFqtRg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-26.0.0.tgz",
+      "integrity": "sha512-hUuB7LaaqM8abvkOO84wh5oYSkpXgTzHu2Zza6e7mY+aOmpNTjoFBRxSLlzY0uAOMWEFx0OMKzr+reG1BUtcqQ==",
       "dev": true,
       "dependencies": {
-        "stylelint-config-recommended": "^6.0.0"
+        "stylelint-config-recommended": "^8.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.0.0"
+        "stylelint": "^14.9.0"
       }
     },
     "node_modules/stylelint-config-standard-scss": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-2.0.1.tgz",
-      "integrity": "sha512-TW5NLquUSS0mg2N31zzaSbYRbV/CMifSVLdpgo6VdGvjysgYqJOcKM/5bmXucTOsdfqomcPXetFZ3adC7nD+cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-5.0.0.tgz",
+      "integrity": "sha512-zoXLibojHZYPFjtkc4STZtAJ2yGTq3Bb4MYO0oiyO6f/vNxDKRcSDZYoqN260Gv2eD5niQIr1/kr5SXlFj9kcQ==",
       "dev": true,
       "dependencies": {
-        "stylelint-config-recommended-scss": "^5.0.0",
-        "stylelint-config-standard": "^23.0.0"
+        "stylelint-config-recommended-scss": "^7.0.0",
+        "stylelint-config-standard": "^26.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^14.0.0"
+        "stylelint": "^14.9.0"
       }
     },
     "node_modules/stylelint-config-suitcss": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-suitcss/-/stylelint-config-suitcss-17.0.0.tgz",
-      "integrity": "sha512-hBd6inIaU7pwmNPxfcPfeKwt3oje3dn7Oc23ghHDTMzRgaTFWJsMaNQGDf4cNYsV4K9juQUo74aMiSdCRiPAUw==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-suitcss/-/stylelint-config-suitcss-18.0.0.tgz",
+      "integrity": "sha512-hZHo/wLn2j65mI4JpqSipTmcPXsShf+PKxP5I0SeaV4ABAn/DME9eChTkoVYncUPUEiqIsBSPsiwlY7zfQLiYg==",
       "dev": true,
       "dependencies": {
-        "stylelint-order": "^4.1.0",
-        "stylelint-suitcss": "^4.0.0"
+        "stylelint-order": "^5.0.0",
+        "stylelint-suitcss": "^5.0.0"
       },
       "peerDependencies": {
-        "stylelint": "^13.13.1"
-      }
-    },
-    "node_modules/stylelint-config-suitcss/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "dev": true
-    },
-    "node_modules/stylelint-config-suitcss/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dev": true,
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/stylelint-config-suitcss/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stylelint-config-suitcss/node_modules/stylelint-order": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-4.1.0.tgz",
-      "integrity": "sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.15",
-        "postcss": "^7.0.31",
-        "postcss-sorting": "^5.0.1"
-      },
-      "peerDependencies": {
-        "stylelint": "^10.0.1 || ^11.0.0 || ^12.0.0 || ^13.0.0"
-      }
-    },
-    "node_modules/stylelint-config-suitcss/node_modules/stylelint-suitcss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-suitcss/-/stylelint-suitcss-4.0.0.tgz",
-      "integrity": "sha512-oVTd6ga/CoAssjm0hiTLJu7vMa6ib/xCJz1eGAIJTs+eW1s4WhCyc5zNTk3mD5i2PmCeY/sM8QzXPGKz3tYkDw==",
-      "dev": true,
-      "dependencies": {
-        "lodash.find": "^4.6.0",
-        "postcss-selector-parser": "^6.0.6"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "stylelint": "^13.13.1"
+        "stylelint": "^14.2.0"
       }
     },
     "node_modules/stylelint-high-performance-animation": {
@@ -37522,6 +37424,19 @@
       "dev": true,
       "peerDependencies": {
         "stylelint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0"
+      }
+    },
+    "node_modules/stylelint-order": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-5.0.0.tgz",
+      "integrity": "sha512-OWQ7pmicXufDw5BlRqzdz3fkGKJPgLyDwD1rFY3AIEfIH/LQY38Vu/85v8/up0I+VPiuGRwbc2Hg3zLAsJaiyw==",
+      "dev": true,
+      "dependencies": {
+        "postcss": "^8.3.11",
+        "postcss-sorting": "^7.0.1"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.0.0"
       }
     },
     "node_modules/stylelint-scss": {
@@ -37538,6 +37453,20 @@
       },
       "peerDependencies": {
         "stylelint": "^14.5.1"
+      }
+    },
+    "node_modules/stylelint-suitcss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-suitcss/-/stylelint-suitcss-5.0.0.tgz",
+      "integrity": "sha512-ezx4lVcqE0S9dN5oRWc9BantR3xJk3Dg3ZKH4BOzkhA/4r9/1VhpB4lc9svguC1VzOnzs/b/6jLKRAzZk7ZWNA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.find": "^4.6.0",
+        "postcss-selector-parser": "^6.0.8",
+        "stylelint": "^14.2.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/stylelint-use-logical-spec": {
@@ -65647,9 +65576,9 @@
       "requires": {}
     },
     "postcss-scss": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.2.tgz",
-      "integrity": "sha512-xfdkU128CkKKKVAwkyt0M8OdnelJ3MRcIRAPPQkRpoPeuzWY3RIeg7piRCpZ79MK7Q16diLXMMAD9dN5mauPlQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
+      "integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
       "dev": true,
       "requires": {}
     },
@@ -65664,38 +65593,11 @@
       }
     },
     "postcss-sorting": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
-      "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-7.0.1.tgz",
+      "integrity": "sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==",
       "dev": true,
-      "requires": {
-        "lodash": "^4.17.14",
-        "postcss": "^7.0.17"
-      },
-      "dependencies": {
-        "picocolors": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.39",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-          "dev": true,
-          "requires": {
-            "picocolors": "^0.2.1",
-            "source-map": "^0.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
+      "requires": {}
     },
     "postcss-svgo": {
       "version": "5.1.0",
@@ -69627,13 +69529,13 @@
       }
     },
     "stylelint-config-cloudfour": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-cloudfour/-/stylelint-config-cloudfour-5.1.0.tgz",
-      "integrity": "sha512-LWkX544n6HHe7C9ka8L2I0uUI79fJpkYcXcI/aXqPoy1I7Dx3VCi3wp5glWnx/3DTrchUVINY6KW/ANOSNQVAw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-cloudfour/-/stylelint-config-cloudfour-6.1.0.tgz",
+      "integrity": "sha512-YuT3wBnWMp2Arva9DbSQ/OvQTPvX+jZpMEjTmq3RIkUhLOBVAWyqWLiUiFQa5SftMMTGVfhDxOAJRRsUxeFYOQ==",
       "dev": true,
       "requires": {
-        "stylelint-config-standard-scss": "2.0.1",
-        "stylelint-config-suitcss": "^17.0.0",
+        "stylelint-config-standard-scss": "5.0.0",
+        "stylelint-config-suitcss": "^18.0.0",
         "stylelint-high-performance-animation": "1.6.0"
       }
     },
@@ -69644,95 +69546,50 @@
       "requires": {}
     },
     "stylelint-config-recommended": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
-      "integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-8.0.0.tgz",
+      "integrity": "sha512-IK6dWvE000+xBv9jbnHOnBq01gt6HGVB2ZTsot+QsMpe82doDQ9hvplxfv4YnpEuUwVGGd9y6nbaAnhrjcxhZQ==",
       "dev": true,
       "requires": {}
     },
     "stylelint-config-recommended-scss": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
-      "integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-7.0.0.tgz",
+      "integrity": "sha512-rGz1J4rMAyJkvoJW4hZasuQBB7y9KIrShb20l9DVEKKZSEi1HAy0vuNlR8HyCKy/jveb/BdaQFcoiYnmx4HoiA==",
       "dev": true,
       "requires": {
         "postcss-scss": "^4.0.2",
-        "stylelint-config-recommended": "^6.0.0",
+        "stylelint-config-recommended": "^8.0.0",
         "stylelint-scss": "^4.0.0"
       }
     },
     "stylelint-config-standard": {
-      "version": "23.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-23.0.0.tgz",
-      "integrity": "sha512-8PDlk+nWuc1T66nVaODTdVodN0pjuE5TBlopi39Lt9EM36YJsRhqttMyUhnS78oc/59Q6n8iw2GJB4QcoFqtRg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-26.0.0.tgz",
+      "integrity": "sha512-hUuB7LaaqM8abvkOO84wh5oYSkpXgTzHu2Zza6e7mY+aOmpNTjoFBRxSLlzY0uAOMWEFx0OMKzr+reG1BUtcqQ==",
       "dev": true,
       "requires": {
-        "stylelint-config-recommended": "^6.0.0"
+        "stylelint-config-recommended": "^8.0.0"
       }
     },
     "stylelint-config-standard-scss": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-2.0.1.tgz",
-      "integrity": "sha512-TW5NLquUSS0mg2N31zzaSbYRbV/CMifSVLdpgo6VdGvjysgYqJOcKM/5bmXucTOsdfqomcPXetFZ3adC7nD+cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-5.0.0.tgz",
+      "integrity": "sha512-zoXLibojHZYPFjtkc4STZtAJ2yGTq3Bb4MYO0oiyO6f/vNxDKRcSDZYoqN260Gv2eD5niQIr1/kr5SXlFj9kcQ==",
       "dev": true,
       "requires": {
-        "stylelint-config-recommended-scss": "^5.0.0",
-        "stylelint-config-standard": "^23.0.0"
+        "stylelint-config-recommended-scss": "^7.0.0",
+        "stylelint-config-standard": "^26.0.0"
       }
     },
     "stylelint-config-suitcss": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-config-suitcss/-/stylelint-config-suitcss-17.0.0.tgz",
-      "integrity": "sha512-hBd6inIaU7pwmNPxfcPfeKwt3oje3dn7Oc23ghHDTMzRgaTFWJsMaNQGDf4cNYsV4K9juQUo74aMiSdCRiPAUw==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-suitcss/-/stylelint-config-suitcss-18.0.0.tgz",
+      "integrity": "sha512-hZHo/wLn2j65mI4JpqSipTmcPXsShf+PKxP5I0SeaV4ABAn/DME9eChTkoVYncUPUEiqIsBSPsiwlY7zfQLiYg==",
       "dev": true,
       "requires": {
-        "stylelint-order": "^4.1.0",
-        "stylelint-suitcss": "^4.0.0"
-      },
-      "dependencies": {
-        "picocolors": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.39",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-          "dev": true,
-          "requires": {
-            "picocolors": "^0.2.1",
-            "source-map": "^0.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "stylelint-order": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-4.1.0.tgz",
-          "integrity": "sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.15",
-            "postcss": "^7.0.31",
-            "postcss-sorting": "^5.0.1"
-          }
-        },
-        "stylelint-suitcss": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/stylelint-suitcss/-/stylelint-suitcss-4.0.0.tgz",
-          "integrity": "sha512-oVTd6ga/CoAssjm0hiTLJu7vMa6ib/xCJz1eGAIJTs+eW1s4WhCyc5zNTk3mD5i2PmCeY/sM8QzXPGKz3tYkDw==",
-          "dev": true,
-          "requires": {
-            "lodash.find": "^4.6.0",
-            "postcss-selector-parser": "^6.0.6"
-          }
-        }
+        "stylelint-order": "^5.0.0",
+        "stylelint-suitcss": "^5.0.0"
       }
     },
     "stylelint-high-performance-animation": {
@@ -69741,6 +69598,16 @@
       "integrity": "sha512-RW3XbNLMoKcqY97NTNLXzfg4IGzCfaIf+s4aQem7BzN5IYqYLdYuU1WCqMCoiZHRILQIkrkNvcaQOAu7bA9qxw==",
       "dev": true,
       "requires": {}
+    },
+    "stylelint-order": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-5.0.0.tgz",
+      "integrity": "sha512-OWQ7pmicXufDw5BlRqzdz3fkGKJPgLyDwD1rFY3AIEfIH/LQY38Vu/85v8/up0I+VPiuGRwbc2Hg3zLAsJaiyw==",
+      "dev": true,
+      "requires": {
+        "postcss": "^8.3.11",
+        "postcss-sorting": "^7.0.1"
+      }
     },
     "stylelint-scss": {
       "version": "4.3.0",
@@ -69753,6 +69620,17 @@
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-selector-parser": "^6.0.6",
         "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "stylelint-suitcss": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-suitcss/-/stylelint-suitcss-5.0.0.tgz",
+      "integrity": "sha512-ezx4lVcqE0S9dN5oRWc9BantR3xJk3Dg3ZKH4BOzkhA/4r9/1VhpB4lc9svguC1VzOnzs/b/6jLKRAzZk7ZWNA==",
+      "dev": true,
+      "requires": {
+        "lodash.find": "^4.6.0",
+        "postcss-selector-parser": "^6.0.8",
+        "stylelint": "^14.2.0"
       }
     },
     "stylelint-use-logical-spec": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "style-dictionary": "3.7.1",
     "style-loader": "2.0.0",
     "stylelint": "14.10.0",
-    "stylelint-config-cloudfour": "5.1.0",
+    "stylelint-config-cloudfour": "^6.1.0",
     "stylelint-config-prettier": "9.0.3",
     "stylelint-scss": "4.3.0",
     "stylelint-use-logical-spec": "4.1.0",

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -161,7 +161,7 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
 figure.wp-block-image {
   /// When this element has no alignment option set, attempt to fill the
   /// container padding.
-  &:not(.alignwide, .alignfull) {
+  &:not(.alignwide):not(.alignfull) {
     @include spacing.fluid-margin-inline-negative;
   }
 
@@ -177,7 +177,7 @@ figure.wp-block-image {
 /// Gutenberg block: Video
 /// Styles for videos inserted via Gutenberg blocks.
 .wp-block-video {
-  &:not(.alignwide, .alignfull, .aligncenter) {
+  &:not(.alignwide):not(.alignfull):not(.aligncenter) {
     @include spacing.fluid-margin-inline-negative;
   }
 

--- a/src/vendor/wordpress/styles/_utilities.scss
+++ b/src/vendor/wordpress/styles/_utilities.scss
@@ -32,7 +32,7 @@
   @include border-radius.conditional;
 
   /// Set inline margins unless the element's alignment has been set.
-  &:not(.alignfull, .alignwide, .aligncenter) {
+  &:not(.alignfull):not(.alignwide):not(.aligncenter) {
     @include spacing.fluid-margin-inline-negative;
   }
 }


### PR DESCRIPTION
Following the discussion in #1992 I've updated our stylelint config to prefer _not_ collapsing adjacent `:not()` selectors.

This PR updates to the latest version of our Stylelint config and un-collapses a few `:not()` selectors.

## Testing

Check out the WordPress core blocks story for [Image block](https://deploy-preview-2018--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-core-blocks--image), and [alignment](https://deploy-preview-2018--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-utilities--alignment&args=alignment:alignleft) for blocks with a background color, and confirm there are no regressions.