### PR TITLE
Fix nested rhythm object issue

### DIFF
--- a/.changeset/hip-numbers-learn.md
+++ b/.changeset/hip-numbers-learn.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Nested rhythm objects with modifiers no longer lose their own vertical rhythm

--- a/src/objects/rhythm/demo/nesting.twig
+++ b/src/objects/rhythm/demo/nesting.twig
@@ -1,9 +1,26 @@
 {% embed '@cloudfour/objects/rhythm/rhythm.twig' %}
   {% block content %}
-    <p>This paragraph is in a rhythm object with {% if amount %}<code>{{amount}}</code>{% else %}no{% endif %} spacing set.</p>
-    <p>This list is also a rhythm object, inheriting that spacing:</p>
+    <p>
+      This paragraph is in a rhythm object with
+      {% if amount %}
+        <code>{{amount}}</code>
+      {% else %}
+        no
+      {% endif %}
+      spacing set.
+    </p>
+    <p>
+      This list is also a rhythm object
+      {% if nested_amount and nested_amount != amount %}
+        but with <code>{{nested_amount}}</code>
+      {%- else -%}
+        with inherited
+      {%- endif %}
+      spacing:
+    </p>
     {% embed '@cloudfour/objects/rhythm/rhythm.twig' with {
       tag_name: 'ul',
+      amount: nested_amount
     } only %}
       {% block content %}
         <li><a href="#">Accessibility</a></li>

--- a/src/objects/rhythm/rhythm.scss
+++ b/src/objects/rhythm/rhythm.scss
@@ -9,34 +9,37 @@
   @include spacing.vertical-rhythm(size.$rhythm-default);
 }
 
-// General spacing modifiers
+/// General spacing modifiers
+///
+/// The `--rhythm` property change is applied to children so it won't impact
+/// any rhythm acting on the parent element.
 
-.o-rhythm--compact {
+.o-rhythm--compact > * {
   --rhythm: #{size.$rhythm-compact};
 }
 
-.o-rhythm--condensed {
+.o-rhythm--condensed > * {
   --rhythm: #{size.$rhythm-condensed};
 }
 
-.o-rhythm--generous {
+.o-rhythm--generous > * {
   --rhythm: #{size.$rhythm-generous};
 }
 
-.o-rhythm--lavish {
+.o-rhythm--lavish > * {
   @include spacing.fluid-vertical-rhythm;
 }
 
-.o-rhythm--default {
+.o-rhythm--default > * {
   --rhythm: #{size.$rhythm-default};
 }
 
 // Heading modifiers
 
-.o-rhythm--generous-headings {
+.o-rhythm--generous-headings > * {
   --rhythm-headings: #{size.$rhythm-generous};
 }
 
-.o-rhythm--lavish-headings {
+.o-rhythm--lavish-headings > * {
   @include spacing.fluid-vertical-rhythm($headings: true);
 }

--- a/src/objects/rhythm/rhythm.stories.mdx
+++ b/src/objects/rhythm/rhythm.stories.mdx
@@ -29,38 +29,47 @@ const nestingDemoTransformSource = (_src, storyContext) => {
   const argsString = argsStringFromStoryContext(storyContext);
   return nestingDemoSource.replace(".twig' %}", `.twig'${argsString} only %}`);
 };
+const amountOptions = [
+  '',
+  'compact',
+  'condensed',
+  'default',
+  'generous',
+  'lavish',
+];
+const argTypes = {
+  amount: {
+    options: amountOptions,
+    type: { name: 'enum' },
+    control: { type: 'select' },
+    description:
+      'Amount of vertical space to apply between adjacent elements as a keyword.',
+  },
+  heading_amount: {
+    options: ['', 'generous', 'lavish'],
+    type: { name: 'enum' },
+    control: { type: 'select' },
+    description:
+      'Amount of vertical space to apply before headings as a keyword.',
+  },
+  class: {
+    type: { name: 'string' },
+    description: 'CSS class name to append to element.',
+  },
+  tag_name: {
+    type: { name: 'string' },
+    description: 'The HTML tag of the element.',
+    table: {
+      defaultValue: {
+        summary: 'div',
+      },
+    },
+  },
+};
 
 <Meta
   title="Objects/Rhythm"
-  argTypes={{
-    amount: {
-      options: ['', 'compact', 'condensed', 'default', 'generous', 'lavish'],
-      type: { name: 'enum' },
-      control: { type: 'select' },
-      description:
-        'Amount of vertical space to apply between adjacent elements as a keyword.',
-    },
-    heading_amount: {
-      options: ['', 'generous', 'lavish'],
-      type: { name: 'enum' },
-      control: { type: 'select' },
-      description:
-        'Amount of vertical space to apply before headings as a keyword.',
-    },
-    class: {
-      type: { name: 'string' },
-      description: 'CSS class name to append to element.',
-    },
-    tag_name: {
-      type: { name: 'string' },
-      description: 'The HTML tag of the element.',
-      table: {
-        defaultValue: {
-          summary: 'div',
-        },
-      },
-    },
-  }}
+  argTypes={argTypes}
   parameters={{
     docs: { transformSource: demoTransformSource },
   }}
@@ -119,6 +128,14 @@ Nested rhythm objects will inherit any spacing set via modifiers. In this exampl
 <Canvas>
   <Story
     name="Nesting"
+    argTypes={{
+      ...argTypes,
+      nested_amount: {
+        options: amountOptions,
+        type: { name: 'enum' },
+        control: { type: 'select' },
+      },
+    }}
     args={{ amount: 'condensed' }}
     parameters={{
       docs: { transformSource: nestingDemoTransformSource },


### PR DESCRIPTION
## Overview

By default, a nested rhythm object inherits the `--rhythm` of its parent. In cases where you did _not_ want to inherit the rhythm, however, the containing element would lose its parent `--rhythm`, which necessitated multiple containing elements to overcome.

This PR changes the modifiers so the `--rhythm` is applied to immediate children, which prevents the element itself from losing its own rhythm.

## Screenshots

### Before

Notice how the list with `compact` spacing runs up against its sibling, even though the containing element has `generous` spacing:

<img width="511" alt="Screen Shot 2022-09-15 at 4 11 15 PM" src="https://user-images.githubusercontent.com/69633/190524285-8b832a7d-1a4f-457d-9257-b1ab31e18258.png">

### After

Now the `compact` spacing only applies to the element's children, so the parent spacing is intact:

<img width="516" alt="Screen Shot 2022-09-15 at 4 12 11 PM" src="https://user-images.githubusercontent.com/69633/190524358-3416b69e-a3d2-481b-b726-d1f841c8c9b2.png">

## Testing

Open [this story in the deploy preview](https://deploy-preview-2051--cloudfour-patterns.netlify.app/?path=/story/objects-rhythm--nesting&args=amount:generous;nested_amount:compact) and mess with the `amount` and `nested_amount` controls. The `amount` spacing should always apply to the `ul` itself, while the `nested_amount` should only apply to the list elements therein.

---

- Fixes #1933 
