### PR TITLE
Fix WordPress pullquote block sizing bug

### DIFF
--- a/.changeset/wise-points-sneeze.md
+++ b/.changeset/wise-points-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Prevent WordPress's default pullquote block styles from starting out too large

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -415,6 +415,15 @@ figure.wp-block-image {
 /// Pullquote Block Styles
 
 .wp-block-pullquote {
+  /// We have to reset the default text color and font size because Gutenberg
+  /// makes it really difficult to adjust the defaults without a complete switch
+  /// to using `theme.json`. These defaults are only exposed via inline styles
+  /// rather than the core block CSS, which makes them extra difficult to
+  /// troublehoot as well.
+  color: var(--theme-color-text-muted);
+  font-size: inherit;
+  line-height: inherit;
+
   /// We use generous margins to differentiate the pull quote from adjacent
   /// content. The core pattern uses padding for this, but we use margin so the
   /// margin of adjacent elements won't needlessly stack.


### PR DESCRIPTION
## Overview

It turns out that WordPress's default pullquote block styles are rather opinionated and will be injected into a page instead of in block library CSS. This resulted in the blockquotes being much larger than intended and the wrong text color by default.

Font size and text color may still be adjusted via the WordPress block options as before.

## Screenshots

Before | After
--- | ---
<img width="884" alt="Screenshot 2023-06-26 at 2 23 02 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/f29929b5-8566-4008-89f1-8ee27b36a37f"> | <img width="854" alt="Screenshot 2023-06-26 at 2 22 50 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/6824cc4e-edcc-4286-9514-3ade3aa9dabb">
