### PR TITLE
Add primary button modifier

### DIFF
--- a/.changeset/clean-peas-suffer.md
+++ b/.changeset/clean-peas-suffer.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Added a new `primary` modifier for buttons when particular visual emphasis is desired.

--- a/.changeset/gorgeous-eels-teach.md
+++ b/.changeset/gorgeous-eels-teach.md
@@ -1,5 +1,0 @@
----
-'@cloudfour/patterns': patch
----
-
-Removed scale animations for buttons to improve experiences where buttons line up with adjacent elements (such as input groups)

--- a/.changeset/gorgeous-eels-teach.md
+++ b/.changeset/gorgeous-eels-teach.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Removed scale animations for buttons to improve experiences where buttons line up with adjacent elements (such as input groups)

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -5,6 +5,14 @@
 }
 
 /**
+ * Modifier: Primary
+ */
+
+.c-button--primary {
+  @include button.primary;
+}
+
+/**
  * Modifier: Secondary
  */
 

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -81,7 +81,7 @@ The `c-button` class may be applied to button and link elements. The button appe
 
 ## Styles
 
-Some buttons may not require as much emphasis as others. The `c-button--secondary` and `c-button--tertiary` modifiers reflect lesser importance with reduced contrast.
+The `c-button--primary` modifier may be used when a single call to action requires unique emphasis. The `c-button--secondary` and `c-button--tertiary` modifiers reflect lesser importance with reduced contrast.
 
 <Canvas>
   <Story

--- a/src/components/button/demo/styles.twig
+++ b/src/components/button/demo/styles.twig
@@ -1,5 +1,6 @@
 {% embed '@cloudfour/objects/button-group/button-group.twig' %}
   {% block content %}
+    {% include '@cloudfour/components/button/button.twig' with { label: 'Primary', class: 'c-button--primary' } %}
     {% include '@cloudfour/components/button/button.twig' with { label: 'Default' } %}
     {% include '@cloudfour/components/button/button.twig' with { label: 'Secondary', class: 'c-button--secondary' } %}
     {% include '@cloudfour/components/button/button.twig' with { label: 'Tertiary', class: 'c-button--tertiary' } %}

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -2,7 +2,6 @@
 @use '../compiled/tokens/scss/color';
 @use '../compiled/tokens/scss/ease';
 @use '../compiled/tokens/scss/font-weight';
-@use '../compiled/tokens/scss/scale';
 @use '../compiled/tokens/scss/size';
 @use '../compiled/tokens/scss/transition';
 @use './focus';
@@ -16,18 +15,26 @@
 
 @include theme.props {
   --theme-color-background-button-default: #{color.$brand-primary};
-  --theme-color-background-button-secondary: transparent;
+  --theme-color-background-button-primary: #{color.$base-purple};
+  --theme-color-background-button-secondary: var(--theme-color-background-base);
   --theme-color-border-button-default: #{color.$brand-primary-dark};
+  --theme-color-border-button-primary: #{color.$base-purple-dark};
   --theme-color-border-button-secondary: #{color.$brand-primary-light};
+  --theme-color-text-button-default: #{color.$text-light-emphasis};
+  --theme-color-text-button-primary: #{color.$text-light-emphasis};
   --theme-color-text-button-secondary: var(--theme-color-text-action);
   --theme-color-text-button-tertiary: var(--theme-color-text-action);
 }
 
 @include theme.props(dark) {
   --theme-color-background-button-default: #{color.$brand-primary-dark};
-  --theme-color-background-button-secondary: transparent;
+  --theme-color-background-button-primary: #{color.$base-white};
+  --theme-color-background-button-secondary: var(--theme-color-background-base);
   --theme-color-border-button-default: #{color.$brand-primary-darker};
-  --theme-color-border-button-secondary: #{color.$brand-primary-dark};
+  --theme-color-border-button-primary: #{color.$brand-primary-darker};
+  --theme-color-border-button-secondary: #{color.$brand-primary-darker};
+  --theme-color-text-button-default: #{color.$text-light-emphasis};
+  --theme-color-text-button-primary: #{color.$brand-primary};
   --theme-color-text-button-secondary: var(--theme-color-text-action);
   --theme-color-text-button-tertiary: var(--theme-color-text-action);
 }
