### PR TITLE
Remove usage of input "elastic" modifier

### DIFF
--- a/.changeset/afraid-monkeys-smile.md
+++ b/.changeset/afraid-monkeys-smile.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Remove usage of `c-input--elastic` modifier

--- a/src/components/comment-form/comment-form.twig
+++ b/src/components/comment-form/comment-form.twig
@@ -1,74 +1,69 @@
-<form
-  class="c-comment-form{% if class %} {{class}}{% endif %}"
-  {% if heading_id %}aria-labelledby="{{ heading_id }}"{% endif %}
-  {%- if action %}action="{{ action }}"{% endif -%}
-  {%- if method %}method="{{ method }}"{% endif -%}
->
-  {% block prompt %}
-    {% set _heading_tag = heading_tag|default('h2') %}
-    <{{_heading_tag}}
-      {% if heading_id %}id="{{ heading_id }}"{% endif %}
-      {% if heading_class %}class="{{ heading_class }}"{% endif %}
-    >
-      {{ heading_text|default("Leave a Comment") }}
-    </{{_heading_tag}}>
+<form class="c-comment-form{% if class %} {{class}}{% endif %}" {% if heading_id %} aria-labelledby="{{ heading_id }}" {% endif %} {%- if action %} action="{{ action }}" {% endif -%} {%- if method %} method="{{ method }}" {% endif -%}>
+	{% block prompt %}
+		{% set _heading_tag = heading_tag|default('h2') %}
+		<{{_heading_tag}} {% if heading_id %} id="{{ heading_id }}" {% endif %} {% if heading_class %} class="{{ heading_class }}" {% endif %}>
+			{{ heading_text|default("Leave a Comment") }}
+		</{{_heading_tag}}>
 
-    {% embed '@cloudfour/components/alert/alert.twig' %}
-      {% block content %}
-        <p {% if help_text_id %}id="{{ help_text_id }}"{% endif %}>
-          Please be kind, courteous and constructive.
-          You may use simple HTML or
-          <a href="https://en.support.wordpress.com/markdown-quick-reference">Markdown</a>
-          in your comments.
-          All fields are required.
-        </p>
-      {% endblock %}
-    {% endembed %}
-  {% endblock %}
+		{% embed '@cloudfour/components/alert/alert.twig' %}
+			{% block content %}
+				<p {% if help_text_id %} id="{{ help_text_id }}" {% endif %}>
+					Please be kind, courteous and constructive.
+					          You may use simple HTML or
+					<a href="https://en.support.wordpress.com/markdown-quick-reference">Markdown</a>
+					in your comments.
+					          All fields are required.
+				</p>
+			{% endblock %}
+		{% endembed %}
+	{% endblock %}
 
