### PR TITLE
Account for badges in Form Group labels

### DIFF
--- a/.changeset/brave-ravens-applaud.md
+++ b/.changeset/brave-ravens-applaud.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Improve alignment of complex Form Group label content

--- a/.changeset/tasty-otters-type.md
+++ b/.changeset/tasty-otters-type.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add new `parenthetical` template property for badges to wrap content in visually hidden parentheses

--- a/src/components/badge/badge.stories.mdx
+++ b/src/components/badge/badge.stories.mdx
@@ -20,6 +20,7 @@ const badgeStory = (args) => {
         type: 'select',
       },
     },
+    parenthetical: { type: { name: 'boolean' } },
   }}
 />
 
@@ -63,11 +64,12 @@ Avoid using badges for critical links: Their appearance is too subtle to rely on
 - `class` (string)
 - `href` (string, optional): A URL for the badge to link to.
 - `icon` (string, optional): The name of one of [our icons](/docs/design-icons--page) to display.
-- `message` (string, default `'Label'`)
+- `label` (string, default `'Label'`)
 - `rel` (string, optional): Specify the relationship of the linked URL.
+- `parenthetical` (boolean, optional): If `true`, the badge `label` will be wrapped by visually hidden parentheses.
 - `tag_name` (string, default `'span'` or `'a'` depending on presence of `href`)
 
 ## Template Blocks
 
-- `content`: The main label content, typically the value of `message`.
+- `content`: The main label content, typically the value of `label`.
 - `extra`: A visual extra preceding the content, typically populated by an icon if `icon` is set.

--- a/src/components/badge/badge.twig
+++ b/src/components/badge/badge.twig
@@ -22,8 +22,14 @@
     </span>
   {% endif %}
   <span class="c-badge__content">
-    {% block content %}
+    {%- if parenthetical -%}
+      <span class="u-hidden-visually">(</span>
+    {%- endif -%}
+    {%- block content -%}
       {{label|default('Label')}}
-    {% endblock %}
+    {%- endblock -%}
+    {%- if parenthetical -%}
+      <span class="u-hidden-visually">)</span>
+    {%- endif -%}
   </span>
 </{{_tag_name}}>

--- a/src/objects/form-group/demo/badge.twig
+++ b/src/objects/form-group/demo/badge.twig
@@ -1,0 +1,16 @@
+{% embed '@cloudfour/objects/form-group/form-group.twig' only %}
+  {% block label %}
+    Email
+    {% include '@cloudfour/components/badge/badge.twig' with {
+      label: 'Required',
+      icon: 'asterisk',
+      parenthetical: true,
+    } only %}
+  {% endblock %}
+  {% block control %}
+    {% include '@cloudfour/components/input/input.twig' with {
+      type: 'email',
+      required: true,
+    } only %}
+  {% endblock %}
+{% endembed %}

--- a/src/objects/form-group/demo/input.twig
+++ b/src/objects/form-group/demo/input.twig
@@ -1,4 +1,3 @@
-{# Make sure to update the corresponding code snippet in the story file #}
 {% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Email' } only %}
   {% block control %}
     {% include '@cloudfour/components/input/input.twig' with { type: 'email' } only %}

--- a/src/objects/form-group/form-group.scss
+++ b/src/objects/form-group/form-group.scss
@@ -1,9 +1,15 @@
 @use '../../compiled/tokens/scss/size';
 
-/**
- * Form Group layout object
- */
+/// Form Group layout object
 .o-form-group {
   display: grid;
   gap: #{size.$spacing-gap-form-group-default};
+}
+
+/// Nicely align label content, such as label text and adjacent badges or icons.
+.o-form-group__label {
+  align-items: center;
+  column-gap: 1ch;
+  display: flex;
+  flex-wrap: wrap;
 }

--- a/src/objects/form-group/form-group.stories.mdx
+++ b/src/objects/form-group/form-group.stories.mdx
@@ -1,5 +1,18 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
-import demo from './demo/input.twig';
+import basicDemo from './demo/input.twig';
+import badgeDemo from './demo/badge.twig';
+// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
+// See: https://github.com/webpack-contrib/raw-loader#examples
+// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we
+// are okay with the following Webpack-specific raw loader syntax. It's better
+// to leave the ESLint rule enabled globally, and only thoughtfully disable as
+// needed (e.g. within a Storybook docs page and not within an actual
+// component). This can be revisited in the future if Storybook no longer relies
+// on Webpack.
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import basicDemoSource from '!!raw-loader!./demo/input.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import badgeDemoSource from '!!raw-loader!./demo/badge.twig';
 
 <Meta title="Objects/Form Group" />
 
@@ -7,29 +20,31 @@ import demo from './demo/input.twig';
 
 The Form Group layout object groups a label and its corresponding control.
 
-## Default
+<Canvas>
+  <Story
+    name="Basic"
+    parameters={{ docs: { source: { code: basicDemoSource } } }}
+  >
+    {() => basicDemo()}
+  </Story>
+</Canvas>
+
+## With more label content
+
+The `label` content may be set as a template property or a content block. In this example, we use the block to append [a Badge component](/?path=/docs/components-badge--basic) noting that this is a required field.
 
 <Canvas>
   <Story
-    name="Default"
-    parameters={{
-      docs: {
-        source: {
-          code: `{% embed '@cloudfour/objects/form-group/form-group.twig' with { label: 'Email' } only %}
-  {% block control %}
-    {% include '@cloudfour/components/input/input.twig' with { type: 'email' } only %}
-  {% endblock %}
-{% endembed %}`,
-        },
-      },
-    }}
+    name="With badge"
+    parameters={{ docs: { source: { code: badgeDemoSource } } }}
   >
-    {() => demo()}
+    {() => badgeDemo()}
   </Story>
 </Canvas>
 
 ## Template Properties
 
 - `class`: Append a class to the root element.
-- `label`: Label text (can be either a block or a variable)
+- `label`: Label text.
+- `label` (block): Label content.
 - `control` (block): Block to add controls/inputs.

--- a/src/objects/form-group/form-group.twig
+++ b/src/objects/form-group/form-group.twig
@@ -1,6 +1,8 @@
 <label class="o-form-group{% if class %} {{ class }}{% endif %}">
-  {% block label %}
-    <div>{{ label | default('Label') }}</div>
-  {% endblock %}
+  <div class="o-form-group__label">
+    {% block label %}
+      {{ label | default('Label') }}
+    {% endblock %}
+  </div>
   {% block control %}{% endblock %}
 </label>


### PR DESCRIPTION
## Overview

A marketing page prototype I'm working on includes a content form with a mixture of required and optional fields, which benefit from some note in their respective labels. This PR makes two changes to account for that:

- It modifies the Form Group object to better align child elements of the label.
- It adds a new `parenthetical` property to badges to wrap the label contents in visually hidden parentheses ("Email (Required)" instead of "Email Required").

## Screenshots

<img width="710" alt="Screenshot 2023-05-15 at 10 27 52 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/509d0252-9e06-4b45-8974-3909b025d1a6">

## Testing

On the deploy preview, test the [Form Group](https://deploy-preview-2165--cloudfour-patterns.netlify.app/?path=/docs/objects-form-group--basic) and [Comment Form](https://deploy-preview-2165--cloudfour-patterns.netlify.app/?path=/docs/components-comment-form--default-story) patterns to make sure their labels still behave as expected.