### PR TITLE
Remove focus-visible polyfill

### DIFF
--- a/.changeset/tasty-points-speak.md
+++ b/.changeset/tasty-points-speak.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': patch
 ---
 
-Remove focus-visible JS dependency
+Remove focus-visible polyfill

--- a/.changeset/tasty-points-speak.md
+++ b/.changeset/tasty-points-speak.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Remove focus-visible JS dependency

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,7 +5,6 @@ import twig from 'react-syntax-highlighter/dist/esm/languages/prism/twig';
 import { withTheme } from './theme-decorator';
 import { withTextFlow } from './text-flow-decorator';
 import tokens from '../src/compiled/tokens/js/tokens';
-import 'focus-visible';
 import '../src/index-with-dependencies.scss';
 import './preview.scss';
 import { makeTwigInclude } from '../src/make-twig-include';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "12.3.1",
       "license": "MIT",
       "dependencies": {
-        "focus-visible": "5.2.0",
         "prismjs": "1.28.0"
       },
       "devDependencies": {
@@ -22060,10 +22059,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/focus-visible": {
-      "version": "5.2.0",
-      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -57729,10 +57724,6 @@
       "requires": {
         "tslib": "^1.9.3"
       }
-    },
-    "focus-visible": {
-      "version": "5.2.0",
-      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "!src/index.scss"
   ],
   "dependencies": {
-    "focus-visible": "5.2.0",
     "prismjs": "1.28.0"
   },
   "devDependencies": {

--- a/src/design/defaults.stories.mdx
+++ b/src/design/defaults.stories.mdx
@@ -25,7 +25,7 @@ More options are available via [the Heading component](/docs/components-heading-
 <Canvas>
   <Story name="Inline elements">
     {`<p>
-  <b>Progressive Web Apps</b> are awesome, <em>especially</em> when they make the <del>best</del> <ins>most</ins> of the web! That means using both tried and true <abbr title="HyperText Markup Language">HTML</abbr> techniques like <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">links</a> alongside new techniques like <code>display: grid</code> or <a href="https://github.com/WICG/focus-visible"><code>focus-visible</code></a>! You can use <kbd>ctrl</kbd> + <kbd>c</kbd> on Windows and <kbd>⌘</kbd> + <kbd>c</kbd> on Mac.
+  <b>Progressive Web Apps</b> are awesome, <em>especially</em> when they make the <del>best</del> <ins>most</ins> of the web! That means using both tried and true <abbr title="HyperText Markup Language">HTML</abbr> techniques like <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">links</a> alongside new techniques like <code>display: grid</code> or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible"><code>:focus-visible</code></a>! You can use <kbd>ctrl</kbd> + <kbd>c</kbd> on Windows and <kbd>⌘</kbd> + <kbd>c</kbd> on Mac.
 </p>`}
   </Story>
 </Canvas>

--- a/src/design/demo/theme-content.twig
+++ b/src/design/demo/theme-content.twig
@@ -1,7 +1,7 @@
 {% embed '@cloudfour/objects/rhythm/rhythm.twig' %}
   {% block content %}
     <p>
-      <b>Progressive Web Apps</b> are awesome, <em>especially</em> when they make the <del>best</del> <ins>most</ins> of the web! That means using both tried and true <abbr title="HyperText Markup Language">HTML</abbr> techniques like <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">links</a> alongside new techniques like <code>display: grid</code> or <a href="https://github.com/WICG/focus-visible"><code>focus-visible</code></a>!
+      <b>Progressive Web Apps</b> are awesome, <em>especially</em> when they make the <del>best</del> <ins>most</ins> of the web! That means using both tried and true <abbr title="HyperText Markup Language">HTML</abbr> techniques like <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">links</a> alongside new techniques like <code>display: grid</code> or <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible"><code>:focus-visible</code></a>!
     </p>
 
     <p>

--- a/src/mixins/_focus.scss
+++ b/src/mixins/_focus.scss
@@ -1,15 +1,13 @@
 @mixin focus-visible {
-  .js-focus-visible & {
-    &::-moz-focus-inner {
-      border: 0;
-    }
+  &::-moz-focus-inner {
+    border: 0;
+  }
 
-    &:focus {
-      outline: 0;
+  &:focus {
+    outline: 0;
+  }
 
-      &.focus-visible {
-        @content;
-      }
-    }
+  &:focus-visible {
+    @content;
   }
 }


### PR DESCRIPTION
## Overview

This PR removes the `focus-visible` polyfill in favor of the native `:focus-visible`.

## Screenshots

Before | After
--- | ---
<img width="564" alt="Screen Shot 2022-08-29 at 10 43 23 AM" src="https://user-images.githubusercontent.com/459757/187269845-a69b44d7-0d3e-4646-845b-dd19e39844ff.png"> | <img width="495" alt="Screen Shot 2022-08-29 at 10 43 34 AM" src="https://user-images.githubusercontent.com/459757/187269850-ddd0b614-6d95-4e70-ba27-92cf03c31511.png">
<img width="556" alt="Screen Shot 2022-08-29 at 10 56 02 AM" src="https://user-images.githubusercontent.com/459757/187269938-0d7168f9-07aa-47f1-b658-fd99b042f8c0.png"> | <img width="494" alt="Screen Shot 2022-08-29 at 10 56 09 AM" src="https://user-images.githubusercontent.com/459757/187269943-fedba4ef-81f3-43c3-b189-7ac817845a29.png">
<img width="171" alt="Screen Shot 2022-08-29 at 10 58 00 AM" src="https://user-images.githubusercontent.com/459757/187270124-dfab76e0-b0f0-4695-b5ff-17877d3c34a1.png"> | <img width="181" alt="Screen Shot 2022-08-29 at 10 58 07 AM" src="https://user-images.githubusercontent.com/459757/187270132-faa01430-eea8-46fb-891f-dd82cfd0ec9e.png">
<img width="265" alt="Screen Shot 2022-08-29 at 11 03 29 AM" src="https://user-images.githubusercontent.com/459757/187270238-fd1390db-ec9e-4386-970c-70e35f09bf53.png"> | <img width="270" alt="Screen Shot 2022-08-29 at 11 03 40 AM" src="https://user-images.githubusercontent.com/459757/187270244-27bb94b2-f879-4027-a5f0-0b5d1cf101d7.png">



## Testing

Review each before/after and confirm there are no visual differences when tabbing or clicking focusable elements.

### Alert
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-alert--dismissable
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-alert--dismissable

### Card
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-card--link
- https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-card--link

### Checkbox 
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-checkbox--enabled
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-checkbox--enabled

### Footnote basic
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-footnote-footnote--basic
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-footnote-footnote--basic

### Footnote Group basic
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-footnote-footnote-group--basic
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-footnote-footnote-group--basic

### Footnote Group compact
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-footnote-footnote-group--compact
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-footnote-footnote-group--compact

### Footnote Link basic

- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-footnote-footnote-link--basic
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-footnote-footnote-link--basic

### Heading permalink
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-heading--permalink
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-heading--permalink

### Media Summary
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-media-summary--event
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-media-summary--event

### Pagination
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-pagination--example
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-pagination--example

### Sky Nav logo and "menu" toggle
- Before: https://cloudfour-patterns.netlify.app/?path=/story/components-sky-nav--dark
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/story/components-sky-nav--dark

### Button
- Before: https://cloudfour-patterns.netlify.app/?path=/docs/components-button--button-element
- After: https://deploy-preview-2032--cloudfour-patterns.netlify.app/?path=/docs/components-button--button-element


---

- Closes #1998 