### PR TITLE
Disable resizing for Elastic Textareas

### DIFF
--- a/.changeset/fresh-moose-draw.md
+++ b/.changeset/fresh-moose-draw.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fix bug where `c-input` did not respect `rows` attribute

--- a/.changeset/strange-steaks-sneeze.md
+++ b/.changeset/strange-steaks-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add option to disable elastic textarea resize

--- a/.changeset/strange-steaks-sneeze.md
+++ b/.changeset/strange-steaks-sneeze.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Disable resizing for `c-input--elastic` modifier
+Disable resizing for Elastic Textareas

--- a/.changeset/strange-steaks-sneeze.md
+++ b/.changeset/strange-steaks-sneeze.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Add `c-input--noResize` modifier
+Disable resizing for `c-input--elastic` modifier

--- a/.changeset/strange-steaks-sneeze.md
+++ b/.changeset/strange-steaks-sneeze.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Add option to disable Elastic TextArea resize
+Add `c-input--noResize` modifier

--- a/.changeset/strange-steaks-sneeze.md
+++ b/.changeset/strange-steaks-sneeze.md
@@ -2,4 +2,4 @@
 '@cloudfour/patterns': minor
 ---
 
-Add option to disable elastic textarea resize
+Add option to disable Elastic TextArea resize

