### PR TITLE
Revise blockquote-derived styles

### DIFF
--- a/.changeset/tame-geese-provide.md
+++ b/.changeset/tame-geese-provide.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': major
+---
+
+Revised `blockquote` and WordPress Quote and Pullquote block styles to address issues of consistency and improve feature support. Content that relied on previous quote styles may need to be reviewed or updated.

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -2,7 +2,9 @@
 @use '../compiled/tokens/scss/color';
 @use '../compiled/tokens/scss/size';
 @use '../mixins/border-radius';
+@use '../mixins/emdash';
 @use '../mixins/ms';
+@use '../mixins/spacing';
 @use '../mixins/theme';
 
 /**
@@ -235,15 +237,25 @@ blockquote {
   padding-inline-start: size.$spacing-type-block-indent;
 }
 
-/**
- * Adjacent children of blockquotes should include some default vertical rhythm.
- * We use the same design token as the `o-rhythm` pattern for consistency.
- *
- * @see https://alistapart.com/article/axiomatic-css-and-lobotomized-owls/
- */
+blockquote {
+  @include spacing.vertical-rhythm;
+  border-inline-start: size.$border-width-blockquote solid
+    var(--theme-color-border-text-group);
+  color: var(--theme-color-text-muted);
+}
 
-blockquote > * + * {
-  margin-block-start: size.$rhythm-default;
+blockquote > cite,
+blockquote > footer > cite {
+  display: block;
+  font-style: inherit;
+  padding-inline-start: size.$spacing-type-block-indent;
+  position: relative;
+
+  &::before {
+    @include emdash.content;
+    inset-inline-start: 0;
+    position: absolute;
+  }
 }
 
 /**

--- a/src/components/comment/comment.scss
+++ b/src/components/comment/comment.scss
@@ -2,7 +2,6 @@
 @use '../../compiled/tokens/scss/color';
 @use '../../compiled/tokens/scss/font-weight';
 @use '../../compiled/tokens/scss/size';
-@use '../../mixins/emdash';
 @use '../../mixins/headings';
 @use '../../mixins/theme';
 
@@ -76,24 +75,6 @@
   grid-area: content;
   margin-block-start: math.div(size.$rhythm-condensed, -4); // 1
   min-inline-size: 0; // 2
-}
-
-// We added default styles to the blockquote element using the `wp-block-quote`
-// class. We're applying those same styles here, so comment blockquotes look
-// the similar.
-
-.c-comment__content blockquote {
-  border-inline-start: size.$border-width-blockquote solid
-    var(--theme-color-border-kbd);
-  color: var(--theme-color-text-muted);
-}
-
-.c-comment__content blockquote cite {
-  font-style: normal;
-}
-
-.c-comment__content blockquote cite::before {
-  @include emdash.content;
 }
 
 .c-comment__footer {

--- a/src/vendor/wordpress/core-blocks.stories.mdx
+++ b/src/vendor/wordpress/core-blocks.stories.mdx
@@ -535,7 +535,7 @@ class.
 
 ## Quote
 
-The quote block adds class of `wp-block-quote` directly to a `blockquote` element. It supports background and text colors as well as text alignment, but not general alignment sizes. It may or may not include a citation.
+The quote block adds a class of `wp-block-quote` directly to a `blockquote` element. It supports background and text colors as well as text alignment, but not general alignment options. It may or may not include a citation.
 
 <Canvas>
   <Story

--- a/src/vendor/wordpress/core-blocks.stories.mdx
+++ b/src/vendor/wordpress/core-blocks.stories.mdx
@@ -5,6 +5,8 @@ import blockEmbedYouTubeDemo from './demo/embed/youtube.twig';
 import blockImageDemo from './demo/image.twig';
 import blockGroupDemo from './demo/group.twig';
 import blockMediaTextDemo from './demo/media-text.twig';
+import blockQuoteDemo from './demo/quote.twig';
+import blockPullQuoteDemo from './demo/pullquote.twig';
 import blockTableDemo from './demo/table.twig';
 const blockEmbedDemoArgTypes = {
   alignment: {
@@ -531,38 +533,69 @@ class.
   </Story>
 </Canvas>
 
+## Quote
+
+The quote block adds class of `wp-block-quote` directly to a `blockquote` element. It supports background and text colors as well as text alignment, but not general alignment sizes. It may or may not include a citation.
+
+<Canvas>
+  <Story
+    name="Quote"
+    args={{
+      show_citation: true,
+      has_background: false,
+    }}
+    argTypes={{
+      show_citation: {
+        control: { type: 'boolean' },
+      },
+      style: {
+        options: ['default', 'plain'],
+        control: { type: 'select' },
+      },
+      has_background: {
+        control: { type: 'boolean' },
+      },
+      text_align: {
+        options: ['left', 'center', 'right'],
+        control: { type: 'select' },
+      },
+    }}
+  >
+    {(args) => blockQuoteDemo(args)}
+  </Story>
+</Canvas>
+
 ## Pullquote
 
 The pullquote block wraps a `blockquote` element in a `figure` element with the class
 `wp-block-pullquote`.
 
-[Color controls](#color-settings) allow the setting of pre-defined or custom `background-color` and
-text `color`. A styles control adds one of two wrapper classes, `is-style-default` or
-`is-style-solid-color`. By default, any user-selected `background-color` will be
-applied only if the solid color background is toggled on.
+Its visual appearance is more opinionated than the quote block, and it supports more alignment options (such as floating or breaking out of the containing element).
 
 <Canvas>
-  <Story name="Pullquote">
-    {`<figure class="wp-block-pullquote has-background is-style-solid-color">
-        <blockquote class="has-text-color has-accent-color">
-          <p>One of the hardest things to do in technology is disrupt yourself.</p>
-          <cite>Matt Mullenweg</cite>
-        </blockquote>
-      </figure>`}
-  </Story>
-</Canvas>
-
-## Quote
-
-The quote block adds class of `wp-block-quote` directly to a `blockquote` element.
-It has a control to add an optional `is-style-large` class.
-
-<Canvas>
-  <Story name="Quote">
-    {`<blockquote class="wp-block-quote is-style-large">
-        <p>In quoting others, we cite ourselves.</p>
-        <cite>Julio Cortázar</cite>
-      </blockquote>`}
+  <Story
+    name="Pullquote"
+    parameters={{
+      layout: 'fullscreen',
+    }}
+    args={{
+      show_citation: true,
+    }}
+    argTypes={{
+      show_citation: {
+        control: { type: 'boolean' },
+      },
+      align: {
+        options: ['left', 'right', 'wide', 'full'],
+        control: { type: 'select' },
+      },
+      text_align: {
+        options: ['left', 'center', 'right'],
+        control: { type: 'select' },
+      },
+    }}
+  >
+    {(args) => blockPullQuoteDemo(args)}
   </Story>
 </Canvas>
 

--- a/src/vendor/wordpress/demo/pullquote.twig
+++ b/src/vendor/wordpress/demo/pullquote.twig
@@ -1,0 +1,24 @@
+
+<div class="o-container o-container--prose o-container--pad">
+  <div class="o-container__content o-rhythm">
+    <p>
+      This content precedes the pullquote. Notice how the pullquote has more margin than usual.
+    </p>
+
+    <figure class="wp-block-pullquote
+      {% if text_align %}has-text-align-{{text_align}}{% endif %}
+      {% if align %}align{{align}}{% endif %}">
+      <blockquote>
+        <p>In case of conflict, consider users over authors over implementors over specifiers over theoretical purity.</p>
+        {% if show_citation %}
+          <cite><a href="https://www.w3.org/TR/html-design-principles/#priority-of-constituencies">HTML Design Principles Priority of Constituencies</a></cite>
+        {% endif %}
+      </blockquote>
+    </figure>
+
+    <p>
+      This content follows the pullquote. Notice how the pullquote has more margin than usual.
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </div>
+</div>

--- a/src/vendor/wordpress/demo/quote.twig
+++ b/src/vendor/wordpress/demo/quote.twig
@@ -1,0 +1,11 @@
+<blockquote class="
+  wp-block-quote
+  {% if style %}is-style-{{style}}{% endif %}
+  {% if text_align %}has-text-align-{{text_align}}{% endif %}
+  {% if has_background %}has-gray-lighter-background-color has-background{% endif %}">
+  <p><b>CSS Grid Layout</b> excels at dividing a page into major regions or defining the relationship in terms of size, position, and layer, between parts of a control built from HTML primitives.</p>
+  <p>Like tables, grid layout enables an author to align elements into columns and rows. However, many more layouts are either possible or easier with CSS grid than they were with tables. For example, a grid container's child elements could position themselves so they actually overlap and layer, similar to CSS positioned elements.</p>
+  {% if show_citation %}
+    <cite><a href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout">MDN Web Docs</a></cite>
+  {% endif %}
+</blockquote>

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -6,6 +6,7 @@
 @use '../../../mixins/border-radius';
 @use '../../../mixins/button';
 @use '../../../mixins/emdash';
+@use '../../../mixins/headings';
 @use '../../../mixins/ms';
 @use '../../../mixins/ratio-box';
 @use '../../../mixins/spacing';
@@ -370,119 +371,124 @@ figure.wp-block-image {
   }
 }
 
-/**
- * Quote and Pull-quote
- * Styles for quotes and pull-quotes
- *
- * Note the `:not(.wp-block-pullquote) > blockquote` selectors are to
- * target vanilla `blockquote` elements in Markdown and HTML blocks.
- * We need to ensure they're not in a Pull Quote block so the standard
- * blockquote styles don't collide with the Pull Quote styles.
- */
+/// Quote and Pullquote shared block styles
 
-.wp-block-pullquote,
 .wp-block-quote,
-:not(.wp-block-pullquote) > blockquote {
-  color: var(--theme-color-text-muted);
+.wp-block-pullquote {
+  /// When the quote has text alignment other than left, we right-align the
+  /// citation styles so they don't disrupt the reading line.
+  &.has-text-align-center,
+  &.has-text-align-right {
+    cite {
+      text-align: end;
+
+      &::before {
+        margin-inline-end: 1ch;
+        position: static;
+      }
+    }
+  }
 }
 
-/**
- * 1. Reset bottom margin
- * 2. Reset padding
- * 3. Reset text alignment
- */
+/// Quote Block Styles
+
+.wp-block-quote {
+  /// We reset the left border and padding when the style is plain or when text
+  /// alignment or background color will differentiate the content on its own.
+  &.is-style-plain,
+  &.has-background,
+  &.has-text-align-center,
+  &.has-text-align-right {
+    border-inline-start-width: 0;
+    padding-inline-start: 0;
+  }
+
+  /// We reset the text color when the blockquote is plain
+
+  /// The plain style tries to make the blockquote appear more or less unstyled,
+  /// so we reset all of the defaults.
+  &.is-style-plain {
+    color: inherit;
+  }
+}
+
+/// Pullquote Block Styles
 
 .wp-block-pullquote {
-  @include border-radius.conditional;
-  background-color: var(--theme-color-background-secondary);
-  margin-block-end: 0; /* 1 */
-  padding: 0; /* 2 */
-  text-align: start; /* 3 */
-}
+  /// We use generous margins to differentiate the pull quote from adjacent
+  /// content. The core pattern uses padding for this, but we use margin so the
+  /// margin of adjacent elements won't needlessly stack.
+  margin: size.$rhythm-generous 0;
+  padding: 0;
 
-/**
- * Our default styles for the blockquote element include `padding-left`.
- * Pullquotes get padding on every side.
- */
-
-.wp-block-pullquote blockquote {
-  padding: ms.step(1);
-}
-
-/**
- * 1. Adjacent children of blockquotes have vertical spacing. Making `cite`
- *    a block level element so that it has the same spacing.
- */
-
-.wp-block-pullquote cite,
-.wp-block-quote cite,
-:not(.wp-block-pullquote) > blockquote cite {
-  display: block; /* 1 */
-  font-style: normal;
-}
-
-/**
- * Add an em dash before the citation.
- */
-
-.wp-block-pullquote cite::before,
-.wp-block-quote cite::before,
-:not(.wp-block-pullquote) > blockquote cite::before {
-  @include emdash.content;
-}
-
-/**
- * Makes the line-height more consistent with existing typographic styles.
- */
-
-.wp-block-pullquote,
-.wp-block-quote.is-large,
-.wp-block-quote.is-style-large {
-  p {
-    line-height: line-height.$tight;
+  /// Inherit parent element text by default instead of centering
+  &:not([class*='has-text-align']) {
+    text-align: inherit;
   }
-}
 
-/**
- * Reset the max-width so the text spans the width of the container.
- */
+  /// For alignments that exceed the content container, apply fluid padding
+  /// to maintain a consistent reading line.
+  &.alignwide,
+  &.alignfull {
+    @include spacing.fluid-padding-inline;
+  }
 
-.wp-block-pullquote.is-style-solid-color {
-  blockquote {
+  /// For alignment styles that cause the element to float, don't adjust the
+  /// element's appearance until a specific breakpoint.
+  &.alignleft,
+  &.alignright {
     max-inline-size: 100%;
-  }
-}
 
-.wp-block-pullquote,
-.wp-block-pullquote.is-style-solid-color blockquote {
+    /// At that breakpoint, omit the border, apply default margins to encourage
+    /// alignment with adjacent elements, and set a maximum width to prevent
+    /// this element from overwhelming its siblings.
+    @media (width >= breakpoint.$m) {
+      border-inline-start-width: 0;
+      margin: var(--rhythm, size.$rhythm-default) 0;
+      max-inline-size: 50%;
+    }
+  }
+
+  &.alignleft {
+    @media (width >= breakpoint.$m) {
+      float: left;
+      margin-inline-end: size.$rhythm-generous;
+    }
+  }
+
+  &.alignright {
+    @media (width >= breakpoint.$m) {
+      float: right;
+      margin-inline-start: size.$rhythm-generous;
+    }
+  }
+
+  /// We omit the typical blockquote border and padding because the text size,
+  /// margin and various alignment options will differentiate the element from
+  /// its siblings without. This also simplifies having to turn the border on
+  /// and off for the aforementioned alignment options.
+  blockquote {
+    border-inline-start-width: 0;
+    padding: 0;
+  }
+
+  /// Increase the typical font size for pull quotes
   p {
-    font-size: ms.step(1);
-  }
-}
-
-.wp-block-quote,
-:not(.wp-block-pullquote) > blockquote {
-  border-inline-start: size.$border-width-blockquote solid
-    var(--theme-color-border-text-group);
-}
-
-/**
-* 1. Reset margins and padding
-* 2. The quote itself defaults to being italic, this straightens out the quote
-*/
-.wp-block-quote.is-style-large,
-.wp-block-quote.is-large {
-  margin: 0; /* 1 */
-  padding-inline: ms.step(1) 0; /* 1 */
-
-  p {
-    font-size: ms.step(0);
-    font-style: normal; /* 2 */
+    @include headings.level(1, false);
   }
 
-  cite {
-    font-size: ms.step(0);
-    text-align: start;
+  /// Use a smaller font size when the pull quote is floating.
+  /// We're ignoring this selector because Stylelint thinks it's duplicating
+  /// the parent styles because it isn't seeing the nested selector.
+
+  /* stylelint-disable-next-line no-duplicate-selectors */
+  &.alignleft,
+  &.alignright {
+    p {
+      @media (width >= breakpoint.$m) {
+        @include headings.level(3, false);
+      }
+    }
   }
 }
 

--- a/src/vendor/wordpress/styles/_utilities.scss
+++ b/src/vendor/wordpress/styles/_utilities.scss
@@ -49,7 +49,8 @@
 ///    so that the inner content will align with its siblings.
 p,
 .wp-block-group,
-.wp-block-media-text {
+.wp-block-media-text,
+.wp-block-quote {
   &.has-background {
     padding: size.$rhythm-default; // 1
 


### PR DESCRIPTION
## Overview

Our revised marketing content contains a lot more testimonials than before. This exposed some issues with our current `blockquote` styles as well as dependencies, specifically:

- The default `blockquote` styles were probably _too_ lean: We were having to repeat the styles in comment content, markdown/classic blocks and the WordPress quote and pullquote blocks.
- In an attempt to preserve those lean, default styles, `:not` selectors were used to fence the WordPress block styles, but these were used too broadly, resulting in the opposite effect: The WordPress block styles were overriding _all_ `blockquote` elements as a result.
- The WordPress block styles were out of date, making them difficult to use.
- Citations did not break to a new line gracefully. 

This PR attempts to address that by:

- Expanding the default `blockquote` styles.
- Removing the comment, markdown and classic styles in favor of deferring to those defaults.
- Revising the WordPress quote styles to focus on the block features without leakage.

I've marked this as a "major" release because I know of several marketing pages with inline styles that will need to be simplified after this change takes effect.

## Screenshots

### Default blockquote

<img width="394" alt="Screenshot 2023-06-23 at 11 46 51 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/4ad3f2bf-0aee-49b6-9afd-eff7e066603c">

### WordPress quote block

<img width="476" alt="Screenshot 2023-06-23 at 11 47 39 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/073faad1-f7c8-497e-8593-ba395d479bdf">

The "plain" style omits the usual appearance, presumably for situations where a blockquote is the right semantic choice but shouldn't be differentiated from surrounding content:

<img width="474" alt="Screenshot 2023-06-23 at 11 47 48 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/03bd8904-dd5e-4923-b779-a6b58f0b169d">

Text alignment options are supported:

<img width="478" alt="Screenshot 2023-06-23 at 11 47 58 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/94777c0b-ef0a-43e7-bdc7-296d3e436b1e">

If the blockquote is given a background color, it will now behave similarly to paragraphs and groups instead of requiring inline styles to omit borders or adjust padding:

<img width="479" alt="Screenshot 2023-06-23 at 11 49 36 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/cdfd2584-4932-4c3b-98a0-793244cc2436">

### WordPress pullquote block

<img width="954" alt="Screenshot 2023-06-23 at 11 50 11 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/b198fe23-3b20-4807-83cf-c8c54cecb6ac">

Supports text alignment options:

<img width="958" alt="Screenshot 2023-06-23 at 11 50 33 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/c8d3c7e7-c2be-48b5-899a-629c174874a6">

As well as general alignment options:

<img width="956" alt="Screenshot 2023-06-23 at 11 51 17 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/924bf684-2deb-4fa2-b828-a53e7bf88a67">


## Testing

TODO

---

- Fixes #2161 
