### PR TITLE
Fix for WordPress "small" utility conflict

### DIFF
--- a/.changeset/dirty-deers-turn.md
+++ b/.changeset/dirty-deers-turn.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Prevent WordPress from overriding the "small" font size utility styles.

--- a/src/mixins/_font-size.scss
+++ b/src/mixins/_font-size.scss
@@ -17,6 +17,13 @@
 /// To prevent small text from impairing readability (most importantly) and our
 /// Core Web Vitals (secondarily), we only apply the small font size if it isn't
 /// smaller than 16 pixels.
-@mixin small {
-  font-size: max(16px, size.$font-small);
+///
+/// @param {Boolean} $important - Whether or not to output the rule with an
+/// `!important` flag. Added to satisfy WordPress 5.9+.
+@mixin small($important: false) {
+  @if $important {
+    font-size: max(16px, size.$font-small) !important;
+  } @else {
+    font-size: max(16px, size.$font-small);
+  }
 }

--- a/src/mixins/_font-size.scss
+++ b/src/mixins/_font-size.scss
@@ -20,6 +20,7 @@
 ///
 /// @param {Boolean} $important - Whether or not to output the rule with an
 /// `!important` flag. Added to satisfy WordPress 5.9+.
+/// @link https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/
 @mixin small($important: false) {
   @if $important {
     font-size: max(16px, size.$font-small) !important;

--- a/src/vendor/wordpress/styles/_utilities.scss
+++ b/src/vendor/wordpress/styles/_utilities.scss
@@ -82,8 +82,15 @@ $color-map: meta.module-variables('color-base');
   @include font-size.big;
 }
 
+/// We need to use `!important` because otherwise WordPress will override this
+/// size as of version 5.9. We could get around this by setting the font size
+/// via `theme.json`, but that would make this an outlier among our other sizes,
+/// so for now we'll just use `!important`.
+///
+/// @link https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/
+
 .has-small-font-size {
-  @include font-size.small;
+  @include font-size.small($important: true);
 }
 
 @for $level from -2 through 3 {


### PR DESCRIPTION
## Overview

[WordPress 5.9 introduced a change to the way that font size classes work](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/). Instead of outputting the classes themselves, they output custom properties with the values as they saw them. While this _should_ make overriding easier, they also made the utility classes use `!important`, so they actually are overriding more aggressively than before.

I researched a few different solutions:

- [WordPress recommends that theme devs style the custom property instead of the class](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#block-font-sizes). Unfortunately, this is not sufficient because the custom property they are outputting gets injected into the `head` after any enqueued stylesheets, so the property is always overridden.
- We could update our token value to include the full `max` function, which would get passed to WordPress's font size configuration alongside our heading styles and the like. Unfortunately, we are using the "small" token somewhat inconsistently across various patterns, so this carries the most risk when it comes to regressions.
- We could manually add the new `small` value to WordPress's theme configuration, but that would mean maintaining the value in separate places.
- We could just add `!important` to our WordPress utility.

I went with the last one.

(Note: In theory, this should also be affecting other text utilities. But it seems that WordPress recently moved away from the "big" font size terminology, so "small" is the only one that overlaps with a WordPress default.)

## Testing

1. Open [the story for our non-WordPress text size utilities](https://deploy-preview-2183--cloudfour-patterns.netlify.app/?path=/story/utilities-text--big-and-small). Inspect the utility and confirm that its `font-size` is set to `max(16px, 0.8em)` _without_ an `!important` flag.
2. Open [the story for our WordPress text size utilities](https://deploy-preview-2183--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-utilities--font-size&args=font_size:small). Using Storybook's controls, set the size to "small" and inspect the element. Confirm that its `font-size` is `max(16px, 0.8em)` _with_ an `!important` flag.

---

- See https://github.com/cloudfour/cloudfour.com-wp/issues/1039