-  {#
-    Can be used to include `<input type="hidden">` elements, which systems like
-    Wordpress use to provide additional context during form submission.
-  #}
-  {% block hidden_inputs %}{% endblock %}
+	{#
+	    Can be used to include `<input type="hidden">` elements, which systems like
+	    Wordpress use to provide additional context during form submission.
+	  #}
+	{% block hidden_inputs %}{% endblock %}
 
-  {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: main_label|default('Message') } %}
-    {% block control %}
-      {% include '@cloudfour/components/input/input.twig' with {
+	{% embed '@cloudfour/objects/form-group/form-group.twig' with { label: main_label|default('Message') } %}
+		{% block control %}
+			{% include '@cloudfour/components/input/input.twig' with {
         type: 'textarea',
         name: 'comment',
         required: true,
-        class: 'c-input--elastic js-elastic-textarea',
+        class: 'js-elastic-textarea',
         'aria-describedby': help_text_id
       } only %}
-    {% endblock %}
-  {% endembed %}
-  {% if logged_in_user and log_out_url %}
-    <p>Logged in as <a href="{{ logged_in_user.link }}">{{ logged_in_user.name }}</a>. <a href="{{ log_out_url }}">Log out?</a></p>
-  {% else %}
-    {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Name', class: 'c-comment-form__name' } only %}
-      {% block control %}
-        {% include '@cloudfour/components/input/input.twig' with { name: 'author', autocomplete: 'name', required: true } only %}
-      {% endblock %}
-    {% endembed %}
-    {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Email', class: 'c-comment-form__email' } only %}
-      {% block control %}
-        {% include '@cloudfour/components/input/input.twig' with { name: 'email', type: 'email', autocomplete: 'home email', required: true } only %}
-      {% endblock %}
-    {% endembed %}
-  {% endif %}
-  <label class="o-media">
-    {% include '@cloudfour/components/checkbox/checkbox.twig' with { name: 'subscribe_comments', class: 'o-media__object' } only %}
-    <span class="o-media__content">Notify me of follow-up comments by email.</span>
-  </label>
-  {% if is_reply %}
-    {% embed '@cloudfour/objects/button-group/button-group.twig' with { grow: true, class: 'c-comment-form__reply-actions' } only %}
-      {% block content %}
-        {% include '@cloudfour/components/button/button.twig' with { label: 'Submit Reply' } only %}
-        {% include '@cloudfour/components/button/button.twig' with { label: 'Cancel', class: 'c-button--secondary js-cancel-reply', type: 'button' } only %}
-      {% endblock %}
-    {% endembed %}
-  {% else %}
-    {% include '@cloudfour/components/button/button.twig' with { label: 'Submit Comment' } only %}
-  {% endif %}
+		{% endblock %}
+	{% endembed %}
+	{% if logged_in_user and log_out_url %}
+		<p>Logged in as
+			<a href="{{ logged_in_user.link }}">{{ logged_in_user.name }}</a>.
+			<a href="{{ log_out_url }}">Log out?</a>
+		</p>
+	{% else %}
+		{% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Name', class: 'c-comment-form__name' } only %}
+			{% block control %}
+				{% include '@cloudfour/components/input/input.twig' with { name: 'author', autocomplete: 'name', required: true } only %}
+			{% endblock %}
+		{% endembed %}
+		{% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Email', class: 'c-comment-form__email' } only %}
+			{% block control %}
+				{% include '@cloudfour/components/input/input.twig' with { name: 'email', type: 'email', autocomplete: 'home email', required: true } only %}
+			{% endblock %}
+		{% endembed %}
+	{% endif %}
+	<label class="o-media">
+		{% include '@cloudfour/components/checkbox/checkbox.twig' with { name: 'subscribe_comments', class: 'o-media__object' } only %}
+		<span class="o-media__content">Notify me of follow-up comments by email.</span>
+	</label>
+	{% if is_reply %}
+		{% embed '@cloudfour/objects/button-group/button-group.twig' with { grow: true, class: 'c-comment-form__reply-actions' } only %}
+			{% block content %}
+				{% include '@cloudfour/components/button/button.twig' with { label: 'Submit Reply' } only %}
+				{% include '@cloudfour/components/button/button.twig' with { label: 'Cancel', class: 'c-button--secondary js-cancel-reply', type: 'button' } only %}
+			{% endblock %}
+		{% endembed %}
+	{% else %}
+		{% include '@cloudfour/components/button/button.twig' with { label: 'Submit Comment' } only %}
+	{% endif %}
 </form>

--- a/src/components/comment-form/comment-form.twig
+++ b/src/components/comment-form/comment-form.twig
@@ -1,69 +1,74 @@
-<form class="c-comment-form{% if class %} {{class}}{% endif %}" {% if heading_id %} aria-labelledby="{{ heading_id }}" {% endif %} {%- if action %} action="{{ action }}" {% endif -%} {%- if method %} method="{{ method }}" {% endif -%}>
-	{% block prompt %}
-		{% set _heading_tag = heading_tag|default('h2') %}
-		<{{_heading_tag}} {% if heading_id %} id="{{ heading_id }}" {% endif %} {% if heading_class %} class="{{ heading_class }}" {% endif %}>
-			{{ heading_text|default("Leave a Comment") }}
-		</{{_heading_tag}}>
+<form
+  class="c-comment-form{% if class %} {{class}}{% endif %}"
+  {% if heading_id %}aria-labelledby="{{ heading_id }}"{% endif %}
+  {%- if action %}action="{{ action }}"{% endif -%}
+  {%- if method %}method="{{ method }}"{% endif -%}
+>
+  {% block prompt %}
+    {% set _heading_tag = heading_tag|default('h2') %}
+    <{{_heading_tag}}
+      {% if heading_id %}id="{{ heading_id }}"{% endif %}
+      {% if heading_class %}class="{{ heading_class }}"{% endif %}
+    >
+      {{ heading_text|default("Leave a Comment") }}
+    </{{_heading_tag}}>
 
-		{% embed '@cloudfour/components/alert/alert.twig' %}
-			{% block content %}
-				<p {% if help_text_id %} id="{{ help_text_id }}" {% endif %}>
-					Please be kind, courteous and constructive.
-					          You may use simple HTML or
-					<a href="https://en.support.wordpress.com/markdown-quick-reference">Markdown</a>
-					in your comments.
-					          All fields are required.
-				</p>
-			{% endblock %}
-		{% endembed %}
-	{% endblock %}
+    {% embed '@cloudfour/components/alert/alert.twig' %}
+      {% block content %}
+        <p {% if help_text_id %}id="{{ help_text_id }}"{% endif %}>
+          Please be kind, courteous and constructive.
+          You may use simple HTML or
+          <a href="https://en.support.wordpress.com/markdown-quick-reference">Markdown</a>
+          in your comments.
+          All fields are required.
+        </p>
+      {% endblock %}
+    {% endembed %}
+  {% endblock %}
 
-	{#
-	    Can be used to include `<input type="hidden">` elements, which systems like
-	    Wordpress use to provide additional context during form submission.
-	  #}
-	{% block hidden_inputs %}{% endblock %}
+  {#
+    Can be used to include `<input type="hidden">` elements, which systems like
+    Wordpress use to provide additional context during form submission.
+  #}
+  {% block hidden_inputs %}{% endblock %}
 
-	{% embed '@cloudfour/objects/form-group/form-group.twig' with { label: main_label|default('Message') } %}
-		{% block control %}
-			{% include '@cloudfour/components/input/input.twig' with {
+  {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: main_label|default('Message') } %}
+    {% block control %}
+      {% include '@cloudfour/components/input/input.twig' with {
         type: 'textarea',
         name: 'comment',
         required: true,
         class: 'js-elastic-textarea',
         'aria-describedby': help_text_id
       } only %}
-		{% endblock %}
-	{% endembed %}
-	{% if logged_in_user and log_out_url %}
-		<p>Logged in as
-			<a href="{{ logged_in_user.link }}">{{ logged_in_user.name }}</a>.
-			<a href="{{ log_out_url }}">Log out?</a>
-		</p>
-	{% else %}
-		{% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Name', class: 'c-comment-form__name' } only %}
-			{% block control %}
-				{% include '@cloudfour/components/input/input.twig' with { name: 'author', autocomplete: 'name', required: true } only %}
-			{% endblock %}
-		{% endembed %}
-		{% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Email', class: 'c-comment-form__email' } only %}
-			{% block control %}
-				{% include '@cloudfour/components/input/input.twig' with { name: 'email', type: 'email', autocomplete: 'home email', required: true } only %}
-			{% endblock %}
-		{% endembed %}
-	{% endif %}
-	<label class="o-media">
-		{% include '@cloudfour/components/checkbox/checkbox.twig' with { name: 'subscribe_comments', class: 'o-media__object' } only %}
-		<span class="o-media__content">Notify me of follow-up comments by email.</span>
-	</label>
-	{% if is_reply %}
-		{% embed '@cloudfour/objects/button-group/button-group.twig' with { grow: true, class: 'c-comment-form__reply-actions' } only %}
-			{% block content %}
-				{% include '@cloudfour/components/button/button.twig' with { label: 'Submit Reply' } only %}
-				{% include '@cloudfour/components/button/button.twig' with { label: 'Cancel', class: 'c-button--secondary js-cancel-reply', type: 'button' } only %}
-			{% endblock %}
-		{% endembed %}
-	{% else %}
-		{% include '@cloudfour/components/button/button.twig' with { label: 'Submit Comment' } only %}
-	{% endif %}
+    {% endblock %}
+  {% endembed %}
+  {% if logged_in_user and log_out_url %}
+    <p>Logged in as <a href="{{ logged_in_user.link }}">{{ logged_in_user.name }}</a>. <a href="{{ log_out_url }}">Log out?</a></p>
+  {% else %}
+    {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Name', class: 'c-comment-form__name' } only %}
+      {% block control %}
+        {% include '@cloudfour/components/input/input.twig' with { name: 'author', autocomplete: 'name', required: true } only %}
+      {% endblock %}
+    {% endembed %}
+    {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Email', class: 'c-comment-form__email' } only %}
+      {% block control %}
+        {% include '@cloudfour/components/input/input.twig' with { name: 'email', type: 'email', autocomplete: 'home email', required: true } only %}
+      {% endblock %}
+    {% endembed %}
+  {% endif %}
+  <label class="o-media">
+    {% include '@cloudfour/components/checkbox/checkbox.twig' with { name: 'subscribe_comments', class: 'o-media__object' } only %}
+    <span class="o-media__content">Notify me of follow-up comments by email.</span>
+  </label>
+  {% if is_reply %}
+    {% embed '@cloudfour/objects/button-group/button-group.twig' with { grow: true, class: 'c-comment-form__reply-actions' } only %}
+      {% block content %}
+        {% include '@cloudfour/components/button/button.twig' with { label: 'Submit Reply' } only %}
+        {% include '@cloudfour/components/button/button.twig' with { label: 'Cancel', class: 'c-button--secondary js-cancel-reply', type: 'button' } only %}
+      {% endblock %}
+    {% endembed %}
+  {% else %}
+    {% include '@cloudfour/components/button/button.twig' with { label: 'Submit Comment' } only %}
+  {% endif %}
 </form>

--- a/src/components/input/elastic-textarea.test.ts
+++ b/src/components/input/elastic-textarea.test.ts
@@ -20,7 +20,7 @@ test(
   withBrowser(async ({ utils, screen, user }) => {
     await utils.injectHTML(
       await textInputHTML({
-        class: 'c-input--elastic js-elastic-textarea',
+        class: 'js-elastic-textarea',
         type: 'textarea',
       })
     );
@@ -55,7 +55,7 @@ test(
   withBrowser(async ({ utils, screen, user }) => {
     await utils.injectHTML(
       await textInputHTML({
-        class: 'c-input--elastic js-elastic-textarea',
+        class: 'js-elastic-textarea',
         type: 'textarea',
         rows: 1,
       })


### PR DESCRIPTION
## Overview

This PR does a bit of cleanup by removing usage of the `c-input--elastic` modifier. The modifier is no longer needed as of #2098. 

## Screenshots

N/A

## Testing

1. Confirm the [Comment Form](https://deploy-preview-2110--cloudfour-patterns.netlify.app/iframe.html?args=&id=components-comment-form--default-story&viewMode=story) still has Elastic TextArea functionality

---

- https://github.com/cloudfour/cloudfour.com-wp/issues/945