### PR TITLE
Support more WordPress table styles

### DIFF
--- a/.changeset/good-pandas-applaud.md
+++ b/.changeset/good-pandas-applaud.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add support for "ruled" and "numeric" WordPress Table block styles (in addition to the standard default and "stripes" styles)

--- a/src/vendor/wordpress/core-blocks.stories.mdx
+++ b/src/vendor/wordpress/core-blocks.stories.mdx
@@ -548,7 +548,7 @@ The spacer block is a `div` with a class of `wp-block-spacer`.
 
 The table block renders a table wrapped in a `figure` element with the class `wp-block-table`. Controls for this block render optional `thead` and `tfoot` sections. A caption input renders a `figcaption` element within the wrapper and below the `table` element.
 
-Left, right, or center alignment of cell content can be set at the column level, and adds a `has-text-align-` class to each affected cell. Another control optionally adds the `has-fixed-layout` class to the `table` element: This forces column widths to be identical.
+Left, right, or center alignment of cell content can be set at the column level, and adds a `has-text-align-*` class to each affected cell. Another control optionally adds the `has-fixed-layout` class to the `table` element: This forces column widths to be identical.
 
 WordPress ships with a "stripes" style (using the class `is-style-stripes`), which we support. We also support `is-style-ruled` and `is-style-numeric` classes, which can be added to a WordPress theme using `register_block_style`.
 

--- a/src/vendor/wordpress/core-blocks.stories.mdx
+++ b/src/vendor/wordpress/core-blocks.stories.mdx
@@ -2,6 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import blockImageDemo from './demo/image.twig';
 import blockCodeDemo from './demo/code.twig';
 import blockGroupDemo from './demo/group.twig';
+import blockTableDemo from './demo/table.twig';
 
 <Meta title="Vendor/WordPress/Core Blocks" />
 
@@ -545,171 +546,50 @@ The spacer block is a `div` with a class of `wp-block-spacer`.
 
 ## Table
 
-The table block renders a table wrapped in a `figure` element with the class
-`wp-block-table`. Controls for this block render optional `thead` and `tfoot` sections.
-A caption input renders a `figcaption` element within the wrapper and below the
-`table` element.
+The table block renders a table wrapped in a `figure` element with the class `wp-block-table`. Controls for this block render optional `thead` and `tfoot` sections. A caption input renders a `figcaption` element within the wrapper and below the `table` element.
 
-Right, left, or center alignment of cell content can be set at the column level,
-and adds a `has-text-align-` class to each affected cell. Another control optionally adds the `has-fixed-layout` class to the `table` element.
+Left, right, or center alignment of cell content can be set at the column level, and adds a `has-text-align-` class to each affected cell. Another control optionally adds the `has-fixed-layout` class to the `table` element: This forces column widths to be identical.
 
-The default WP styles controls allow for one of two classes, `is-style-default` or `is-style-stripes`. When selected, these classes are applied to the parent wrapper, for controlling zebra-striping on alternate rows.
-
-Additionally, the Advanced → Additional CSS Classes input can be used to generate ruled and numeric tables by adding `c-table--ruled` and/or `c-table--numeric`. These additional classes will be added to the `<figure>` element, which differs from how our `c-table` pattern is set up, but the styled outcome will be the same.
+WordPress ships with a "stripes" style (using the class `is-style-stripes`), which we support. We also support `is-style-ruled` and `is-style-numeric` classes, which can be added to a WordPress theme using `register_block_style`.
 
 <Canvas>
-  <Story name="Table">
-    {`<h2>Default Table</h2>
-    <figure class="wp-block-table is-style-default">
-        <table class="has-fixed-layout">
-          <thead>
-            <tr>
-              <th class="has-text-align-right" data-align="right">Heading 1</th>
-              <th class="has-text-align-right" data-align="right">Heading 2</th>
-              <th class="has-text-align-right" data-align="right">Heading 3</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-          </tbody>
-          <tfoot>
-            <tr>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-            </tr>
-          </tfoot>
-        </table>
-        <figcaption>A caption can be added but is not rendered as a caption element</figcaption>
-      </figure>
-      <h2>Ruled Table</h2>
-      <figure class="wp-block-table is-style-default c-table--ruled">
-        <table class="has-fixed-layout">
-          <thead>
-            <tr>
-              <th class="has-text-align-right" data-align="right">Heading 1</th>
-              <th class="has-text-align-right" data-align="right">Heading 2</th>
-              <th class="has-text-align-right" data-align="right">Heading 3</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-          </tbody>
-          <tfoot>
-            <tr>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-            </tr>
-          </tfoot>
-        </table>
-        <figcaption>A caption can be added but is not rendered as a caption element</figcaption>
-      </figure>
-      <h2>Striped Table</h2>
-      <figure class="wp-block-table is-style-stripes">
-        <table class="has-fixed-layout">
-          <thead>
-            <tr>
-              <th class="has-text-align-right" data-align="right">Heading 1</th>
-              <th class="has-text-align-right" data-align="right">Heading 2</th>
-              <th class="has-text-align-right" data-align="right">Heading 3</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-          </tbody>
-          <tfoot>
-            <tr>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-            </tr>
-          </tfoot>
-        </table>
-        <figcaption>A caption can be added but is not rendered as a caption element</figcaption>
-      </figure>
-      <h2>Numeric Table</h2>
-      <figure class="wp-block-table c-table--numeric">
-        <table class="has-fixed-layout">
-          <thead>
-            <tr>
-              <th class="has-text-align-right" data-align="right">Heading 1</th>
-              <th class="has-text-align-right" data-align="right">Heading 2</th>
-              <th class="has-text-align-right" data-align="right">Heading 3</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-            <tr>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-              <td class="has-text-align-right" data-align="right">content</td>
-            </tr>
-          </tbody>
-          <tfoot>
-            <tr>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-              <td class="has-text-align-right" data-align="right">Footer</td>
-            </tr>
-          </tfoot>
-        </table>
-        <figcaption>A caption can be added but is not rendered as a caption element</figcaption>
-      </figure>
-      `}
+  <Story
+    name="Table"
+    args={{
+      show_header: true,
+      show_footer: true,
+      show_caption: true,
+    }}
+    argTypes={{
+      block_style: {
+        options: ['', 'stripes', 'ruled', 'numeric'],
+        type: { name: 'enum' },
+        control: { type: 'select' },
+      },
+      column_alignment: {
+        options: ['', 'center', 'right'],
+        type: { name: 'enum' },
+        control: { type: 'select' },
+      },
+      fixed_layout: {
+        type: { name: 'boolean' },
+      },
+      show_header: {
+        type: { name: 'boolean' },
+      },
+      show_footer: {
+        type: { name: 'boolean' },
+      },
+      show_caption: {
+        type: { name: 'boolean' },
+      },
+    }}
+  >
+    {(args) => blockTableDemo(args)}
   </Story>
 </Canvas>