--- a/src/components/input/elastic-textarea.test.ts
+++ b/src/components/input/elastic-textarea.test.ts
@@ -82,7 +82,7 @@ test(
 
 test(
   'Disables native resize via CSS',
-  withBrowser(async ({ utils, screen, user }) => {
+  withBrowser(async ({ utils, screen }) => {
     await utils.injectHTML(
       await textInputHTML({
         class: 'c-input--elastic js-elastic-textarea',

--- a/src/components/input/elastic-textarea.test.ts
+++ b/src/components/input/elastic-textarea.test.ts
@@ -5,21 +5,14 @@ import { withBrowser } from 'pleasantest';
 
 import { loadGlobalCSS, loadTwigTemplate } from '../../../test-utils.js';
 
-import type { ElasticTextAreaOpts } from './elastic-textarea.js';
-
 const textInputHTML = loadTwigTemplate(path.join(__dirname, './input.twig'));
-const initTextareaJS = (
-  utils: PleasantestUtils,
-  textarea: ElementHandle,
-  elasticTextAreaOpts: ElasticTextAreaOpts = {}
-) =>
+const initTextareaJS = (utils: PleasantestUtils, textarea: ElementHandle) =>
   utils.runJS(
     `
     import { createElasticTextArea } from './elastic-textarea'
-    export default (textarea, elasticTextAreaOpts) =>
-      createElasticTextArea(textarea, elasticTextAreaOpts);
+    export default (textarea) => createElasticTextArea(textarea);
     `,
-    [textarea, elasticTextAreaOpts]
+    [textarea]
   );
 
 test(
@@ -80,26 +73,5 @@ test(
     // After emptying it out, it should have 1 row, since that is what we initialized `rows` to
     await user.clear(textarea);
     await expect(textarea).toHaveAttribute('rows', '1');
-  })
-);
-
-test(
-  'Disables native resize via CSS',
-  withBrowser(async ({ utils, screen }) => {
-    await utils.injectHTML(
-      await textInputHTML({
-        class: 'c-input--elastic js-elastic-textarea',
-        type: 'textarea',
-      })
-    );
-    const textarea = await screen.getByRole('textbox');
-    await initTextareaJS(utils, textarea, {
-      disableResize: true,
-    });
-
-    const isCssResizeDisabled = await textarea.evaluate(
-      (el) => el.style.resize === 'none'
-    );
-    expect(isCssResizeDisabled).toEqual(true);
   })
 );

--- a/src/components/input/elastic-textarea.test.ts
+++ b/src/components/input/elastic-textarea.test.ts
@@ -5,18 +5,21 @@ import { withBrowser } from 'pleasantest';
 
 import { loadGlobalCSS, loadTwigTemplate } from '../../../test-utils.js';
 
+import type { ElasticTextAreaOpts } from './elastic-textarea.js';
+
 const textInputHTML = loadTwigTemplate(path.join(__dirname, './input.twig'));
 const initTextareaJS = (
   utils: PleasantestUtils,
   textarea: ElementHandle,
-  disableResize = false
+  elasticTextAreaOpts: ElasticTextAreaOpts = {}
 ) =>
   utils.runJS(
     `
     import { createElasticTextArea } from './elastic-textarea'
-    export default (textarea, disableResize) => createElasticTextArea(textarea, disableResize);
+    export default (textarea, elasticTextAreaOpts) =>
+      createElasticTextArea(textarea, elasticTextAreaOpts);
     `,
-    [textarea, disableResize]
+    [textarea, elasticTextAreaOpts]
   );
 
 test(
@@ -90,7 +93,9 @@ test(
       })
     );
     const textarea = await screen.getByRole('textbox');
-    await initTextareaJS(utils, textarea, true);
+    await initTextareaJS(utils, textarea, {
+      disableResize: true,
+    });
 
     const isCssResizeDisabled = await textarea.evaluate(
       (el) => el.style.resize === 'none'

--- a/src/components/input/elastic-textarea.ts
+++ b/src/components/input/elastic-textarea.ts
@@ -1,3 +1,7 @@
+export interface ElasticTextAreaOpts {
+  disableResize?: boolean;
+}
+
 /**
  * Create Elastic TextArea
  *
@@ -7,19 +11,19 @@
  * method to remove the event listener.
  *
  * @param textarea - the target `textarea` element
- * @param {boolean} [disableResize=false] - Disables the textarea resize functionality if set to `true`
+ * @param {ElasticTextAreaOpts} [elasticTextAreaOpts] - Disables the textarea resize functionality if set to `true`
  */
 export const createElasticTextArea = (
   textarea: HTMLTextAreaElement,
-  disableResize = false
+  elasticTextAreaOpts: ElasticTextAreaOpts = {}
 ) => {
   const minRows = Number(textarea.getAttribute('rows')) || 2;
   let rows = Number(textarea.getAttribute('rows')) || minRows;
   textarea.setAttribute('rows', String(rows));
 
   // Disables the native textarea resize functionality via inline CSS
-  if (disableResize) {
-    textarea.style.resize = 'none';
+  if (elasticTextAreaOpts.disableResize === true) {
+    textArea.style.resize = 'none';
   }
 
   /** Check if the textarea is currently scrolling */

--- a/src/components/input/elastic-textarea.ts
+++ b/src/components/input/elastic-textarea.ts
@@ -9,8 +9,9 @@
  * @param textarea - the target `textarea` element
  */
 export const createElasticTextArea = (textarea: HTMLTextAreaElement) => {
-  // Progressively enhances experience
-  textarea.classList.add('is-elastic');
+  // Provides a CSS hook for JS-only styles
+  const JS_ENABLED_HOOK = 'is-elastic';
+  textarea.classList.add(JS_ENABLED_HOOK);
 
   const minRows = Number(textarea.getAttribute('rows')) || 2;
   let rows = Number(textarea.getAttribute('rows')) || minRows;
@@ -63,7 +64,10 @@ export const createElasticTextArea = (textarea: HTMLTextAreaElement) => {
   };
 
   /** As part of the public API, allow users to remove the event listener */
-  const destroy = () => textarea.removeEventListener('input', update);
+  const destroy = () => {
+    textarea.classList.remove(JS_ENABLED_HOOK);
+    textarea.removeEventListener('input', update);
+  };
 
   // Initialize the textarea with elastic behavior
   textarea.addEventListener('input', update);

--- a/src/components/input/elastic-textarea.ts
+++ b/src/components/input/elastic-textarea.ts
@@ -1,7 +1,3 @@
-export interface ElasticTextAreaOpts {
-  disableResize?: boolean;
-}
-
 /**
  * Create Elastic TextArea
  *
@@ -10,36 +6,27 @@ export interface ElasticTextAreaOpts {
  * `textarea` is scrolling or not. Returns an object containing a `destroy()`
  * method to remove the event listener.
  *
- * @param textArea - the target `textarea` element
- * @param {ElasticTextAreaOpts} [elasticTextAreaOpts] - Disables the textarea resize functionality if set to `true`
+ * @param textarea - the target `textarea` element
  */
-export const createElasticTextArea = (
-  textArea: HTMLTextAreaElement,
-  elasticTextAreaOpts: ElasticTextAreaOpts = {}
-) => {
-  const minRows = Number(textArea.getAttribute('rows')) || 2;
-  let rows = Number(textArea.getAttribute('rows')) || minRows;
-  textArea.setAttribute('rows', String(rows));
-
-  // Disables the native textarea resize functionality via inline CSS
-  if (elasticTextAreaOpts.disableResize === true) {
-    textArea.style.resize = 'none';
-  }
+export const createElasticTextArea = (textarea: HTMLTextAreaElement) => {
+  const minRows = Number(textarea.getAttribute('rows')) || 2;
+  let rows = Number(textarea.getAttribute('rows')) || minRows;
+  textarea.setAttribute('rows', String(rows));
 
   /** Check if the textarea is currently scrolling */
-  const isScrolling = () => textArea.scrollHeight > textArea.clientHeight;
+  const isScrolling = () => textarea.scrollHeight > textarea.clientHeight;
 
   /** Grow until the textarea stops scrolling */
   const grow = () => {
     // Store initial height of textarea
-    let previousHeight = textArea.clientHeight;
+    let previousHeight = textarea.clientHeight;
 
     while (isScrolling()) {
       rows++;
-      textArea.setAttribute('rows', String(rows));
+      textarea.setAttribute('rows', String(rows));
 
       // Get height after rows change is made
-      const newHeight = textArea.clientHeight;
+      const newHeight = textarea.clientHeight;
 
       // If the height hasn't changed, break the loop
       // This sanity check is to prevent an infinite loop in IE11
@@ -54,7 +41,7 @@ export const createElasticTextArea = (
   const shrink = () => {
     while (!isScrolling() && rows > minRows) {
       rows--;
-      textArea.setAttribute('rows', String(Math.max(rows, minRows)));
+      textarea.setAttribute('rows', String(Math.max(rows, minRows)));
 
       if (isScrolling()) {
         grow();
@@ -73,10 +60,10 @@ export const createElasticTextArea = (
   };
 
   /** As part of the public API, allow users to remove the event listener */
-  const destroy = () => textArea.removeEventListener('input', update);
+  const destroy = () => textarea.removeEventListener('input', update);
 
   // Initialize the textarea with elastic behavior
-  textArea.addEventListener('input', update);
+  textarea.addEventListener('input', update);
 
   // Run the update method to set the initial size correctly
   update();

--- a/src/components/input/elastic-textarea.ts
+++ b/src/components/input/elastic-textarea.ts
@@ -10,16 +10,16 @@ export interface ElasticTextAreaOpts {
  * `textarea` is scrolling or not. Returns an object containing a `destroy()`
  * method to remove the event listener.
  *
- * @param textarea - the target `textarea` element
+ * @param textArea - the target `textarea` element
  * @param {ElasticTextAreaOpts} [elasticTextAreaOpts] - Disables the textarea resize functionality if set to `true`
  */
 export const createElasticTextArea = (
-  textarea: HTMLTextAreaElement,
+  textArea: HTMLTextAreaElement,
   elasticTextAreaOpts: ElasticTextAreaOpts = {}
 ) => {
-  const minRows = Number(textarea.getAttribute('rows')) || 2;
-  let rows = Number(textarea.getAttribute('rows')) || minRows;
-  textarea.setAttribute('rows', String(rows));
+  const minRows = Number(textArea.getAttribute('rows')) || 2;
+  let rows = Number(textArea.getAttribute('rows')) || minRows;
+  textArea.setAttribute('rows', String(rows));
 
   // Disables the native textarea resize functionality via inline CSS
   if (elasticTextAreaOpts.disableResize === true) {
@@ -27,19 +27,19 @@ export const createElasticTextArea = (
   }
 
   /** Check if the textarea is currently scrolling */
-  const isScrolling = () => textarea.scrollHeight > textarea.clientHeight;
+  const isScrolling = () => textArea.scrollHeight > textArea.clientHeight;
 
   /** Grow until the textarea stops scrolling */
   const grow = () => {
     // Store initial height of textarea
-    let previousHeight = textarea.clientHeight;
+    let previousHeight = textArea.clientHeight;
 
     while (isScrolling()) {
       rows++;
-      textarea.setAttribute('rows', String(rows));
+      textArea.setAttribute('rows', String(rows));
 
       // Get height after rows change is made
-      const newHeight = textarea.clientHeight;
+      const newHeight = textArea.clientHeight;
 
       // If the height hasn't changed, break the loop
       // This sanity check is to prevent an infinite loop in IE11
@@ -54,7 +54,7 @@ export const createElasticTextArea = (
   const shrink = () => {
     while (!isScrolling() && rows > minRows) {
       rows--;
-      textarea.setAttribute('rows', String(Math.max(rows, minRows)));
+      textArea.setAttribute('rows', String(Math.max(rows, minRows)));
 
       if (isScrolling()) {
         grow();
@@ -73,10 +73,10 @@ export const createElasticTextArea = (
   };
 
   /** As part of the public API, allow users to remove the event listener */
-  const destroy = () => textarea.removeEventListener('input', update);
+  const destroy = () => textArea.removeEventListener('input', update);
 
   // Initialize the textarea with elastic behavior
-  textarea.addEventListener('input', update);
+  textArea.addEventListener('input', update);
 
   // Run the update method to set the initial size correctly
   update();

--- a/src/components/input/elastic-textarea.ts
+++ b/src/components/input/elastic-textarea.ts
@@ -63,7 +63,9 @@ export const createElasticTextArea = (textarea: HTMLTextAreaElement) => {
     }
   };
 
-  /** As part of the public API, allow users to remove the event listener */
+  /**
+   * Part of the public API, reset state and remove event listeners
+   */
   const destroy = () => {
     textarea.classList.remove(JS_ENABLED_HOOK);
     textarea.removeEventListener('input', update);

--- a/src/components/input/elastic-textarea.ts
+++ b/src/components/input/elastic-textarea.ts
@@ -7,11 +7,20 @@
  * method to remove the event listener.
  *
  * @param textarea - the target `textarea` element
+ * @param {boolean} [disableResize=false] - Disables the textarea resize functionality if set to `true`
  */
-export const createElasticTextArea = (textarea: HTMLTextAreaElement) => {
+export const createElasticTextArea = (
+  textarea: HTMLTextAreaElement,
+  disableResize = false
+) => {
   const minRows = Number(textarea.getAttribute('rows')) || 2;
   let rows = Number(textarea.getAttribute('rows')) || minRows;
   textarea.setAttribute('rows', String(rows));
+
+  // Disables the native textarea resize functionality via inline CSS
+  if (disableResize) {
+    textarea.style.resize = 'none';
+  }
 
   /** Check if the textarea is currently scrolling */
   const isScrolling = () => textarea.scrollHeight > textarea.clientHeight;

--- a/src/components/input/elastic-textarea.ts
+++ b/src/components/input/elastic-textarea.ts
@@ -9,6 +9,9 @@
  * @param textarea - the target `textarea` element
  */
 export const createElasticTextArea = (textarea: HTMLTextAreaElement) => {
+  // Progressively enhances experience
+  textarea.classList.add('is-elastic');
+
   const minRows = Number(textarea.getAttribute('rows')) || 2;
   let rows = Number(textarea.getAttribute('rows')) || minRows;
   textarea.setAttribute('rows', String(rows));

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -83,12 +83,6 @@
    */
   &.c-input--elastic {
     block-size: auto;
-  }
-
-  /**
-   * Removes ability to resize element
-   */
-  &.c-input--noResize {
     resize: none;
   }
 

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -86,6 +86,13 @@
   }
 
   /**
+   * Removes ability to resize element
+   */
+  &.c-input--noResize {
+    resize: none;
+  }
+
+  /**
    * Types that disclose additional options should have an icon
    *
    * 1. Setting the background size to `100%` avoids a strange background shift

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -79,7 +79,7 @@
   }
 
   /**
-   * Only disable resize when JavaScript is enabled
+   * Progressively-enhanced styles; `is-elastic` is added by JavaScript
    */
 
   &.is-elastic {

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -71,19 +71,27 @@
   }
 
   /**
+   * For textareas with rows, overrides static default height
+   */
+
+  &[rows] {
+    block-size: auto;
+  }
+
+  /**
+   * Only disable reszie when JavaScript is enabled
+   */
+
+  &.is-elastic {
+    resize: none;
+  }
+
+  /**
    * Multi-line types should be taller
    */
 
   @at-root textarea#{&} {
     block-size: size.$height-control-multiline;
-  }
-
-  /**
-   * Elastic Inputs get their height from javascript.
-   */
-  &.c-input--elastic {
-    block-size: auto;
-    resize: none;
   }
 
   /**

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -79,7 +79,7 @@
   }
 
   /**
-   * Only disable reszie when JavaScript is enabled
+   * Only disable resize when JavaScript is enabled
    */
 
   &.is-elastic {

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -88,7 +88,7 @@ You can also add `c-input` to `<select>` elements, in which case you’ll get a 
 
 ## Elastic TextArea
 
-Add the `c-input--elastic` modifier class to a `<textarea>` element and follow the [JavaScript instructions](#javascript-instructions) to have it expand as the user types more than will fit.
+Add the `c-input--elastic` modifier class to a `<textarea>` element and follow the [JavaScript instructions](#javascript-instructions) below to have it expand as the user types more than will fit.
 
 If the `rows` attribute is set, it will be used as the minimum height.
 
@@ -100,9 +100,7 @@ If the `rows` attribute is set, it will be used as the minimum height.
       rows: { type: { name: 'number' } },
       class: { type: { name: 'string' } },
     }}
-    args={{
-      ...elasticTextAreaConfig,
-    }}
+    args={elasticTextAreaConfig}
     parameters={{
       docs: {
         source: {
@@ -125,7 +123,43 @@ If the `rows` attribute is set, it will be used as the minimum height.
   </Story>
 </Canvas>
 
-### JavaScript Instructions
+You can also disable the `<textarea>` resizing ability by adding the `c-input--noResize` modifier:
+
+<Canvas>
+  <Story
+    name="Elastic Textarea with No Resize"
+    height="250px"
+    argTypes={{
+      rows: { type: { name: 'number' } },
+      class: { type: { name: 'string' } },
+    }}
+    args={{
+      ...elasticTextAreaConfig,
+      class: 'c-input--elastic c-input--noResize js-elastic-textarea',
+    }}
+    parameters={{
+      docs: {
+        source: {
+          code: makeTwigInclude('@cloudfour/components/input/input.twig', {
+            ...elasticTextAreaConfig,
+            class: 'c-input--elastic c-input--noResize js-elastic-textarea',
+          }),
+        },
+      },
+    }}
+  >
+    {(args) => {
+      // Use storybook hooks to trigger JS after story renders
+      // @see https://github.com/storybookjs/storybook/issues/7786
+      useEffect(() => {
+        createElasticTextArea(document.querySelector('.js-elastic-textarea'));
+      }, []);
+      return input(args);
+    }}
+  </Story>
+</Canvas>
+
+<h3 id="javascript-instructions">JavaScript Instructions</h3>
 
 You'll need to use JavaScript to select and initialize all the elastic textareas on the page.
 
@@ -160,60 +194,3 @@ elasticTextAreas.forEach((textarea) => {
 // Or, if you only have one elastic textarea on the page
 elasticTextArea.destroy();
 ```
-
-### Elastic TextArea JavaScript Options
-
-The following options exist:
-
-- `disableResize`: Disables native HTML TextArea resizing via the CSS `resize` property
-
-```js
-interface ElasticTextAreaOpts {
-  disableResize?: boolean;
-}
-```
-
-### Elastic TextArea with Resize Disabled
-
-Below is an example where resizing is disabled:
-
-```js
-createElasticTextArea(textarea, {
-  disableResize: true,
-});
-```
-
-<Canvas>
-  <Story
-    name="Elastic Textarea with Resize Disabled"
-    height="250px"
-    argTypes={{
-      rows: { type: { name: 'number' } },
-      class: { type: { name: 'string' } },
-    }}
-    args={{
-      ...elasticTextAreaConfig,
-    }}
-    parameters={{
-      docs: {
-        source: {
-          code: makeTwigInclude(
-            '@cloudfour/components/input/input.twig',
-            elasticTextAreaConfig
-          ),
-        },
-      },
-    }}
-  >
-    {(args) => {
-      // Use storybook hooks to trigger JS after story renders
-      // @see https://github.com/storybookjs/storybook/issues/7786
-      useEffect(() => {
-        createElasticTextArea(document.querySelector('.js-elastic-textarea'), {
-          disableResize: true,
-        });
-      }, []);
-      return input(args);
-    }}
-  </Story>
-</Canvas>

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -125,6 +125,42 @@ If the `rows` attribute is set, it will be used as the minimum height.
   </Story>
 </Canvas>
 
+### JavaScript Instructions
+
+You'll need to use JavaScript to select and initialize all the elastic textareas on the page.
+
+> Note: The component class is used to reset the `height` of the textarea to `auto`, which allows it to grow or shrink as needed. But, as a best practice, [you should avoid binding your CSS and JS onto the same class in your HTML](https://cssguidelin.es/#javascript-hooks). As a result, we recommend adding an additional JS-specific class. It could be anything, but we're using `js-elastic-textarea` for this example.
+
+Once you have added the `js-elastic-textarea` class to your `textarea` elements, you'll also need to add some JavaScript that runs after the page loads, like so:
+
+```js
+// Select all elastic textarea elements, run create function on each
+const elasticTextAreas = [
+  ...document.querySelectorAll('.js-elastic-textarea'),
+].map((textarea) => {
+  return createElasticTextArea(textarea);
+});
+
+// Or, if you only have one elastic textarea on the page
+const elasticTextArea = createElasticTextArea(
+  document.querySelector('.js-elastic-textarea')
+);
+```
+
+The `createElasticTextArea` function adds an event listener to each `textarea`, allowing it to respond to user input by growing or shrinking as needed.
+
+It also returns an object containing a `destroy()` method, if you need to remove the event listener.
+
+```js
+// Remove event listeners from all elastic text areas
+elasticTextAreas.forEach((textarea) => {
+  textarea.destroy();
+});
+
+// Or, if you only have one elastic textarea on the page
+elasticTextArea.destroy();
+```
+
 You can pass `true` as the second argument to the JavaScript init function to disable
 the ability to resize the textarea:
 
@@ -167,39 +203,3 @@ createElasticTextArea(textarea, true);
     }}
   </Story>
 </Canvas>
-
-### JavaScript Instructions
-
-You'll need to use JavaScript to select and initialize all the elastic textareas on the page.
-
-> Note: The component class is used to reset the `height` of the textarea to `auto`, which allows it to grow or shrink as needed. But, as a best practice, [you should avoid binding your CSS and JS onto the same class in your HTML](https://cssguidelin.es/#javascript-hooks). As a result, we recommend adding an additional JS-specific class. It could be anything, but we're using `js-elastic-textarea` for this example.
-
-Once you have added the `js-elastic-textarea` class to your `textarea` elements, you'll also need to add some JavaScript that runs after the page loads, like so:
-
-```js
-// Select all elastic textarea elements, run create function on each
-const elasticTextAreas = [
-  ...document.querySelectorAll('.js-elastic-textarea'),
-].map((textarea) => {
-  return createElasticTextArea(textarea);
-});
-
-// Or, if you only have one elastic textarea on the page
-const elasticTextArea = createElasticTextArea(
-  document.querySelector('.js-elastic-textarea')
-);
-```
-
-The `createElasticTextArea` function adds an event listener to each `textarea`, allowing it to respond to user input by growing or shrinking as needed.
-
-It also returns an object containing a `destroy()` method, if you need to remove the event listener.
-
-```js
-// Remove event listeners from all elastic text areas
-elasticTextAreas.forEach((textarea) => {
-  textarea.destroy();
-});
-
-// Or, if you only have one elastic textarea on the page
-elasticTextArea.destroy();
-```

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -92,8 +92,6 @@ Follow the [JavaScript instructions](#javascript-instructions) below to have a `
 
 If the `rows` attribute is set, it will be used as the minimum height.
 
-The experience is progressively enhanced by disabling `resize` when JavaScript is enabled.
-
 <Canvas>
   <Story
     name="Elastic Textarea"

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -86,7 +86,7 @@ You can also add `c-input` to `<select>` elements, in which case you’ll get a 
   </Story>
 </Canvas>
 
-## Elastic textarea
+## Elastic TextArea
 
 Add the `c-input--elastic` modifier class to a `<textarea>` element and follow the [JavaScript instructions](#javascript-instructions) to have it expand as the user types more than will fit.
 
@@ -161,11 +161,26 @@ elasticTextAreas.forEach((textarea) => {
 elasticTextArea.destroy();
 ```
 
-You can pass `true` as the second argument to the JavaScript init function to disable
-the ability to resize the textarea:
+### Elastic TextArea JavaScript Options
+
+The following options exist:
+
+- `disableResize`: Disables native HTML TextArea resizing via the CSS `resize` property
 
 ```js
-createElasticTextArea(textarea, true);
+interface ElasticTextAreaOpts {
+  disableResize?: boolean;
+}
+```
+
+### Elastic TextArea with Resize Disabled
+
+Below is an example where resizing is disabled:
+
+```js
+createElasticTextArea(textarea, {
+  disableResize: true,
+});
 ```
 
 <Canvas>
@@ -194,10 +209,9 @@ createElasticTextArea(textarea, true);
       // Use storybook hooks to trigger JS after story renders
       // @see https://github.com/storybookjs/storybook/issues/7786
       useEffect(() => {
-        createElasticTextArea(
-          document.querySelector('.js-elastic-textarea'),
-          true
-        );
+        createElasticTextArea(document.querySelector('.js-elastic-textarea'), {
+          disableResize: true,
+        });
       }, []);
       return input(args);
     }}

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -102,8 +102,6 @@ If the `rows` attribute is set, it will be used as the minimum height.
     }}
     args={{
       ...elasticTextAreaConfig,
-      rows: 2,
-      class: 'c-input--elastic js-elastic-textarea',
     }}
     parameters={{
       docs: {
@@ -121,6 +119,49 @@ If the `rows` attribute is set, it will be used as the minimum height.
       // @see https://github.com/storybookjs/storybook/issues/7786
       useEffect(() => {
         createElasticTextArea(document.querySelector('.js-elastic-textarea'));
+      }, []);
+      return input(args);
+    }}
+  </Story>
+</Canvas>
+
+You can pass `true` as the second argument to the JavaScript init function to disable
+the ability to resize the textarea:
+
+```js
+createElasticTextArea(textarea, true);
+```
+
+<Canvas>
+  <Story
+    name="Elastic Textarea with Resize Disabled"
+    height="250px"
+    argTypes={{
+      rows: { type: { name: 'number' } },
+      class: { type: { name: 'string' } },
+    }}
+    args={{
+      ...elasticTextAreaConfig,
+    }}
+    parameters={{
+      docs: {
+        source: {
+          code: makeTwigInclude(
+            '@cloudfour/components/input/input.twig',
+            elasticTextAreaConfig
+          ),
+        },
+      },
+    }}
+  >
+    {(args) => {
+      // Use storybook hooks to trigger JS after story renders
+      // @see https://github.com/storybookjs/storybook/issues/7786
+      useEffect(() => {
+        createElasticTextArea(
+          document.querySelector('.js-elastic-textarea'),
+          true
+        );
       }, []);
       return input(args);
     }}

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -21,7 +21,7 @@ const elasticTextAreaConfig = {
   placeholder: 'Placeholder text…',
   id: 'demo-elastic',
   rows: 2,
-  class: 'c-input--elastic js-elastic-textarea',
+  class: 'js-elastic-textarea',
 };
 
 <!--
@@ -88,9 +88,11 @@ You can also add `c-input` to `<select>` elements, in which case you’ll get a 
 
 ## Elastic TextArea
 
-Add the `c-input--elastic` modifier class to a `<textarea>` element and follow the [JavaScript instructions](#javascript-instructions) below to have it expand as the user types more than will fit.
+Follow the [JavaScript instructions](#javascript-instructions) below to have a `<textarea>` expand as the user types more than will fit.
 
 If the `rows` attribute is set, it will be used as the minimum height.
+
+The experience is progressively enhanced by disabling `resize` when JavaScript is enabled.
 
 <Canvas>
   <Story

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -135,6 +135,7 @@ You can also disable the `<textarea>` resizing ability by adding the `c-input--n
     }}
     args={{
       ...elasticTextAreaConfig,
+      id: 'demo-elastic-no-resize',
       class: 'c-input--elastic c-input--noResize js-elastic-textarea',
     }}
     parameters={{
@@ -142,6 +143,7 @@ You can also disable the `<textarea>` resizing ability by adding the `c-input--n
         source: {
           code: makeTwigInclude('@cloudfour/components/input/input.twig', {
             ...elasticTextAreaConfig,
+            id: 'demo-elastic-no-resize',
             class: 'c-input--elastic c-input--noResize js-elastic-textarea',
           }),
         },

--- a/src/components/input/input.stories.mdx
+++ b/src/components/input/input.stories.mdx
@@ -123,44 +123,6 @@ If the `rows` attribute is set, it will be used as the minimum height.
   </Story>
 </Canvas>
 
-You can also disable the `<textarea>` resizing ability by adding the `c-input--noResize` modifier:
-
-<Canvas>
-  <Story
-    name="Elastic Textarea with No Resize"
-    height="250px"
-    argTypes={{
-      rows: { type: { name: 'number' } },
-      class: { type: { name: 'string' } },
-    }}
-    args={{
-      ...elasticTextAreaConfig,
-      id: 'demo-elastic-no-resize',
-      class: 'c-input--elastic c-input--noResize js-elastic-textarea',
-    }}
-    parameters={{
-      docs: {
-        source: {
-          code: makeTwigInclude('@cloudfour/components/input/input.twig', {
-            ...elasticTextAreaConfig,
-            id: 'demo-elastic-no-resize',
-            class: 'c-input--elastic c-input--noResize js-elastic-textarea',
-          }),
-        },
-      },
-    }}
-  >
-    {(args) => {
-      // Use storybook hooks to trigger JS after story renders
-      // @see https://github.com/storybookjs/storybook/issues/7786
-      useEffect(() => {
-        createElasticTextArea(document.querySelector('.js-elastic-textarea'));
-      }, []);
-      return input(args);
-    }}
-  </Story>
-</Canvas>
-
 <h3 id="javascript-instructions">JavaScript Instructions</h3>
 
 You'll need to use JavaScript to select and initialize all the elastic textareas on the page.


### PR DESCRIPTION
## Overview

This PR progressively enhances the Elastic Textarea experience by disabling [`resize`](https://developer.mozilla.org/en-US/docs/Web/CSS/resize).

## Screenshots

<img width="948" alt="Screen Shot 2022-12-15 at 2 15 41 PM" src="https://user-images.githubusercontent.com/459757/207978875-be462255-4915-46a2-9df9-06ca1e81c548.png">


## Testing

Preview: https://deploy-preview-2098--cloudfour-patterns.netlify.app/?path=/docs/components-input--elastic-textarea

Confirm:
- [ ] When JS is disabled, `resize` is not disabled
- [ ] When JS is enabled, `resize` is disabled

---

- https://github.com/cloudfour/cloudfour.com-wp/issues/945
