### PR TITLE
Improved Comment Styles

### DIFF
--- a/.changeset/soft-maps-grin.md
+++ b/.changeset/soft-maps-grin.md
@@ -1,0 +1,7 @@
+---
+"@cloudfour/patterns": patch
+---
+
+Improved comment styles:
+- Applying table styles to tables in comments.
+- Removing outdenting from code blocks in comments on legacy posts.

--- a/src/components/comment/comment.scss
+++ b/src/components/comment/comment.scss
@@ -71,9 +71,11 @@
 
 /// 1. The fluid heading size changes depending on the viewport, but the content
 ///    always looks just a *tad* close to the header. This offsets that.
+/// 2. Allow grid cells to shrink when contents are wider than available space.
 .c-comment__content {
   grid-area: content;
   margin-block-start: math.div(size.$rhythm-condensed, -4); // 1
+  min-width: 0; // 2
 }
 
 // We added default styles to the blockquote element using the `wp-block-quote`

--- a/src/components/comment/comment.scss
+++ b/src/components/comment/comment.scss
@@ -75,7 +75,7 @@
 .c-comment__content {
   grid-area: content;
   margin-block-start: math.div(size.$rhythm-condensed, -4); // 1
-  min-width: 0; // 2
+  min-inline-size: 0; // 2
 }
 
 // We added default styles to the blockquote element using the `wp-block-quote`

--- a/src/vendor/wordpress/core-element-comparison.stories.mdx
+++ b/src/vendor/wordpress/core-element-comparison.stories.mdx
@@ -2,6 +2,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import MarkdownDemo from './demo/compare-markdown.twig';
 import HTMLDemo from './demo/compare-html.twig';
 import GutenbergDemo from './demo/compare-gutenberg.twig';
+import CommentDemo from './demo/compare-comment.twig';
 
 <Meta title="Vendor/WordPress/Core Element Comparison" />
 
@@ -31,4 +32,12 @@ This shows the same set of elements created using core WordPress blocks.
 
 <Canvas>
   <Story name="Gutenberg">{() => GutenbergDemo()}</Story>
+</Canvas>
+
+## Comments
+
+This shows the same set of elements created in a comment.
+
+<Canvas>
+  <Story name="Comments">{() => CommentDemo()}</Story>
 </Canvas>

--- a/src/vendor/wordpress/demo/compare-comment.twig
+++ b/src/vendor/wordpress/demo/compare-comment.twig
@@ -1,0 +1,76 @@
+<div
+  class="demo-container c-comment"
+  style="max-width: 40rem; margin: 0 auto; padding: 0 1.25rem"
+>
+  <div class="o-rhythm c-comment__content o-rhythm--condensed">
+  <h1>Heading Level 1</h1>
+  <h2>Heading Level 2</h2>
+  <h3>Heading Level 3</h3>
+  <h4>Heading Level 4</h4>
+  <h5>Heading Level 5</h5>
+  <h6>Heading Level 6</h6>
+  <p>
+    This is a paragraph. It contains some <em>italic text</em>, some
+    <strong>bold text</strong>, some
+    <em><strong>bold and italic text</strong></em
+    >, and some inline <code>code</code>, and a
+    <a href="https://example.com">link</a>.
+  </p>
+  <pre
+    class="language-css"
+  ><code class="language-css">.code-block { color: hotpink; }</code></pre>
+  <blockquote>
+    <p>Here’s a blockquote</p>
+    <cite>with a citation</cite>
+  </blockquote>
+  <ul>
+    <li>Alpha</li>
+    <li>
+      Beta
+      <ul>
+        <li>Beta A</li>
+        <li>Beta B</li>
+      </ul>
+    </li>
+    <li>Gamma</li>
+  </ul>
+  <ol>
+    <li>Alpha</li>
+    <li>
+      Beta
+      <ol>
+        <li>Beta A</li>
+        <li>Beta B</li>
+      </ol>
+    </li>
+    <li>Gamma</li>
+  </ol>
+  <table>
+    <thead>
+      <tr>
+        <th>First Header</th>
+        <th>Second Header</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Content Cell</td>
+        <td>Content Cell</td>
+      </tr>
+      <tr>
+        <td>Content Cell</td>
+        <td>Content Cell</td>
+      </tr>
+    </tbody>
+  </table>
+  <p>Here’s an image:</p>
+  <p>
+    <img
+      src="https://api.lorem.space/image/movie?w=150&amp;h=220&amp;t=1"
+      alt="Movie Poster"
+    />
+  </p>
+  <p>And to wrap it all up, here’s a horizontal rule:</p>
+  <hr />
+</div>
+</div>

