### PR TITLE
Set specific Node version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/*
+lts/gallium


### PR DESCRIPTION
## Overview

A few days ago, Node v18 became the latest LTS release. But our Storybook build commands fail in Node v17 or higher.

The reason for this is that Node changed its cryptographic security requirements in version 17. This breaks the way Webpack generates hashes.

After consulting [this StackOverflow thread](https://stackoverflow.com/q/69692842), I had a few options to address this:

1. Run `npm audit fix --force`. This introduces _many_ breaking changes.
2. Set the `NODE_OPTIONS` environment variable to `--openssl-legacy-provider` everywhere. This felt clunky to me.
3. Set [some Webpack options](https://stackoverflow.com/a/73465262). I attempted this, but it turns out those options are only available in Webpack 5, and this project is currently using version 4.
4. Specify the previous LTS release in our `.nvmrc`.

I went with the last option.

We can update to the latest LTS release once Webpack is updated to version 5 or later, which I believe depends on Storybook. Or we can switch to Vite (see #1403).

## Testing

1. Locally, make sure your nvm aliases are up to date by running `nvm ls-remote`
2. `git checkout main`
3. Recreate the error: `nvm use && npm ci && npm start`
4. Now check out this branch.
5. Try the previous command again: `nvm use && npm ci && npm start`
6. Confirm there is no longer a build error.

Alternatively, you can compare the GitHub checks on this PR to that of #2079, which was stalled by this issue.