### PR TITLE
Use CSS aspect-ratio for Card component

### DIFF
--- a/.changeset/real-nails-design.md
+++ b/.changeset/real-nails-design.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Use CSS aspect-ratio for Card component

--- a/src/components/avatar/avatar.scss
+++ b/src/components/avatar/avatar.scss
@@ -1,6 +1,5 @@
 @use '../../compiled/tokens/scss/color';
 @use '../../compiled/tokens/scss/size';
-@use '../../mixins/ratio-box';
 @use '../../mixins/theme';
 
 /**

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -121,7 +121,7 @@ $_focus-overflow: (size.$edge-large * -1);
      * When the cover image is circular (and thus taller), give it a smaller
      * amount of space and keep the text left-aligned.
      *
-     * 1. Fixes bug where the cirlce wasn't a circle anymore at smallest viewports
+     * 1. Fixes bug where the circle cover wasn't a circle at smallest viewports
      */
 
     &.c-card--circle-cover {

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -235,15 +235,8 @@ $_focus-overflow: (size.$edge-large * -1);
   background-color: var(--theme-color-background-secondary); /* 1 */
   border-radius: size.$border-radius-medium;
   grid-area: cover;
-  transform: translate(0, 0); /* 2 */
   overflow: hidden;
-
-  > *,
-  > picture > img {
-    block-size: 100%;
-    inline-size: 100%;
-    object-fit: cover;
-  }
+  transform: translate(0, 0); /* 2 */
 
   /**
    * Subtly brighten covers within our alternate theme containers to help offset
@@ -295,6 +288,9 @@ $_focus-overflow: (size.$edge-large * -1);
 
 .c-card__cover > *,
 .c-card__cover > picture > img {
+  block-size: 100%;
+  inline-size: 100%;
+  object-fit: cover;
   transition: transform transition.$prompt ease.$out;
 
   .c-card--with-link:hover:not(:active) & {

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -244,11 +244,8 @@ $_focus-overflow: (size.$edge-large * -1);
    */
 
   .c-card--circle-cover & {
+    aspect-ratio: 1;
     border-radius: size.$border-radius-full;
-
-    &::before {
-      padding-block-end: 100%;
-    }
   }
 
   /**

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -11,7 +11,6 @@
 @use '../../mixins/headings';
 @use '../../mixins/media-query';
 @use '../../mixins/ms';
-@use '../../mixins/ratio-box';
 @use '../../mixins/theme';
 
 /// We can't use `grid-gap` exclusively due to some containers only being

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -130,14 +130,6 @@ $_focus-overflow: (size.$edge-large * -1);
         'cover footer footer'
         'cover . .';
       text-align: start;
-
-      /*
-       * 1. Fixes bug where the circle cover wasn't a circle at smallest viewports
-       */
-
-      .c-card__cover {
-        block-size: auto; /* 1 */
-      }
     }
   }
 }
@@ -252,11 +244,14 @@ $_focus-overflow: (size.$edge-large * -1);
 
   /**
    * Square aspect ratio + fully rounded corners = circular cover image
+   *
+   * 1. Fixes bug where the circle cover wasn't a circle at smallest viewports
    */
 
   .c-card--circle-cover & {
     aspect-ratio: 1;
     border-radius: size.$border-radius-full;
+    block-size: auto; /* 1 */
   }
 
   /**

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -137,7 +137,6 @@ $_focus-overflow: (size.$edge-large * -1);
 
       .c-card__cover {
         block-size: auto; /* 1 */
-        inline-size: auto; /* 1 */
       }
     }
   }

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -91,8 +91,9 @@ $_focus-overflow: (size.$edge-large * -1);
  *    available width.
  * 2. We define the layout as three columns instead of `2fr 1fr` so that the
  *    gaps will line up with three-column elements below.
