### PR TITLE
Enhance Calendar Date screen reader UX

### DIFF
--- a/.changeset/dry-kangaroos-try.md
+++ b/.changeset/dry-kangaroos-try.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Enhance Calendar Date screen reader UX

--- a/src/components/calendar-date/calendar-date.twig
+++ b/src/components/calendar-date/calendar-date.twig
@@ -1,21 +1,40 @@
-{% set datetime = datetime|default('now') %}
-{% set days = days|default(1) %}
+{% set _datetime = datetime|default('now') %}
 {% set _note %}{% block note %}{{ note }}{% endblock %}{% endset %}
 
-<time class="c-calendar-date c-calendar-date--{{ datetime|date('F')|lower }}{% if class %} {{ class }}{% endif %}"
-  datetime="{{ datetime|date('Y-m-d') }}"
+<div
+  class="c-calendar-date c-calendar-date--{{ _datetime|date('F')|lower }}{% if class %} {{ class }}{% endif %}"
 >
-  <span class="c-calendar-date__header">
-    {{ datetime|date('M') }}
+  {# The abbreviated month is aria-hidden as it's only presentational #}
+  <span class="c-calendar-date__header" aria-hidden="true">
+    {{ _datetime|date('M') }}
   </span>
+
   <span class="c-calendar-date__main">
-    <span class="c-calendar-date__day">
-      {{ datetime|date('j') }}
-    </span>
+    <time class="c-calendar-date__day" datetime="{{ _datetime|date('Y-m-d') }}">
+      {# The day of the month is aria-hidden as it's only presentational #}
+      <span aria-hidden="true">{{ _datetime|date('j') }}</span>
+      {# The full date is accessible to screen readers to provide full context #}
+      <span class="u-hidden-visually">{{ _datetime|date('F j, o') }}</span>
+    </time>
+
     {% if _note %}
       <span class="c-calendar-date__note">
         {{ _note }}
       </span>
+    {% else %}
+      {#
+        A default visually hidden note to provide extra context for screen reader users.
+      #}
+      <span class="u-hidden-visually">Single-day event</span>
     {% endif %}
   </span>
-</time>
+</div>
+
+{#
+
+September 9, 2022
+Single-day event
+September 9, 2022
+3-day event
+
+ #}

--- a/src/components/calendar-date/calendar-date.twig
+++ b/src/components/calendar-date/calendar-date.twig
@@ -29,12 +29,3 @@
     {% endif %}
   </span>
 </div>
-
-{#
-
-September 9, 2022
-Single-day event
-September 9, 2022
-3-day event
-
- #}

--- a/src/components/media-summary/demo/event.twig
+++ b/src/components/media-summary/demo/event.twig
@@ -1,5 +1,5 @@
 {% embed '@cloudfour/components/media-summary/media-summary.twig' with {
-  heading: "Smashing Magazine",
+  heading: "SmashingConf New York",
   href: "https://cloudfour.com",
   reverse_markup: true,
 } only %}


### PR DESCRIPTION
## Overview

This PR modifies the Calendar Date component in an attempt to create a better screen reader user experience.

Changes include:
- added a "single-day event" visually hidden note fallback
- refactor component markup to lessen the VoiceOver duplicate date announcment
- enhance NVDA screen reader UX

## Screenshots

No visual changes.

## Testing

### Before

Screenshot | NVDA + Firefox | VoiceOver + Safari
--- | --- | ---
<img width="126" alt="Screen Shot 2022-09-09 at 2 10 49 PM" src="https://user-images.githubusercontent.com/459757/189446675-a08af487-55fb-47c0-8adb-16a0cb90fe61.png"> | "SEP" <br> "9" | "SEP, September 9, 2022" <br> "9, September 9, 2022"
<img width="123" alt="Screen Shot 2022-09-09 at 2 10 56 PM" src="https://user-images.githubusercontent.com/459757/189446906-1d53f77d-791b-4b7b-aca8-25bca87d7760.png"> | "SEP" <br> "9" <br> "3-day event" | "SEP, September 9, 2022" <br> "9, September 9, 2022" <br> "3-day event, September 9, 2022"

### After

Screenshot | NVDA + Firefox | VoiceOver + Safari
--- | --- | ---
<img width="126" alt="Screen Shot 2022-09-09 at 2 10 49 PM" src="https://user-images.githubusercontent.com/459757/189446675-a08af487-55fb-47c0-8adb-16a0cb90fe61.png"> | "September 9, 2022" <br> "Single-day event" | "September 9, 2022, September 9, 2022" <br> "Single-day event"
<img width="123" alt="Screen Shot 2022-09-09 at 2 10 56 PM" src="https://user-images.githubusercontent.com/459757/189446906-1d53f77d-791b-4b7b-aca8-25bca87d7760.png"> | "September 9, 2022" <br> "3-day event" | "September 9, 2022, September 9, 2022" <br> "3-day event"

### Why is VoiceOver duplicating the date?
Because VoiceOver is silly. It's the only screen reader that exposes the `datetime` attribute. It probably shouldn't. The NVDA UX is much improved, while the VoiceOver UX is also better, even though it's slightly annoying that the `datetime` value is read, causing the date to be announced twice. Nothing we can do about that, and in my opinion, this solution finds a nice middle-ground where both NVDA and VoiceOver UX are better and acceptable, even though the VoiceOver UX is not perfect.

### Previews

- [Calendar Date component](https://deploy-preview-2040--cloudfour-patterns.netlify.app/?path=/docs/components-calendar-date--basic)
- [Media Summary component with Calendar Date component](https://deploy-preview-2040--cloudfour-patterns.netlify.app/?path=/story/components-media-summary--event)

1. Use VoiceOver and NVDA (if you have access to it) to test the screen reader UX

---

- Closes #1724 