--- a/src/vendor/wordpress/demo/compare-comment.twig
+++ b/src/vendor/wordpress/demo/compare-comment.twig
@@ -3,74 +3,74 @@
   style="max-width: 40rem; margin: 0 auto; padding: 0 1.25rem"
 >
   <div class="o-rhythm c-comment__content o-rhythm--condensed">
-  <h1>Heading Level 1</h1>
-  <h2>Heading Level 2</h2>
-  <h3>Heading Level 3</h3>
-  <h4>Heading Level 4</h4>
-  <h5>Heading Level 5</h5>
-  <h6>Heading Level 6</h6>
-  <p>
-    This is a paragraph. It contains some <em>italic text</em>, some
-    <strong>bold text</strong>, some
-    <em><strong>bold and italic text</strong></em
-    >, and some inline <code>code</code>, and a
-    <a href="https://example.com">link</a>.
-  </p>
-  <pre
-    class="language-css"
-  ><code class="language-css">.code-block { color: hotpink; }</code></pre>
-  <blockquote>
-    <p>Here’s a blockquote</p>
-    <cite>with a citation</cite>
-  </blockquote>
-  <ul>
-    <li>Alpha</li>
-    <li>
-      Beta
-      <ul>
-        <li>Beta A</li>
-        <li>Beta B</li>
-      </ul>
-    </li>
-    <li>Gamma</li>
-  </ul>
-  <ol>
-    <li>Alpha</li>
-    <li>
-      Beta
-      <ol>
-        <li>Beta A</li>
-        <li>Beta B</li>
-      </ol>
-    </li>
-    <li>Gamma</li>
-  </ol>
-  <table>
-    <thead>
-      <tr>
-        <th>First Header</th>
-        <th>Second Header</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Content Cell</td>
-        <td>Content Cell</td>
-      </tr>
-      <tr>
-        <td>Content Cell</td>
-        <td>Content Cell</td>
-      </tr>
-    </tbody>
-  </table>
-  <p>Here’s an image:</p>
-  <p>
-    <img
-      src="https://api.lorem.space/image/movie?w=150&amp;h=220&amp;t=1"
-      alt="Movie Poster"
-    />
-  </p>
-  <p>And to wrap it all up, here’s a horizontal rule:</p>
-  <hr />
-</div>
+    <h1>Heading Level 1</h1>
+    <h2>Heading Level 2</h2>
+    <h3>Heading Level 3</h3>
+    <h4>Heading Level 4</h4>
+    <h5>Heading Level 5</h5>
+    <h6>Heading Level 6</h6>
+    <p>
+      This is a paragraph. It contains some <em>italic text</em>, some
+      <strong>bold text</strong>, some
+      <em><strong>bold and italic text</strong></em
+      >, and some inline <code>code</code>, and a
+      <a href="https://example.com">link</a>.
+    </p>
+    <pre
+      class="language-css"
+    ><code class="language-css">.code-block { color: hotpink; }</code></pre>
+    <blockquote>
+      <p>Here’s a blockquote</p>
+      <cite>with a citation</cite>
+    </blockquote>
+    <ul>
+      <li>Alpha</li>
+      <li>
+        Beta
+        <ul>
+          <li>Beta A</li>
+          <li>Beta B</li>
+        </ul>
+      </li>
+      <li>Gamma</li>
+    </ul>
+    <ol>
+      <li>Alpha</li>
+      <li>
+        Beta
+        <ol>
+          <li>Beta A</li>
+          <li>Beta B</li>
+        </ol>
+      </li>
+      <li>Gamma</li>
+    </ol>
+    <table>
+      <thead>
+        <tr>
+          <th>First Header</th>
+          <th>Second Header</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Content Cell</td>
+          <td>Content Cell</td>
+        </tr>
+        <tr>
+          <td>Content Cell</td>
+          <td>Content Cell</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>Here’s an image:</p>
+    <p>
+      <img
+        src="https://api.lorem.space/image/movie?w=150&amp;h=220&amp;t=1"
+        alt="Movie Poster"
+      />
+    </p>
+    <p>And to wrap it all up, here’s a horizontal rule:</p>
+    <hr />
+  </div>
 </div>

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -115,7 +115,7 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
  */
 .wp-block-code,
 .wp-block-jetpack-markdown pre,
