### PR TITLE
Potential side note / aside design

### DIFF
--- a/src/prototypes/asides/article.twig
+++ b/src/prototypes/asides/article.twig
@@ -1,0 +1,34 @@
+{% embed '@cloudfour/objects/container/container.twig' with {
+  class: '_proto-asides-r1 o-container--prose o-container--pad',
+  content_class: 'o-rhythm',
+  align: align,
+  summary: summary,
+  open: open
+} only %}
+  {% block content %}
+    <p>In the short run for those using a traditional web design process, we need to recognize that design doesn’t stop when something is handed off to developers. It continues until launch so designers can be involved in how the design is implemented in code.</p>
+
+    {% set aside_content -%}
+      <p>Or you could replace the traditional web design process with a process that incorporates in-browser mockups, but not every organization and designer can make that change. But if you’re interested in a process like that, stay tuned or… um… <a href="mailto:info@cloudfour.com">hire us</a>.</p>
+    {%- endset %}
+
+    <aside class="_c-aside {% if align %}_c-aside--align-{{align}}{% endif %}">
+      <div class="_c-aside__inner">
+        {% if summary %}
+          <details class="_c-aside__content"{% if open %} open{% endif %}>
+            <summary>{{summary}}</summary>
+            {{aside_content}}
+          </details>
+        {% else %}
+          <div class="_c-aside__content">
+            {{aside_content}}
+          </div>
+        {% endif %}
+      </div>
+    </aside>
+
+    <p>And in the same vein, there are development decisions happening before handoff. Developers should be involved throughout as well.</p>
+    <p>In the short run for those using a traditional web design process, we need to recognize that design doesn’t stop when something is handed off to developers. It continues until launch so designers can be involved in how the design is implemented in code.</p>
+    <p>In the short run for those using a traditional web design process, we need to recognize that design doesn’t stop when something is handed off to developers. It continues until launch so designers can be involved in how the design is implemented in code.</p>
+  {% endblock %}
+{% endembed %}

--- a/src/prototypes/asides/asides.stories.js
+++ b/src/prototypes/asides/asides.stories.js
@@ -1,0 +1,24 @@
+import articleDemo from './article.twig';
+import './r1.scss';
+
+export default {
+  title: 'Prototypes/Asides',
+  parameters: {
+    docs: { page: null },
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    align: {
+      options: ['start', 'end'],
+      control: { type: 'radio' },
+    },
+    summary: {
+      control: { type: 'text' },
+    },
+    open: {
+      control: { type: 'boolean' },
+    },
+  },
+};
+
+export const Revision1 = (args) => articleDemo(args);

