### PR TITLE
Improve inline code contrast

### DIFF
--- a/.changeset/six-bottles-retire.md
+++ b/.changeset/six-bottles-retire.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Inline code elements inside of lighter gray containers now have improved contrast.

--- a/src/base/_themes.scss
+++ b/src/base/_themes.scss
@@ -21,7 +21,7 @@
   --theme-color-border-text-group: var(--theme-color-border-base);
   --theme-color-text-action: #{color.$text-action};
   --theme-color-text-base: #{color.$text-dark};
-  --theme-color-text-code: #{color.$base-fuchsia};
+  --theme-color-text-code: #{color.$text-code};
   --theme-color-text-emphasis: var(--theme-color-text-base);
   --theme-color-text-muted: #{color.$text-dark-muted};
   --theme-opacity-del: #{opacity.$muted};

--- a/src/tokens/color/text.json
+++ b/src/tokens/color/text.json
@@ -20,6 +20,10 @@
       "action": {
         "value": "{color.base.blue.value}",
         "comment": "Accessible on white and lighter-gray."
+      },
+      "code": {
+        "value": "hsla(322, 98%, 40%, 0.94)",
+        "comment": "Similar to the base fuchsia, but accessible on white and lighter-gray."
       }
     }
   }


### PR DESCRIPTION
## Overview

Adds a new `color.$text-code` token containing an alpha-transparent version of our base fuchsia, which increases the contrast of inline code elements inside of lighter-gray containers from `4.32` to `4.56`.

## Screenshots

Before | After
--- | ---
<img width="692" alt="Screenshot 2023-07-24 at 10 44 53 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/cc2e6c91-91ed-4eb9-bd51-5feb15510297"> | <img width="692" alt="Screenshot 2023-07-24 at 10 45 27 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/f3ab2ce4-0614-436d-adbb-11da98a57ee1">
<img width="692" alt="Screenshot 2023-07-24 at 10 45 05 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/91d66af9-89ee-4853-a9d3-5dbf93677578"> | <img width="694" alt="Screenshot 2023-07-24 at 10 45 37 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/44d6bd85-7563-4192-9245-f9a242ccde95">

## Testing

1. Open up [the inline element story](https://deploy-preview-2182--cloudfour-patterns.netlify.app/?path=/story/design-defaults--inline-elements) in "Canvas" view.
2. Set the "Theme" dropdown to "Light Alt"
3. Open the "Accessibility" tab in Storybook. Insure that there are no violations, especially no "Elements must have sufficient color contrast" violations.
4. Because the color is alpha-transparent, the Accessibility test mentioned in the previous step may show one as "Incomplete." You can use a contrast checker like [Pika](https://superhighfives.com/pika) to confirm sufficient contrast.

---

- Fixes #2181