### PR TITLE
Support WordPress/Timber comment content filters

### DIFF
--- a/.changeset/eight-experts-refuse.md
+++ b/.changeset/eight-experts-refuse.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Add support for a `content` property (in addition to `comment_content`) so the comment component will apply content filters in WordPress/Timber projects

--- a/src/components/comment/comment.test.ts
+++ b/src/components/comment/comment.test.ts
@@ -25,7 +25,7 @@ test(
           author: {
             name: 'Test author name',
           },
-          comment_content: 'Test content',
+          content: 'Test content',
           approved: true,
         },
         allow_replies: true,

--- a/src/components/comment/comment.twig
+++ b/src/components/comment/comment.twig
@@ -44,7 +44,7 @@
           message: 'This comment is awaiting moderation.'
         } only %}
       {% endif %}
-      {{comment.comment_content|raw}}
+      {{comment.content|default(comment.comment_content)|raw}}
     {% endblock %}
   {% endembed %}
   <footer class="c-comment__footer">

--- a/src/components/comment/demo/data.ts
+++ b/src/components/comment/demo/data.ts
@@ -95,6 +95,7 @@ export const makeComment = ({
     author: {
       name: jabber.createFullName().split(' ').slice(1).join(' '),
     },
+    content,
     comment_content: content,
     is_child: isChild,
     children: [] as any,


### PR DESCRIPTION
## Overview

Our comment component was outputting `comment_content` instead of `content`. While this works fine, it prevents any WordPress filters from applying to the comment content, which prevents us from easily enhancing comments with features like server-side syntax highlighting.

I've left the old `comment_content` property as a `default` so this shouldn't be a breaking change.

## Testing

Compare [the deploy preview comments docs](https://deploy-preview-2129--cloudfour-patterns.netlify.app/?path=/docs/components-comment--single) to [the live version](https://cloudfour-patterns.netlify.app/?path=/docs/components-comment--single). Though the randomized content may differ, functionally there should be no change.

---

- See https://github.com/cloudfour/cloudfour.com-patterns/issues/2107
