### PR TITLE
Add copy and external icons

### DIFF
--- a/.changeset/chatty-numbers-perform.md
+++ b/.changeset/chatty-numbers-perform.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add `copy` and `external` icons

--- a/src/assets/icons/copy.svg
+++ b/src/assets/icons/copy.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M16,16v5c0,.55-.45,1-1,1H3c-.55,0-1-.45-1-1V9c0-.55,.45-1,1-1h5" fill="none" stroke-linecap="round"
+    stroke-width="2" />
+  <rect x="8" y="2" width="14" height="14" rx="1" ry="1" fill="none" stroke-linecap="round" stroke-width="2" />
+</svg>

--- a/src/assets/icons/external.svg
+++ b/src/assets/icons/external.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M18,14v5c0,.55-.45,1-1,1H5c-.55,0-1-.45-1-1V7c0-.55,.45-1,1-1h5" fill="none" stroke-linecap="round"
+    stroke-width="2" />
+  <polyline points="14 3 21 3 21 10" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+  <line x1="21" y1="3" x2="9" y2="15" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+</svg>


### PR DESCRIPTION
## Overview

Was playing with some content updates that would benefit from these two icons.

## Screenshots

<img width="114" alt="Screen Shot 2022-09-21 at 4 19 19 PM" src="https://user-images.githubusercontent.com/69633/191626922-5e7c8044-d95d-4da7-abb4-251994808264.png"> <img width="138" alt="Screen Shot 2022-09-21 at 4 19 27 PM" src="https://user-images.githubusercontent.com/69633/191626924-3d483cc7-dca7-4b06-8f64-2feec75942e3.png">

## Testing

[View on deploy preview](https://deploy-preview-2058--cloudfour-patterns.netlify.app/?path=/docs/design-icons--page)
