### PR TITLE
Make WordPress `has-big-font-size` responsive

### DIFF
--- a/.changeset/odd-dryers-visit.md
+++ b/.changeset/odd-dryers-visit.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+The `has-big-font-size` utility class in WordPress now gradually applies the size increase as the viewport width increases to avoid overwhelming smaller viewports

--- a/src/vendor/wordpress/demo/font-size.twig
+++ b/src/vendor/wordpress/demo/font-size.twig
@@ -1,7 +1,13 @@
-<p class="
-  {% if font_size %}
-    has-{{font_size}}-font-size
-  {% endif %}
-">
-  We help forward-thinking teams craft accessible design systems and progressive web apps.
-</p>
+<div class="o-rhythm">
+  <p class="
+    {%- if font_size -%}
+      has-{{font_size}}-font-size
+    {%- endif -%}">
+    This paragraph is {% if font_size %}<b>{{font_size}}</b>{% else %}normal{% endif %}.
+    We help forward-thinking teams craft accessible design systems and progressive web apps.
+  </p>
+  <p>
+    This paragraph is {% if not font_size %}also{% endif %} normal.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean eleifend magna id risus rhoncus, sit amet placerat ligula vehicula. Proin neque dui, pellentesque non arcu sit amet, lacinia facilisis velit. Aenean in bibendum nulla. Nullam elementum neque vel ipsum iaculis, at accumsan dui auctor.
+  </p>
+</div>

--- a/src/vendor/wordpress/styles/_utilities.scss
+++ b/src/vendor/wordpress/styles/_utilities.scss
@@ -4,6 +4,7 @@
 @use '../../../compiled/tokens/scss/color-base';
 @use '../../../compiled/tokens/scss/size';
 @use '../../../mixins/border-radius';
+@use '../../../mixins/fluid';
 @use '../../../mixins/headings';
 @use '../../../mixins/ms';
 @use '../../../mixins/spacing';
@@ -75,8 +76,16 @@ $color-map: meta.module-variables('color-base');
 /// Utilities for Block Font Sizes
 /// @link https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#block-font-sizes
 
+/// Since this is often used for paragraph content that can be overwhelming if
+/// it is always substantially larger than surrounding content, we responsively
+/// apply the font size (similar to Cloud Cover content).
 .has-big-font-size {
-  font-size: size.$font-big;
+  font-size: fluid.fluid-clamp(
+    1em,
+    size.$font-big,
+    breakpoint.$xs,
+    breakpoint.$l
+  );
 }
 
 .has-small-font-size {


### PR DESCRIPTION
## Overview

When using the WordPress Gutenberg editor and setting the `font-size` for an element to "big," the `has-big-font-size` class is applied.

Prior to this PR, the `font-size` would be set to `1.25em` for all viewports. In practice, this created some hierarchy strangeness since the Cloud Cover content responsively increases in size from `1em` to `1.25em` based on the viewport width. Longer paragraphs would also quickly overwhelm the viewport.

This modifies the `has-big-font-size` utility to use the same sizing logic as the Cloud Cover content, only increasing in size as the viewport allows.

## Screenshots

![responsive-big](https://user-images.githubusercontent.com/69633/205182530-0b8008db-3707-42ff-bfee-fb5bdca9c985.gif)

## Testing

[View story in deploy preview](#TBD)

---

- Fixes #2092 