### PR TITLE
Increase label contrast in dark theme

### DIFF
--- a/.changeset/metal-sloths-help.md
+++ b/.changeset/metal-sloths-help.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Increases contrast of `label` element text inside of dark theme containers.

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -309,6 +309,14 @@ address {
 }
 
 /**
+ * Labels
+ */
+
+label {
+  color: var(--theme-color-text-label);
+}
+
+/**
  * Horizontal rules
  *
  * We use border styles and `currentColor` for greater compatibility with

--- a/src/base/_themes.scss
+++ b/src/base/_themes.scss
@@ -23,6 +23,7 @@
   --theme-color-text-base: #{color.$text-dark};
   --theme-color-text-code: #{color.$text-code};
   --theme-color-text-emphasis: var(--theme-color-text-base);
+  --theme-color-text-label: inherit;
   --theme-color-text-muted: #{color.$text-dark-muted};
   --theme-opacity-del: #{opacity.$muted};
 }
@@ -42,6 +43,7 @@
   --theme-color-text-base: #{color.$text-light};
   --theme-color-text-code: var(--theme-color-text-emphasis);
   --theme-color-text-emphasis: #{color.$text-light-emphasis};
+  --theme-color-text-label: var(--theme-color-text-emphasis);
   --theme-color-text-muted: #{color.$text-light};
   --theme-opacity-del: 1;
 }


### PR DESCRIPTION
## Overview

When designing a new newsletter signup block I noticed that label text felt a little low-contrast compared to in the light theme. This applies the emphasized text color to those elements when the dark theme is applied.

## Screenshots

<img width="416" alt="Screenshot 2023-08-14 at 2 19 35 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/e208c320-2f33-4f2c-8d2c-08cd10cf1c23">

## Testing

1. On the deploy preview, view [the Objects / Form Group story](https://deploy-preview-2185--cloudfour-patterns.netlify.app/?path=/story/objects-form-group--basic).
2. Using the 🖌️  icon in Storybook, switch to the "dark" or "dark alternate" themes.
3. Confirm that the label text is fully opaque white.