+
+<ArgsTable story="Table" />
 
 ## Verse
 

--- a/src/vendor/wordpress/demo/table.twig
+++ b/src/vendor/wordpress/demo/table.twig
@@ -1,0 +1,34 @@
+<figure class="wp-block-table{% if block_style %} is-style-{{block_style}}{% endif %}">
+  <table{% if fixed_layout %} class="has-fixed-layout"{% endif %}>
+    {% if show_header %}
+      <thead>
+        <tr>
+          {% for i in 1..3 %}
+            <th{% if column_alignment %} class="has-text-align-{{column_alignment}}" data-align="{{column_alignment}}"{% endif %}>Heading {{i}}</th>
+          {% endfor %}
+        </tr>
+      </thead>
+    {% endif %}
+    <tbody>
+      {% for i in 1..3 %}
+        <tr>
+          <td{% if column_alignment %} class="has-text-align-{{column_alignment}}" data-align="{{column_alignment}}"{% endif %}>Hello, this is row {{i}}</td>
+          <td{% if column_alignment %} class="has-text-align-{{column_alignment}}" data-align="{{column_alignment}}"{% endif %}>Content</td>
+          <td{% if column_alignment %} class="has-text-align-{{column_alignment}}" data-align="{{column_alignment}}"{% endif %}>Content</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+    {% if show_footer %}
+      <tfoot>
+        <tr>
+          {% for i in 1..3 %}
+            <td{% if column_alignment %} class="has-text-align-{{column_alignment}}" data-align="{{column_alignment}}"{% endif %}>Footer {{i}}</td>
+          {% endfor %}
+        </tr>
+      </tfoot>
+    {% endif %}
+  </table>
+  {% if show_caption %}
+    <figcaption>A caption can be added but is not rendered as a caption element</figcaption>
+  {% endif %}
+</figure>

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -258,25 +258,26 @@ figure.wp-block-image {
   }
 }
 
-/**
- * Striped table
- */
-.wp-block-table.is-style-stripes {
-  border-block-end: 0;
+/// Gutenberg block: Table
+.wp-block-table {
+  &.is-style-stripes {
+    border-block-end: 0;
 
-  tbody tr:nth-of-type(2n - 1) {
-    @include table.t-striped;
+    tbody tr:nth-of-type(2n - 1) {
+      @include table.t-striped;
+    }
   }
-}
 
-/**
- * Numeric table
- */
-.wp-block-table.c-table--numeric table {
-  @include table.t-numeric;
+  &.is-style-ruled tbody tr {
+    @include table.t-ruled;
+  }
 
-  th {
-    text-align: end;
+  &.is-style-numeric table {
+    @include table.t-numeric;
+
+    th {
+      text-align: end;
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

Adds more WordPress Table block styles, which can be supported from our site using `register_block_style`. Revises the core block story to include controls for testing various combinations. This will replace the previous recommended technique of adding component-specific modifier classes to a field, which was a complex and incomplete solution.

## Screenshots

Ruled style:

<img width="812" alt="Screen Shot 2022-09-16 at 10 25 28 AM" src="https://user-images.githubusercontent.com/69633/190696936-7fef556f-8273-4b62-a4d4-6149bcb0bae4.png">

Numeric style:

<img width="816" alt="Screen Shot 2022-09-16 at 10 25 36 AM" src="https://user-images.githubusercontent.com/69633/190696946-7bd07085-0410-4e5e-b23c-e376541b8974.png">

## Testing

[Play with controls in this story on the deploy preview](https://deploy-preview-2052--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-core-blocks--table)

---

- See https://github.com/cloudfour/cloudfour.com-wp/issues/532

/CC @Paul-Hebert 
