### PR TITLE
Linked badges

### DIFF
--- a/.changeset/giant-sheep-bake.md
+++ b/.changeset/giant-sheep-bake.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Badges can now be links

--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -1,7 +1,13 @@
+@use '../../compiled/tokens/scss/brightness';
+@use '../../compiled/tokens/scss/color';
+@use '../../compiled/tokens/scss/ease';
 @use '../../compiled/tokens/scss/font-weight';
 @use '../../compiled/tokens/scss/line-height';
 @use '../../compiled/tokens/scss/size';
+@use '../../compiled/tokens/scss/transition';
 @use '../../mixins/ms';
+@use '../../mixins/theme';
+@use 'sass:color' as sasscolor;
 @use 'sass:math';
 
 ///
@@ -23,8 +29,29 @@
   font-weight: font-weight.$medium;
   line-height: line-height.$tighter;
   padding: 0 math.div(size.$padding-cell-horizontal, 2); // 2
+  text-decoration: none;
+  transition: filter transition.$slow ease.$out;
   vertical-align: middle;
   white-space: nowrap;
+}
+
+///
+/// When badges are links, we want to saturate their appearance a bit and add
+/// some basic pointer effects.
+///
+.c-badge:is(a) {
+  // I just wasn't happy with the light gray on its own, but I didn't think this
+  // color was versatile enough to make available as a token.
+  background-color: sasscolor.change(color.$brand-primary-lighter, $alpha: 0.2);
+  color: var(--theme-color-text-action);
+
+  &:hover {
+    filter: brightness(brightness.$control-brighten);
+  }
+
+  &:active {
+    filter: brightness(brightness.$control-dim);
+  }
 }
 
 .c-badge__content {

--- a/src/components/badge/badge.scss
+++ b/src/components/badge/badge.scss
@@ -39,7 +39,7 @@
 /// When badges are links, we want to saturate their appearance a bit and add
 /// some basic pointer effects.
 ///
-.c-badge:is(a) {
+a.c-badge {
   // I just wasn't happy with the light gray on its own, but I didn't think this
   // color was versatile enough to make available as a token.
   background-color: sasscolor.change(color.$brand-primary-lighter, $alpha: 0.2);

--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -12,6 +12,7 @@ const badgeStory = (args) => {
   title="Components/Badge"
   argTypes={{
     label: { type: { name: 'string' } },
+    href: { type: { name: 'string' } },
     icon: {
       options: ['', 'check', 'heart', 'pencil'],
       type: { name: 'string' },
@@ -34,8 +35,25 @@ Badges help provide just a smidge more context to repetitive or serialized conte
 
 ## With icon
 
+An icon may be used to visually support the meaning of the badge.
+
 <Canvas>
   <Story name="With icon" args={{ icon: 'check', label: 'Verified' }}>
+    {(args) => badgeStory(args)}
+  </Story>
+</Canvas>
+
+## Linked
+
+Badges may link to other content. For example, a badge representing an article's category might link to a list of all articles in that category.
+
+Avoid using badges for critical links: Their appearance is too subtle to rely on for important calls to action.
+
+<Canvas>
+  <Story
+    name="Linked"
+    args={{ icon: 'paperclip', label: 'Attachment', href: '#' }}
+  >
     {(args) => badgeStory(args)}
   </Story>
 </Canvas>
@@ -43,8 +61,10 @@ Badges help provide just a smidge more context to repetitive or serialized conte
 ## Template Properties
 
 - `class` (string)
+- `href` (string, optional): A URL for the badge to link to.
 - `icon` (string, optional): The name of one of [our icons](/docs/design-icons--page) to display.
 - `message` (string, default `'Label'`)
+- `tag_name` (string, default `'span'` or `'a'` depending on presence of `href`)
 
 ## Template Blocks
 

--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -52,7 +52,7 @@ Avoid using badges for critical links: Their appearance is too subtle to rely on
 <Canvas>
   <Story
     name="Linked"
-    args={{ icon: 'paperclip', label: 'Attachment', href: '#' }}
+    args={{ icon: 'paperclip', label: 'Attachment', href: '#', rel: 'tag' }}
   >
     {(args) => badgeStory(args)}
   </Story>
@@ -64,6 +64,7 @@ Avoid using badges for critical links: Their appearance is too subtle to rely on
 - `href` (string, optional): A URL for the badge to link to.
 - `icon` (string, optional): The name of one of [our icons](/docs/design-icons--page) to display.
 - `message` (string, default `'Label'`)
+- `rel` (string, optional): Specify the relationship of the linked URL.
 - `tag_name` (string, default `'span'` or `'a'` depending on presence of `href`)
 
 ## Template Blocks

--- a/src/components/badge/badge.twig
+++ b/src/components/badge/badge.twig
@@ -12,7 +12,10 @@
 
 <{{_tag_name}}
   class="c-badge{% if class %} {{class}}{% endif %}"
-  {%- if _tag_name == 'a' %} href="{{href|default('#')}}"{% endif %}>
+  {%- if _tag_name == 'a' %}
+    href="{{href|default('#')}}"
+    {% if rel %}rel="{{rel}}"{% endif %}
+  {% endif -%}>
   {% if _extra_content|trim %}
     <span class="c-badge__extra">
       {{_extra_content}}

--- a/src/components/badge/badge.twig
+++ b/src/components/badge/badge.twig
@@ -1,3 +1,5 @@
+{% set _tag_name = tag_name|default(href ? 'a' : 'span') %}
+
 {% set _extra_content %}
   {% block extra %}
     {% if icon %}
@@ -8,7 +10,9 @@
   {% endblock %}
 {% endset %}
 
-<span class="c-badge{% if class %} {{class}}{% endif %}">
+<{{_tag_name}}
+  class="c-badge{% if class %} {{class}}{% endif %}"
+  {%- if _tag_name == 'a' %} href="{{href|default('#')}}"{% endif %}>
   {% if _extra_content|trim %}
     <span class="c-badge__extra">
       {{_extra_content}}
@@ -19,4 +23,4 @@
       {{label|default('Label')}}
     {% endblock %}
   </span>
-</span>
+</{{_tag_name}}>


### PR DESCRIPTION
## Overview

Adds styles to `c-badge` to support linked badges. Useful when badged meta data (such as a topic) corresponds to a URL.

## Screenshots

<img width="1058" alt="Screenshot 2023-02-09 at 3 55 22 PM" src="https://user-images.githubusercontent.com/69633/217965670-85f31ca1-2ab0-4e24-b922-adb8d418b5cb.png">
