### PR TITLE
Logo Group padding and justification options

### DIFF
--- a/.changeset/blue-balloons-vanish.md
+++ b/.changeset/blue-balloons-vanish.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': major
+---
+
+The Logo Group previously included padding and center-aligned its contents horizontally. Now, the padding and horizontal justification may be set via a template property or modifier class, which makes the pattern more flexible. To retain the previous appearance, opt into padding and use center justification.

--- a/src/objects/logo-group/demo/demo.twig
+++ b/src/objects/logo-group/demo/demo.twig
@@ -1,14 +1,7 @@
-{% embed '@cloudfour/objects/container/container.twig' %}
+{% embed '@cloudfour/objects/logo-group/logo-group.twig' %}
   {% block content %}
-    {% embed '@cloudfour/objects/logo-group/logo-group.twig' %}
-      {% block content %}
-        {% for item in items %}
-          {% include '@cloudfour/components/logo/logo.twig' with {
-            src: item.src,
-            alt: item.alt
-          } only %}
-        {% endfor %}
-      {% endblock %}
-    {% endembed %}
+    {% for logo in logos %}
+      {% include '@cloudfour/components/logo/logo.twig' with logo only %}
+    {% endfor %}
   {% endblock %}
 {% endembed %}

--- a/src/objects/logo-group/logo-group.scss
+++ b/src/objects/logo-group/logo-group.scss
@@ -1,21 +1,41 @@
 @use '../../compiled/tokens/scss/size';
 @use '../../mixins/ms';
 
+/// The Logo Group container is where most of the magic happens. We use flex
+/// instead of grid because we want to support centered justification later (if
+/// we used grid, the bottom row would always be left/start justified).
 .o-logo-group {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
+  gap: size.$spacing-gap-logo-group;
+}
+
+/// The initial use case for this pattern called for white space to surround the
+/// logos, but this makes the pattern more difficult to work with when left-
+/// justified or used in a more condensed layout, so we've moved this to a
+/// modifier class instead.
+.o-logo-group--pad {
+  padding: size.$spacing-gap-logo-group;
+}
+
+/// These modifiers set the horizontal alignment of the logos. Historically we
+/// would have used the term "align" for this, but because Flex and Grid both
+/// use "align" to refer to vertical alignment (at least in Western languages
+/// and writing modes), we're continuing the "justify" usage set in the Logo
+/// component.
+
+.o-logo-group--justify-center {
   justify-content: center;
 }
 
-/**
- * 1. Because there is generous spacing between the logos, we added a lot of
- *    white space around Logo Group to help balance the pattern visually.
- *    Including the spacing as part of the pattern means we don't need to rely
- *    on utilities.
- */
+.o-logo-group--justify-end {
+  justify-content: end;
+}
 
+/// Because Flex doesn't let you set column sizes, we have to apply a width to
+/// child elements intead. Without this, the logos will appear misaligned row-
+/// to-row as they differ in size.
 .o-logo-group > * {
   inline-size: size.$width-logo-group-item-width;
-  margin: size.$spacing-gap-logo-group; /* 1 */
 }

--- a/src/objects/logo-group/logo-group.stories.mdx
+++ b/src/objects/logo-group/logo-group.stories.mdx
@@ -1,29 +1,63 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
-// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
-// See: https://github.com/webpack-contrib/raw-loader#examples
-// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
-// okay with the following Webpack-specific raw loader syntax. It's better to leave
-// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
-// within a Storybook docs page and not within an actual component).
-// This can be revisited in the future if Storybook no longer relies on Webpack.
-// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
-import defaultDemoSource from '!!raw-loader!./demo/demo.twig';
-import defaultDemo from './demo/demo.twig';
+import demo from './demo/demo.twig';
 import logos from './demo/logos.json';
+const justifyOptions = ['start', 'center', 'end'];
+const demoTemplateSource = (_src, storyContext) => {
+  const args = storyContext.args || storyContext.initialArgs;
+  const twigArgs =
+    Object.keys(args).length > 0
+      ? ` with ${JSON.stringify(args, null, 2)}`
+      : '';
+  return `{% embed '@cloudfour/objects/logo-group/logo-group.twig'${twigArgs} %}
+  {% block content %}
+    {# logos #}
+  {% endblock %}
+{% endembed %}`;
+};
+const demoStory = (args) => demo({ ...args, logos });
 
-<Meta title="Objects/Logo Group" />
+<Meta
+  title="Objects/Logo Group"
+  parameters={{
+    docs: {
+      transformSource: demoTemplateSource,
+    },
+  }}
+  argTypes={{
+    justify: {
+      options: justifyOptions,
+      control: { type: 'inline-radio' },
+    },
+    pad: {
+      type: { name: 'boolean' },
+    },
+  }}
+/>
 
 # Logo Group
 
-Logo Group can be used to display a group of logos, such as a summary of past clients. Logos break onto multiple lines depending on the available space and are vertically centered.
+The Logo Group presents multiple logos together with consistent spacing and alignment. It is useful for summarizing a list of projects or clients.
 
-To enforce consistent sizing or fine-tune alignment, consider using [Logo components](/docs/components-logo--basic-options) within the Logo Group.
+To fine-tune the relative scale or layout of individual logos within, consider using [the Logo component](/docs/components-logo--basic-options).
+
+<Canvas>
+  <Story name="Default">{(args) => demoStory(args)}</Story>
+</Canvas>
+
+## Options
+
+The `justify` template property or `o-logo-group--justify-{alignment}` class sets the horizontal alignment of the logos within the group. The default is `start`, but `center` and `end` are also supported.
+
+To repeat the gap between logos around the whole container, set the `pad` template property to `true` or apply the `o-logo-group--pad` modifier class.
 
 <Canvas>
   <Story
-    name="Default"
-    parameters={{ docs: { source: { code: defaultDemoSource } } }}
+    name="Centered with padding"
+    args={{
+      justify: 'center',
+      pad: true,
+    }}
   >
-    {defaultDemo({ items: logos })}
+    {(args) => demoStory(args)}
   </Story>
 </Canvas>

--- a/src/objects/logo-group/logo-group.twig
+++ b/src/objects/logo-group/logo-group.twig
@@ -1,3 +1,5 @@
-<div class="o-logo-group">
+<div class="o-logo-group
+  {% if justify %}o-logo-group--justify-{{justify}}{% endif %}
+  {% if pad %}o-logo-group--pad{% endif %}">
   {% block content %}{% endblock %}
 </div>


### PR DESCRIPTION
## Overview

The Logo Group was designed for the presentation of client logos on our work page, but while prototyping marketing content I encountered a use case for displaying a couple of logos left-aligned within a normal content flow.

Rather than introduce modifier classes that _remove_ functionality, I thought it was more appropriate to start from a less opinionated baseline and to tack on the features. That means that this is a breaking change that will require a small alteration to the template properties of the work page in our WordPress theme.

## Screenshots

![Screenshot 2023-05-16 at 09-57-22 objects-logo-group--default-story](https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/fe5021b3-0a89-4d95-a8f4-387f16a801ec)

## Testing

[Try out the deploy preview](https://deploy-preview-2168--cloudfour-patterns.netlify.app/?path=/docs/objects-logo-group--default-story) in the following browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari
