### PR TITLE
Add basic, opinionated text size utilities

### DIFF
--- a/.changeset/pink-foxes-guess.md
+++ b/.changeset/pink-foxes-guess.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Prevent the WordPress `has-small-font-size` utility class from reducing text below 16 pixels for consistency with `u-text-small`

--- a/.changeset/silly-rockets-kneel.md
+++ b/.changeset/silly-rockets-kneel.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add `u-text-big` and `u-text-small` utilities to bump `font-size` up or down a notch

--- a/src/mixins/_font-size.scss
+++ b/src/mixins/_font-size.scss
@@ -1,0 +1,22 @@
+@use '../compiled/tokens/scss/breakpoint';
+@use '../compiled/tokens/scss/size';
+@use './fluid';
+
+/// Since this is often used for paragraph content that can be overwhelming if
+/// it is always substantially larger than surrounding content, we responsively
+/// apply the font size (similar to Cloud Cover content).
+@mixin big {
+  font-size: fluid.fluid-clamp(
+    1em,
+    size.$font-big,
+    breakpoint.$xs,
+    breakpoint.$l
+  );
+}
+
+/// To prevent small text from impairing readability (most importantly) and our
+/// Core Web Vitals (secondarily), we only apply the small font size if it isn't
+/// smaller than 16 pixels.
+@mixin small {
+  font-size: max(16px, size.$font-small);
+}

--- a/src/utilities/text/demo/size.twig
+++ b/src/utilities/text/demo/size.twig
@@ -1,0 +1,11 @@
+<div class="o-rhythm">
+  <p class="u-text-big">
+    This paragraph has <b>u-text-big</b> applied. It starts the same size as the body copy, but gradually grows larger with the viewport size.
+  </p>
+  <p>
+    This paragraph is the default font size. There are no text utilities applied to it.
+  </p>
+  <p class="u-text-small">
+    This paragraph has <b>u-text-small</b> applied. It will always be one modular scale step smaller than the default font size, except it will never reduce below 16 pixels to maintain readability.
+  </p>
+</div>

--- a/src/utilities/text/text.scss
+++ b/src/utilities/text/text.scss
@@ -1,13 +1,29 @@
 @use '../../compiled/tokens/scss/color';
+@use '../../mixins/fluid';
+@use '../../mixins/font-size';
+
+/// Layout
+
+.u-text-center {
+  text-align: center !important;
+}
 
 .u-text-no-wrap {
   white-space: nowrap !important;
 }
 
+/// Color
+
 .u-text-action {
   color: var(--theme-color-text-action) !important;
 }
 
-.u-text-center {
-  text-align: center !important;
+/// Size
+
+.u-text-big {
+  @include font-size.big;
+}
+
+.u-text-small {
+  @include font-size.small;
 }

--- a/src/utilities/text/text.stories.mdx
+++ b/src/utilities/text/text.stories.mdx
@@ -12,9 +12,12 @@ import noWrapDemoSource from '!!raw-loader!./demo/nowrap.twig';
 import colorDemoSource from '!!raw-loader!./demo/color.twig';
 // eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
 import textAlignDemoSource from '!!raw-loader!./demo/text-align.twig';
+// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
+import sizeDemoSource from '!!raw-loader!./demo/size.twig';
 import noWrapDemo from './demo/nowrap.twig';
 import colorDemo from './demo/color.twig';
 import textAlignDemo from './demo/text-align.twig';
+import sizeDemo from './demo/size.twig';
 
 <Meta title="Utilities/Text" />
 
@@ -66,5 +69,21 @@ Utility that sets `text-align` to `center`
     parameters={{ docs: { source: { code: textAlignDemoSource } } }}
   >
     {(args) => textAlignDemo(args)}
+  </Story>
+</Canvas>
+
+## Size
+
+- `u-text-big`
+- `u-text-small`
+
+These utility classes provide some opinionated size adjustments to bump an element's font size up or down a notch. At narrower viewports, the difference is little to none: Paragraphs of "big" text could easily overwhelm the visible area, and paragraphs of "small" text would cause eye strain and poor accessibility. As the viewport and base font size increase, the difference becomes more noticeable.
+
+<Canvas>
+  <Story
+    name="Big and small"
+    parameters={{ docs: { source: { code: sizeDemoSource } } }}
+  >
+    {(args) => sizeDemo(args)}
   </Story>
 </Canvas>

--- a/src/vendor/wordpress/styles/_utilities.scss
+++ b/src/vendor/wordpress/styles/_utilities.scss
@@ -1,10 +1,10 @@
 @use 'sass:math';
 @use 'sass:meta';
-@use '../../../compiled/tokens/scss/breakpoint';
 @use '../../../compiled/tokens/scss/color-base';
 @use '../../../compiled/tokens/scss/size';
 @use '../../../mixins/border-radius';
 @use '../../../mixins/fluid';
+@use '../../../mixins/font-size';
 @use '../../../mixins/headings';
 @use '../../../mixins/ms';
 @use '../../../mixins/spacing';
@@ -77,20 +77,12 @@ $color-map: meta.module-variables('color-base');
 /// Utilities for Block Font Sizes
 /// @link https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#block-font-sizes
 
-/// Since this is often used for paragraph content that can be overwhelming if
-/// it is always substantially larger than surrounding content, we responsively
-/// apply the font size (similar to Cloud Cover content).
 .has-big-font-size {
-  font-size: fluid.fluid-clamp(
-    1em,
-    size.$font-big,
-    breakpoint.$xs,
-    breakpoint.$l
-  );
+  @include font-size.big;
 }
 
 .has-small-font-size {
-  font-size: size.$font-small;
+  @include font-size.small;
 }
 
 @for $level from -2 through 3 {


### PR DESCRIPTION
## Overview

I've found myself using the WordPress `has-big-font-size` class in prototypes, so it seemed overdue to represent that in our own system (as `u-text-big`). In a recent marketing page prototype, I also found need for a `u-text-small` class that caps the size reduction to `16px`, so I took this chance to introduce both.

I chose to keep the "big" and "small" terms for these, because I think in this case their vagueness actually matches the responsive behavior. If we ever want to introduce utilities that were tied to steps of our modular scale, they shouldn't conflict with these.

## Screenshots

<img width="1052" alt="Screenshot 2023-05-15 at 4 01 13 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/03c454fc-3236-4f4c-87d6-a25139e18162">

![text-big-small](https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/29cce17a-c879-4991-bb96-8b63b980226d)

## Testing

[Try out the deploy preview](https://deploy-preview-2167--cloudfour-patterns.netlify.app/?path=/docs/utilities-text--big-and-small) in the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
