### PR TITLE
Allow captions for centered WordPress Image Blocks to fill their container

### DIFF
--- a/.changeset/honest-spoons-reflect.md
+++ b/.changeset/honest-spoons-reflect.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Allow captions for centered WordPress Image Blocks to fill their container

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -158,6 +158,17 @@ $wp-button-gap: size.$spacing-gap-button-group-default;
     max-inline-size: calc(50% - 0.5em); // 2
   }
 
+  /// By default, WordPress uses table styles to constrain captions to the size
+  /// of the image. This makes sense for left- and right-aligned image blocks,
+  /// but for consistency with our non-block `figure` elements, we allow
+  /// captions to go as wide as they need for centered elements.
+  .aligncenter {
+    &,
+    > figcaption {
+      display: block;
+    }
+  }
+
   /// Apply border only to image
   ///
   /// 1. We're using 1px borders here rather than size.$edge-small because it


### PR DESCRIPTION
## Overview

The default styles for WordPress image blocks with captions that are right-, left- or center-aligned use `table` display styles to constrain captions to the width of the image.

That makes less sense for our content, where we often need to include narrow-width screenshots with accompanying explanations that can feel a bit _confined_ in their space. It also makes them less consistent with regular ol' `figure` styles in our larger project.

## Screenshots

Before | After
--- | ---
<img width="726" alt="Screenshot 2022-11-30 at 11 41 36 AM" src="https://user-images.githubusercontent.com/69633/204893400-e6ee0a44-20b5-45a5-bcc6-708203069186.png"> | <img width="708" alt="Screenshot 2022-11-30 at 11 41 22 AM" src="https://user-images.githubusercontent.com/69633/204893430-fe7d28e5-0c0d-4ae1-9f9f-e37d6acf9f80.png">

## Testing

1. View [the Vendor ▸ WordPress ▸ Utilities ▸ Alignment story](https://deploy-preview-2089--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-utilities--alignment&args=alignment:aligncenter) with `aligncenter` selected.
2. Inspect the image and set its width to be smaller than the caption _or_ inspect the caption and make it longer.
3. Observe that the caption is able to extend past the image boundaries.

---

- Fixes #2019 

/CC @gerardo-rodriguez 
