### PR TITLE
Use primary button in Ground Nav

### DIFF
--- a/.changeset/brave-moles-decide.md
+++ b/.changeset/brave-moles-decide.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Use primary button style for Ground Nav action so it will appear more prominent visually

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -20,6 +20,7 @@
           </h2>
           <p class="c-ground-nav__action-title">
             {% include '@cloudfour/components/button/button.twig' with {
+              class: 'c-button--primary',
               href: link,
               label: title,
               content_start_icon: icon ?? 'link'


### PR DESCRIPTION
## Overview

Uses `c-button--primary` in Ground Nav so the button may appear more visually prominent.

## Screenshots

<img width="994" alt="Screenshot 2023-02-27 at 2 48 34 PM" src="https://user-images.githubusercontent.com/69633/221705300-efbd696a-23f0-4e37-a266-909975fd2637.png">

## Testing

[Deploy Preview](https://deploy-preview-2145--cloudfour-patterns.netlify.app/?path=/docs/components-ground-nav--cloud-four)