### PR TITLE
Fix alignment issue with deck

### DIFF
--- a/.changeset/eleven-dryers-vanish.md
+++ b/.changeset/eleven-dryers-vanish.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix issue where Deck objects would unexpectedly stretch columns at wider viewports

--- a/src/objects/deck/deck.scss
+++ b/src/objects/deck/deck.scss
@@ -18,13 +18,14 @@
    * We define a media query for our initial grid so child elements will flex
    * for viewports smaller than our minimum column size.
    *
-   * Our use of `auto-fit` means columns will be automatically created as space
-   * allows.
+   * `auto-fill` creates extra columns as space allows, and will not stretch
+   * columns to fill empty space (which makes sure adjacent objects with
+   * differing item counts will stay aligned).
    */
 
   @media (width >= breakpoint.$xs) {
     grid-template-columns: repeat(
-      auto-fit,
+      auto-fill,
       minmax(#{size.$width-card-column-min}, 1fr)
     );
   }


### PR DESCRIPTION
## Overview

While addressing https://github.com/cloudfour/cloudfour.com-patterns/issues/2002, I noticed that deck objects with only one item were stretching when column counts were not explicitly specified via a modifier. This was due to a misunderstanding of `auto-fit` versus `auto-fill`. This change fixes that, so if two adjacent deck objects have different item counts, they will not have different alignments.

## Screenshots

Here is an example Deck with multiple items in it. Note the column widths:

<img width="862" alt="Screen Shot 2022-09-14 at 9 49 41 AM" src="https://user-images.githubusercontent.com/69633/190214839-3e5f6bae-58bc-483f-83ed-0cf4dc611035.png">

If we remove all but the first card _before_ this PR, the remaining card stretches to fill the space, becoming far too large:

<img width="862" alt="Screen Shot 2022-09-14 at 9 49 23 AM" src="https://user-images.githubusercontent.com/69633/190214950-a3435b22-eff6-4046-a63b-4cacaf7f7ff9.png">

If we do the same _after_ this PR, the card stays the same size regardless of how many siblings it has:

<img width="858" alt="Screen Shot 2022-09-14 at 9 49 05 AM" src="https://user-images.githubusercontent.com/69633/190215050-263753c6-0ed4-4355-8a9a-f746b7c5c797.png">

## Testing

1. [Open one of the deck stories](https://deploy-preview-2047--cloudfour-patterns.netlify.app/?path=/story/objects-deck--basic)
2. Remove all but one card using the inspector
3. Confirm that the size of the remaining card remains the same

---

- See https://github.com/cloudfour/cloudfour.com-patterns/issues/2002