### PR TITLE
Allow WordPress Group blocks to inherit rhythm

### DIFF
--- a/.changeset/empty-forks-type.md
+++ b/.changeset/empty-forks-type.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Allow WordPress Group blocks to inherit vertical rhythm

--- a/src/vendor/wordpress/demo/group.twig
+++ b/src/vendor/wordpress/demo/group.twig
@@ -26,6 +26,7 @@
         </p>
         <cite>Scott Henning, Marketing Director</cite>
       </blockquote>
+      <p>One more element in this group.</p>
     </div>
   </div>
   <p>

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -205,6 +205,21 @@ figure.wp-block-image {
   }
 }
 
+/// Gutenberg block: Group
+///
+/// Allow child elements to inherit the parent element rhythm.
+.wp-block-group__inner-container {
+  @include spacing.vertical-rhythm;
+
+  /// If the first child of the group is a block image that is not a `figure`
+  /// element, assume it is a left- or right-aligned image. To prevent extra
+  /// whitespace at the top of the group, we negate the start margin of the
+  /// next element in the group.
+  > .wp-block-image:not(figure):first-child + * {
+    margin-block-start: 0;
+  }
+}
+
 /**
  * Gutenberg block: Table
  * Applies our pattern library styles to tables generated via Gutenberg blocks.


### PR DESCRIPTION
## Overview

Addresses an issue with `.wp-block-group` elements where they wouldn't inherit vertical rhythm from the `.o-rhythm` object. This could not be resolved via WordPress admin settings because the `class` attribute will not impact the `.wp-block-group__inner-container` element.

A common use case for this block is to group floating images and adjacent content. To prevent extra space for showing up, a little bit of a selector hack was used to negate the top margin on items following a left- or right-aligned image block.

Alternatively I could have replaced this fix with `.wp-block-group.o-rhythm > * { @include spacing.vertical-rhythm; }`, but then you'd need to add the class every time, and it wouldn't include a fix for the image alignment feature above. 

## Screenshots

### Before

Note the lack of space between the blockquote and paragraph…

<img width="746" alt="Screen Shot 2022-09-15 at 2 28 35 PM" src="https://user-images.githubusercontent.com/69633/190512561-861f0b4c-6656-4110-82cf-0b6162a3d27e.png">

### After

<img width="740" alt="Screen Shot 2022-09-15 at 2 28 01 PM" src="https://user-images.githubusercontent.com/69633/190512659-17b18867-19e1-450c-9237-1a3a8f68cb63.png">

## Testing

[Try out this story on the deploy preview](https://deploy-preview-2049--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-core-blocks--group&args=background:has-gray-lighter-background-color+has-background)

---

- Fixes #2033