- * 3. The `fr` rows on the
- *    ends keep the content rows vertically centered.
+ * 3. The `fr` rows on the ends keep the content rows vertically centered.
+ * 4. Allows cover image to break out of 16/9 aspect-ratio and fill the space
+ *    vertically at smallish viewports (only applies in the horizontal layout)
  */
 
 .c-card--horizontal {
@@ -111,9 +112,16 @@ $_focus-overflow: (size.$edge-large * -1);
     grid-template-columns: repeat(3, 1fr); /* 2 */
     grid-template-rows: 1fr repeat(3, minmax(0, auto)) 1fr; /* 3 */
 
+    .c-card__cover {
+      block-size: 100%; /* 4 */
+      inline-size: 100%; /* 4 */
+    }
+
     /**
      * When the cover image is circular (and thus taller), give it a smaller
      * amount of space and keep the text left-aligned.
+     *
+     * 1. Fixes bug where the cirlce wasn't a circle anymore at smallest viewports
      */
 
     &.c-card--circle-cover {
@@ -124,6 +132,11 @@ $_focus-overflow: (size.$edge-large * -1);
         'cover footer footer'
         'cover . .';
       text-align: start;
+
+      .c-card__cover {
+        block-size: auto; /* 1 */
+        inline-size: auto; /* 1 */
+      }
     }
   }
 }

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -250,8 +250,8 @@ $_focus-overflow: (size.$edge-large * -1);
 
   .c-card--circle-cover & {
     aspect-ratio: 1;
-    border-radius: size.$border-radius-full;
     block-size: auto; /* 1 */
+    border-radius: size.$border-radius-full;
   }
 
   /**

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -92,8 +92,6 @@ $_focus-overflow: (size.$edge-large * -1);
  * 2. We define the layout as three columns instead of `2fr 1fr` so that the
  *    gaps will line up with three-column elements below.
  * 3. The `fr` rows on the ends keep the content rows vertically centered.
- * 4. Allows cover image to break out of 16/9 aspect-ratio and fill the space
- *    vertically at smallish viewports (only applies in the horizontal layout)
  */
 
 .c-card--horizontal {
@@ -111,11 +109,6 @@ $_focus-overflow: (size.$edge-large * -1);
       'cover cover .';
     grid-template-columns: repeat(3, 1fr); /* 2 */
     grid-template-rows: 1fr repeat(3, minmax(0, auto)) 1fr; /* 3 */
-
-    .c-card__cover {
-      block-size: 100%; /* 4 */
-      inline-size: 100%; /* 4 */
-    }
 
     /**
      * When the cover image is circular (and thus taller), give it a smaller
@@ -230,6 +223,21 @@ $_focus-overflow: (size.$edge-large * -1);
   grid-area: cover;
   overflow: hidden;
   transform: translate(0, 0); /* 2 */
+
+  /**
+   * Allows cover image to break out of 16/9 aspect-ratio and fill the space
+   * vertically at smallish viewports (only applies in the horizontal layout)
+   */
+
+  @include media-query.breakpoint-parent-classes(
+    $selector: '.c-card--horizontal',
+    $from: m,
+    $to: xl,
+    $include-default: false
+  ) {
+    block-size: 100%;
+    inline-size: 100%;
+  }
 
   /**
    * Subtly brighten covers within our alternate theme containers to help offset

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -209,12 +209,8 @@ $_focus-overflow: (size.$edge-large * -1);
 /**
  * Cover area
  *
- * 1. We re-use the embed object's styles instead of allowing the embed object
- *    to be included directly so that the horizontal layout will squash more
- *    gracefully. This also lets us apply more opinionated interaction effects
- *    because we can assume more about the content therein.
- * 2. In case the image is missing or slow to load.
- * 3. Fix for Safari bug where transitions cause overflow to no longer be
+ * 1. In case the image is missing or slow to load.
+ * 2. Fix for Safari bug where transitions cause overflow to no longer be
  *    respected. Although other fixes seem to use 3D transforms, this does not
  *    appear to be necessary when the child effect is not 3D.
  *    @see https://bugs.webkit.org/show_bug.cgi?id=68196
@@ -222,11 +218,19 @@ $_focus-overflow: (size.$edge-large * -1);
  */
 
 .c-card__cover {
-  @include ratio-box.core-styles($ratio: aspect-ratio.$wide); /* 1 */
-  background-color: var(--theme-color-background-secondary); /* 2 */
+  aspect-ratio: aspect-ratio.$wide;
+  background-color: var(--theme-color-background-secondary); /* 1 */
   border-radius: size.$border-radius-medium;
   grid-area: cover;
-  transform: translate(0, 0); /* 3 */
+  transform: translate(0, 0); /* 2 */
+  overflow: hidden;
+
+  > *,
+  > picture > img {
+    block-size: 100%;
+    inline-size: 100%;
+    object-fit: cover;
+  }
 
   /**
    * Subtly brighten covers within our alternate theme containers to help offset

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -120,8 +120,6 @@ $_focus-overflow: (size.$edge-large * -1);
     /**
      * When the cover image is circular (and thus taller), give it a smaller
      * amount of space and keep the text left-aligned.
-     *
-     * 1. Fixes bug where the circle cover wasn't a circle at smallest viewports
      */
 
     &.c-card--circle-cover {
@@ -132,6 +130,10 @@ $_focus-overflow: (size.$edge-large * -1);
         'cover footer footer'
         'cover . .';
       text-align: start;
+
+      /*
+       * 1. Fixes bug where the circle cover wasn't a circle at smallest viewports
+       */
 
       .c-card__cover {
         block-size: auto; /* 1 */


### PR DESCRIPTION
## Overview

This PR proposes a solution for using the CSS `aspect-ratio` property and removing the `ratio-box` dependency.

Other changes include:
- Remove `ratio-box` import in Avatar CSS (missed this in my last PR)
- Fix a bug where the circle cover variant wasn't a circle

## Screenshots

Left: Before
Right: After

<img width="1743" alt="Screen Shot 2022-09-20 at 2 30 48 PM" src="https://user-images.githubusercontent.com/459757/191381595-daea6f3d-a6d7-44fc-83ca-f3f74d23e709.png">
<img width="1743" alt="Screen Shot 2022-09-20 at 2 31 12 PM" src="https://user-images.githubusercontent.com/459757/191381607-f65a1be3-8e02-4a2b-832b-5d99a4e25b60.png">
<img width="2556" alt="Screen Shot 2022-09-20 at 2 35 42 PM" src="https://user-images.githubusercontent.com/459757/191381610-03170ff3-4135-4c13-8b8e-6be843e7dff7.png">
<img width="994" alt="Screen Shot 2022-09-20 at 2 36 49 PM" src="https://user-images.githubusercontent.com/459757/191381612-359cf5cf-a334-451d-bf52-12bce5646765.png">

I also fixed a bug where the circle wasn't a circle at ~640px wide viewports:

<img width="1284" alt="Screen Shot 2022-09-20 at 2 38 59 PM" src="https://user-images.githubusercontent.com/459757/191381613-7831a270-8d31-4aff-9501-2fa7254db022.png">


## Testing

Before: https://cloudfour-patterns.netlify.app/?path=/docs/components-card--cover-image
After: https://deploy-preview-2057--cloudfour-patterns.netlify.app/?path=/docs/components-card--cover-image

- [ ] Review at various viewport sizes, confirm layout is the same as before
- [ ] Confirm [the circle is a circle](https://deploy-preview-2057--cloudfour-patterns.netlify.app/iframe.html?args=&id=components-card--circular-cover-image&viewMode=story) at a viewport width of ~640px

---

- #1999 