### PR TITLE
Use CSS aspect-ratio property for Avatar

### DIFF
--- a/.changeset/breezy-hats-exist.md
+++ b/.changeset/breezy-hats-exist.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Use CSS aspect-ratio property for Avatar

--- a/src/components/avatar/avatar.scss
+++ b/src/components/avatar/avatar.scss
@@ -24,6 +24,7 @@
  * 2. Prevent this element from squashing or stretching within a flex container.
  * 3. The most common use cases for avatars use a consistent width, so we set
  *    that here.
+ * 4. Ensures the image fills the full dimensions of the avatar container.
  */
 
 .c-avatar {
@@ -33,6 +34,12 @@
   flex: none; /* 2 */
   inline-size: size.$square-avatar-medium; /* 3 */
   overflow: hidden;
+
+  > img,
+  > picture > img {
+    block-size: 100%; /* 4 */
+    inline-size: 100%; /* 4 */
+  }
 }
 
 /**

--- a/src/components/avatar/avatar.scss
+++ b/src/components/avatar/avatar.scss
@@ -27,12 +27,12 @@
  */
 
 .c-avatar {
-  // Ratio box hack lets us support fixed _and_ percentage widths with ease
-  @include ratio-box.core-styles;
+  aspect-ratio: 1;
   background: var(--theme-color-background-avatar); /* 1 */
   border-radius: size.$border-radius-full;
   flex: none; /* 2 */
   inline-size: size.$square-avatar-medium; /* 3 */
+  overflow: hidden;
 }
 
 /**


### PR DESCRIPTION
## Overview

This PR removes the `ratio-box` mixin dependency and switches it out for the CSS `aspect-ratio` property.

## Screenshots

Left: before
Right: after

<img width="897" alt="Screen Shot 2022-09-20 at 10 38 45 AM" src="https://user-images.githubusercontent.com/459757/191327315-575e2c56-a530-4906-be85-040ce5135e4b.png">

## Testing

Before: https://cloudfour-patterns.netlify.app/?path=/docs/components-avatar--empty
After: https://deploy-preview-2055--cloudfour-patterns.netlify.app/?path=/docs/components-avatar--empty

- [ ] Compare before and after, confirm no visual/layout differences
- [ ] Play in the "Canvas" view to confirm there are no functionality differences

---

- #1999 