-.legacy-post pre {
+.legacy-post :not(.c-comment .c-comment__content) > pre {
   @include spacing.fluid-margin-inline-negative; // 1
   @include spacing.fluid-padding-inline; // 1
 
@@ -202,7 +202,8 @@ figure.wp-block-image {
  */
 .wp-block-table,
 .wp-block-jetpack-markdown,
-.legacy-post {
+.legacy-post,
+.c-comment {
   table td,
   table th {
     @include table.t-container;

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -115,7 +115,7 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
  */
 .wp-block-code,
 .wp-block-jetpack-markdown pre,
-.legacy-post :not(.c-comment .c-comment__content) > pre {
+.legacy-post :not(.c-comment) > :not(.c-comment__content) > pre {
   @include spacing.fluid-margin-inline-negative; // 1
   @include spacing.fluid-padding-inline; // 1
 

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -115,7 +115,7 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
  */
 .wp-block-code,
 .wp-block-jetpack-markdown pre,
-.legacy-post :not(.c-comment) > :not(.c-comment__content) > pre {
+.legacy-post :not(.c-comment__content) > pre {
   @include spacing.fluid-margin-inline-negative; // 1
   @include spacing.fluid-padding-inline; // 1
 

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -115,13 +115,19 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
  */
 .wp-block-code,
 .wp-block-jetpack-markdown pre,
-.legacy-post :not(.c-comment__content) > pre {
+.legacy-post pre {
   @include spacing.fluid-margin-inline-negative; // 1
   @include spacing.fluid-padding-inline; // 1
 
   code {
     white-space: pre; // 2
   }
+}
+
+// Don't outdent code blocks in comments, where spacing is at a premium.
+.c-comment pre {
+  margin-inline: 0;
+  padding-inline: ms.step(1); // restoring default padding
 }
 
 /// Gutenberg block: Image


### PR DESCRIPTION
## Overview

This PR updates some of the core block styles to better match base
element styles between posts and comments. Specifically:

1. Applying table styles to tables in comments.
2. Removing outdenting from code blocks in comments on legacy posts.

## Screenshots

<img width="500" alt="Screen Shot 2022-08-24 at 4 39 47 PM" src="https://user-images.githubusercontent.com/257309/186542320-854db9dd-3f79-4b08-b529-8e0e7d6351a1.png">

## Testing

1. On the preview deploy, go to the [Vendor > WordPress > Core Element Comparison > Comments](https://deploy-preview-2022--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-core-element-comparison--comments) page.
1. Confirm that the table has the base table styles applied (border under the `thead`)
1. Confirm that the code block is _not_ outdented.
1. View source, add the `legacy-post` class to the `#root` element.
1. Confirm that the code block is still not outdented. (previously, `legacy-post` would do this)

---

- Fixes #1997
- Fixes #2021