@@ -57,6 +64,7 @@
   border-style: solid;
   border-width: size.$edge-control;
   color: color.$text-light-emphasis;
+  color: var(--theme-color-text-button-default);
   cursor: pointer; /* 2 */
   display: inline-flex;
   font: inherit; /* 3 */
@@ -68,8 +76,7 @@
   position: relative;
   text-align: center;
   text-decoration: none;
-  transition: filter transition.$slow ease.$out,
-    transform transition.$quick ease.$out;
+  transition: filter transition.$slow ease.$out;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -85,12 +92,10 @@
 
   &:hover {
     filter: brightness(brightness.$control-brighten);
-    transform: scale(scale.$effect-grow);
   }
 
   &:active {
     filter: brightness(brightness.$control-dim);
-    transform: scale(scale.$effect-shrink);
   }
 
   &:disabled,
@@ -98,7 +103,6 @@
     cursor: not-allowed;
     filter: grayscale(60%);
     opacity: 0.85;
-    transform: none;
   }
 
   /**
@@ -141,6 +145,16 @@
       opacity: 0;
     }
   }
+}
+
+/**
+ * Modifier: Primary
+ */
+
+@mixin primary {
+  background-color: var(--theme-color-background-button-primary);
+  border-color: var(--theme-color-border-button-primary);
+  color: var(--theme-color-text-button-primary);
 }
 
 /**

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -2,6 +2,7 @@
 @use '../compiled/tokens/scss/color';
 @use '../compiled/tokens/scss/ease';
 @use '../compiled/tokens/scss/font-weight';
+@use '../compiled/tokens/scss/scale';
 @use '../compiled/tokens/scss/size';
 @use '../compiled/tokens/scss/transition';
 @use './focus';
@@ -76,7 +77,8 @@
   position: relative;
   text-align: center;
   text-decoration: none;
-  transition: filter transition.$slow ease.$out;
+  transition: filter transition.$slow ease.$out,
+    transform transition.$quick ease.$out;
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
@@ -92,10 +94,12 @@
 
   &:hover {
     filter: brightness(brightness.$control-brighten);
+    transform: scale(scale.$effect-grow);
   }
 
   &:active {
     filter: brightness(brightness.$control-dim);
+    transform: scale(scale.$effect-shrink);
   }
 
   &:disabled,
@@ -103,6 +107,7 @@
     cursor: not-allowed;
     filter: grayscale(60%);
     opacity: 0.85;
+    transform: none;
   }
 
   /**


### PR DESCRIPTION
## Overview

This adds a new `c-button--primary` modifier class that lends additional visual emphasis to a button. This was done with a future promotional content element in mind, where the existing buttons appears to blend in to adjacent text a bit too much.

My original instinct was to re-style the default button instead, but in practice I found it difficult to find a new "default" button style with enough contrast in our dark theme that did not blend in with Input Group. I decided a new modifier would be a better option.

~While interacting with Input Group, I rediscovered the issue where our button scale effects would conflict with adjacent elements: Hovering a button in an input group feels off, because the button loses its alignment when it scales up. This also came up in the past when discussing the possibility of adding tooltip patterns. I decided the filter effects were probably enough, but I adjusted the "secondary" button styles so that they would feel more visible there.~ (**Edit:** Paul made some really interesting alternative suggestions that made me re-think just straight-up _removing_ this effect. I've set a reminder to create an issue preserving some of those ideas, and for now I'm focusing this PR on the new modifier only.)

## Screenshots

<img width="1062" alt="Screenshot 2023-02-21 at 11 41 05 AM" src="https://user-images.githubusercontent.com/69633/220443324-21e32bc0-c95d-4052-b072-10616e80172a.png">

## Testing

[Try out deploy preview](https://deploy-preview-2140--cloudfour-patterns.netlify.app/?path=/docs/components-button--styles)
