### PR TITLE
Add download icon

### DIFF
--- a/.changeset/twenty-bees-mate.md
+++ b/.changeset/twenty-bees-mate.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add download icon

--- a/src/assets/icons/download.svg
+++ b/src/assets/icons/download.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M21,18v3c0,.55-.45,1-1,1H4c-.55,0-1-.45-1-1v-3" fill="none" stroke-linecap="round" stroke-miterlimit="10"
+    stroke-width="2" />
+  <polyline points="17 11 12 16 7 11" fill="none" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" />
+  <line x1="12" y1="14" x2="12" y2="2" fill="none" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" />
+</svg>


### PR DESCRIPTION
## Overview

The `arrow-down` looked a little large and simplistic when juxtaposed with icons like `external` and `copy`.

## Screenshots

<img width="382" alt="Screenshot 2022-12-01 at 3 18 35 PM" src="https://user-images.githubusercontent.com/69633/205179856-697f771b-bc7c-4f86-8e7e-c2a0ea6f5060.png">

<img width="1068" alt="Screenshot 2022-12-01 at 3 22 05 PM" src="https://user-images.githubusercontent.com/69633/205179940-20928152-1225-4c0e-a202-ba6e03f74c10.png">

---

- Fixes #2093 