--- a/src/prototypes/asides/r1.scss
+++ b/src/prototypes/asides/r1.scss
@@ -1,0 +1,85 @@
+
+@use '../../compiled/tokens/scss/breakpoint';
+@use '../../compiled/tokens/scss/size';
+@use '../../mixins/border-radius';
+@use '../../mixins/spacing';
+@use '../../mixins/ms';
+
+._proto-asides-r1 {
+
+  ._c-aside {
+    position: relative;
+
+    @media (width < breakpoint.$xxl) {
+      @include spacing.fluid-margin-inline-negative;
+    }
+  }
+
+  ._c-aside__inner {
+    @media (width > breakpoint.$xxl) {
+      inline-size: calc((100vw - 100%) / 2);
+      inset-inline-start: 100%;
+      max-inline-size: 50%;
+      position: absolute;
+      @include spacing.fluid-padding-inline;
+    }
+  }
+
+  ._c-aside--align-start ._c-aside__inner {
+    @media (width > breakpoint.$xxl) {
+      inset-inline-start: auto;
+      inset-inline-end: 100%;
+    }
+  }
+
+  ._c-aside__content {
+    background-color: var(--theme-color-background-secondary);
+    font-size: max(16px, ms.step(-1)); // Smaller than text usually but not too small
+    padding: size.$rhythm-default;
+    position: relative;
+    @include border-radius.conditional;
+    @include spacing.vertical-rhythm(size.$rhythm-default);
+
+    @media (width < breakpoint.$xxl) {
+      @include spacing.fluid-padding-inline;
+    }
+
+    @media (width > breakpoint.$xxl) {
+      margin: size.$rhythm-default * -1;
+      margin-top: ms.step(0) * -1; // Better baseline alignment
+    }
+  }
+
+  ._c-aside:not(._c-aside--align-start) ._c-aside__content {
+    @media (width > breakpoint.$xxl) {
+      border-top-left-radius: 0;
+    }
+  }
+
+  ._c-aside--align-start ._c-aside__content {
+    @media (width > breakpoint.$xxl) {
+      border-top-right-radius: 0;
+    }
+  }
+
+  ._c-aside__content::before {
+    @media (width > breakpoint.$xxl) {
+      background-image: radial-gradient(circle at 0 100%, transparent ms.step(2), var(--theme-color-background-secondary) ms.step(2));
+      block-size: ms.step(2);
+      content: '';
+      inline-size: ms.step(2);
+      inset-block-start: 0;
+      inset-inline-end: 100%;
+      position: absolute;
+    }
+  }
+
+  ._c-aside--align-start ._c-aside__content::before {
+    @media (width > breakpoint.$xxl) {
+      inset-inline-end: auto;
+      inset-inline-start: 100%;
+      transform: scaleX(-1);
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview

A little prototype with some controls to experiment with a potential floating sidebar design, which @Paul-Hebert suggested in #2148.

This isn't intended to be merged, just to share a deploy preview for reference and discussion.

## Screenshots

On small screens, the side does not look much different from a paragraph with a silver background:

<img width="535" alt="Screenshot 2023-04-06 at 9 58 32 AM" src="https://user-images.githubusercontent.com/69633/230446572-a11ccf9d-c4d3-4eaf-b258-b0eae990bd47.png">

I set its `font-size` to be one step down in our modular scale, but it felt _really_ small to me, so I used a `max` function to only do so up to a minimum of `16px`. I'm open to feedback on this.

I wondered if it might feel less intrusive sometimes to use `<details>` and `<summary>`, so I added a control for specifying a summary:

<img width="530" alt="Screenshot 2023-04-06 at 9 58 43 AM" src="https://user-images.githubusercontent.com/69633/230446813-7dc48fe0-152b-4a2b-84ef-d67362c97ed9.png">

Is that too boring looking? I'm not sure.

At very wide sizes, I use some absolute positioning and a lot of `calc` to nestle the side note into the margins. I also use a radial gradient to fake an inverted rounded corner, because I thought it felt a bit disconnected from its point in the article. (I mean, it's _still_ a lot more disconnected from the original footnote, but this way I think it's clear that it comes between two paragraphs.)

<img width="1420" alt="Screenshot 2023-04-06 at 9 59 05 AM" src="https://user-images.githubusercontent.com/69633/230447074-6afaf75e-3a22-4e41-9404-c44568b1db2c.png">

Like @Paul-Hebert's site, I added a modifier to allow the aside to align the opposite way:

<img width="1418" alt="Screenshot 2023-04-06 at 9 59 15 AM" src="https://user-images.githubusercontent.com/69633/230447162-ff62b34d-244b-4f0e-b10d-e80267c934df.png">

The `<details>` version would work the same way at large sizes:

<img width="1420" alt="Screenshot 2023-04-06 at 9 59 37 AM" src="https://user-images.githubusercontent.com/69633/230447251-9397b14b-2048-412e-ba75-6d078252e478.png">

<img width="1422" alt="Screenshot 2023-04-06 at 9 59 48 AM" src="https://user-images.githubusercontent.com/69633/230447281-95fd40af-03fc-4885-98c3-30fb41c16381.png">

Gosh, that version is missing something. Does it need a rule between the summary and details? Should the summary be a medium weight? I'm not sure.

I'm also wondering now if the container is too confining on large screens. Maybe a border to the left or right would work? Might be worth trying and comparing.

## Testing

Try it out for yourself. I've not tested it outside of Arc (Chromium).