### PR TITLE
Allow Media Link to inherit `line-height`

### DIFF
--- a/src/components/media-link/media-link.scss
+++ b/src/components/media-link/media-link.scss
@@ -32,7 +32,6 @@
 ///    nice! Apologies to our future selves if we have to modify or rip out.
 .c-media-link__action {
   font-weight: font-weight.$medium;
-  line-height: line-height.$tight;
   text-wrap: balance; // 1
 
   /// Normally hiding text decoration is a bad idea, but in this case the


### PR DESCRIPTION
## Overview

While actually using the new Media Link component, I realized the tighter `line-height` was a bit of an overreach, impairing readability for multi-line text at smaller sizes. This removes it in favor of inheriting the parent element's `line-height`.

(I have not included a changeset since Media Link has yet to be released in a published version.)

## Screenshots

Before | After
--- | ---
<img width="380" alt="Screenshot 2023-05-16 at 1 09 13 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/2ab59c33-cae6-45f4-8a68-00d6d094b998"> | <img width="382" alt="Screenshot 2023-05-16 at 1 09 00 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/6a7dce97-3b51-4592-94c6-b2d047ba9d67">
