### PR TITLE
Used fixed positioning for Alert component

### DIFF
--- a/.changeset/fuzzy-singers-double.md
+++ b/.changeset/fuzzy-singers-double.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Fixed positioning, bottom-alignment for Alert component

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -72,7 +72,7 @@
       )};
     --theme-color-shadow-outer: #{sass-color.change(
         color.$brand-primary-darker,
-        $alpha: 0.3
+        $alpha: 0.2
       )};
   }
   @include theme.styles(dark) {

--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -68,11 +68,11 @@
   @include theme.styles {
     --theme-color-shadow-inner: #{sass-color.change(
         color.$brand-primary-darker,
-        $alpha: 0.2
+        $alpha: 0.4
       )};
     --theme-color-shadow-outer: #{sass-color.change(
         color.$brand-primary-darker,
-        $alpha: 0.1
+        $alpha: 0.3
       )};
   }
   @include theme.styles(dark) {

--- a/src/mixins/_spacing.scss
+++ b/src/mixins/_spacing.scss
@@ -37,11 +37,21 @@ $fluid-gap: fluid.fluid-clamp(
 );
 
 @mixin fluid-padding-block($factor: 1) {
-  padding-block: calc($fluid-spacing-block * $factor);
+  padding-block: fluid.fluid-clamp(
+    $fluid-spacing-block-min * $factor,
+    $fluid-spacing-block-max * $factor,
+    $fluid-spacing-breakpoint-min,
+    $fluid-spacing-breakpoint-max
+  );
 }
 
 @mixin fluid-padding-inline($factor: 1) {
-  padding-inline: calc($fluid-spacing-inline * $factor);
+  padding-inline: fluid.fluid-clamp(
+    $fluid-spacing-inline-min * $factor,
+    $fluid-spacing-inline-max * $factor,
+    $fluid-spacing-breakpoint-min,
+    $fluid-spacing-breakpoint-max
+  );
 }
 
 @mixin fluid-margin-inline-negative() {

--- a/src/mixins/_spacing.scss
+++ b/src/mixins/_spacing.scss
@@ -36,12 +36,12 @@ $fluid-gap: fluid.fluid-clamp(
   $fluid-spacing-breakpoint-max
 );
 
-@mixin fluid-padding-block() {
-  padding-block: $fluid-spacing-block;
+@mixin fluid-padding-block($factor: 1) {
+  padding-block: calc($fluid-spacing-block * $factor);
 }
 
-@mixin fluid-padding-inline() {
-  padding-inline: $fluid-spacing-inline;
+@mixin fluid-padding-inline($factor: 1) {
+  padding-inline: calc($fluid-spacing-inline * $factor);
 }
 
 @mixin fluid-margin-inline-negative() {

--- a/src/objects/page/demo/example-with-alert.twig
+++ b/src/objects/page/demo/example-with-alert.twig
@@ -13,12 +13,34 @@
     </p>
   {% endblock %}
   {% block content %}
-    <p class="u-pad-1">
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu ex
-      enim. Nunc efficitur scelerisque dolor et sollicitudin. Donec finibus
-      lorem elit, eu consectetur quam pellentesque sed. Pellentesque habitant
-      morbi tristique senectus et netus et malesuada fames ac turpis egestas.
-    </p>
+    {% embed '@cloudfour/objects/container/container.twig' with {
+      class: 'o-container--pad'
+    } only %}
+      {% block content %}
+        {% embed '@cloudfour/objects/rhythm/rhythm.twig' only %}
+          {% block content %}
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu ex
+              enim. Nunc efficitur scelerisque dolor et sollicitudin. Donec finibus
+              lorem elit, eu consectetur quam pellentesque sed. Pellentesque habitant
+              morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu ex
+              enim. Nunc efficitur scelerisque dolor et sollicitudin. Donec finibus
+              lorem elit, eu consectetur quam pellentesque sed. Pellentesque habitant
+              morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque eu ex
+              enim. Nunc efficitur scelerisque dolor et sollicitudin. Donec finibus
+              lorem elit, eu consectetur quam pellentesque sed. Pellentesque habitant
+              morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+            </p>
+          {% endblock %}
+        {% endembed %}
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
   {% block footer %}
     <p class="u-pad-1 t-dark">

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -32,16 +32,21 @@
 /**
  * An optional `alert` block can be used to pass an Alert component
  *
- * 1. The alert should overlap the content above slightly
+ * 1. Use a $factor of 0.5 to allow the alert to bleed more into the
+ *    content margins instead of aligning with the content itself.
+ * 2. Match the padding-inline for visual balance.
  */
 
 .o-page__alert {
-  @include spacing.fluid-padding-inline;
+  @include spacing.fluid-padding-inline($factor: 0.5); // 1
+  @include spacing.fluid-padding-block($factor: 0.5); // 2
+
   display: grid;
   grid-row: 2;
-  inset-block-start: calc(size.$overlap-large * -1); // 1
+  inline-size: 100%;
+  inset-block-end: 0;
   justify-content: center;
-  position: relative;
+  position: fixed;
   z-index: z-index.$alert;
 }
 


### PR DESCRIPTION
## Overview

This PR refactors the Alert component positioning to a `fixed` position with bottom alignment.

Other changes include:
- make drop-shadows darker for light-theme
- added a `$factor` to the `spacing.fluid-padding-inline` and `spacing.fluid-padding-block` mixins for customization

## Screenshots

Smaller viewport | Larger viewport
--- | ---
<img width="331" alt="Screen Shot 2022-09-12 at 3 53 19 PM" src="https://user-images.githubusercontent.com/459757/189772548-394282a8-478e-4395-a5df-b77b9bc3a58a.png"> | <img width="1090" alt="Screen Shot 2022-09-12 at 3 52 59 PM" src="https://user-images.githubusercontent.com/459757/189772564-d46f8aff-9e5b-485a-b65e-dc6dd5f008f8.png">


## Testing

Preview: https://deploy-preview-2044--cloudfour-patterns.netlify.app/iframe.html?args=&id=objects-page--example-with-alert&viewMode=story

Review various viewport sizes, the Alert:
- [ ] Should always be `fixed`, bottom-aligned
- [ ] Should bleed horizontally into content margins at smaller viewports
- [ ] Should be horizontally centered at larger viewports


---

- Closes https://github.com/cloudfour/cloudfour.com-wp/issues/869