### PR TITLE
Add styles for Mailchimp signup forms

### DIFF
--- a/.changeset/quiet-news-impress.md
+++ b/.changeset/quiet-news-impress.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add styles for Mailchimp signup forms.

--- a/src/vendor/mailchimp/_mailchimp.scss
+++ b/src/vendor/mailchimp/_mailchimp.scss
@@ -1,0 +1,49 @@
+@use '../../mixins/button';
+@use '../../mixins/input';
+@use '../../mixins/ms';
+@use '../../mixins/spacing';
+@use '../../compiled/tokens/scss/size';
+
+/// Mailchimp form customizations
+///
+/// These assume Mailchimp's CSS is not included.
+///
+/// @link https://mailchimp.com/help/css-hooks-for-customizing-forms/
+/// @link https://mailchimp.com/help/customize-embedded-signup-form/
+
+#mc_embed_signup_scroll {
+  @include spacing.vertical-rhythm;
+}
+
+#mc_embed_shell {
+  .indicates-required {
+    color: var(--theme-color-text-muted);
+    font-size: ms.step(-1);
+    text-align: end;
+
+    + * {
+      margin-block-start: 0;
+    }
+  }
+
+  .mc-field-group {
+    display: grid;
+    gap: #{size.$spacing-gap-form-group-default};
+  }
+
+  input {
+    &:not([type='checkbox']):not([type='radio']):not([type='submit']):not(
+        [type='hidden']
+      ) {
+      @include input.default;
+    }
+  }
+
+  .button {
+    @include button.default;
+  }
+
+  .asterisk {
+    color: var(--theme-color-icon-error);
+  }
+}

--- a/src/vendor/mailchimp/demo/signup.twig
+++ b/src/vendor/mailchimp/demo/signup.twig
@@ -1,0 +1,102 @@
+<div class="o-container o-container--pad o-container--prose">
+  <div class="o-container__content o-rhythm">
+    <div id="mc_embed_shell">
+      <div id="mc_embed_signup">
+        <form
+          action="#"
+          method="post"
+          id="mc-embedded-subscribe-form"
+          name="mc-embedded-subscribe-form"
+          class="validate"
+          target="_self"
+          novalidate=""
+        >
+          <div id="mc_embed_signup_scroll">
+            <div class="c-heading c-heading--level-2 c-heading--with-permalink">
+              <div class="c-heading__main">
+                <a
+                  class="c-heading__permalink"
+                  href="#download-the-checklist-and-get-cloud-four-in-your-inbox"
+                >
+                  <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                    class="c-icon"
+                  >
+                    <path
+                      d="M13.68 10.17L13 9.5a3.8 3.8 0 00-5.37 0l-4 4a3.79 3.79 0 000 5.37l1.33 1.33a3.81 3.81 0 005.38 0l1.34-1.34"
+                      fill="none"
+                      stroke-linecap="round"
+                      stroke-width="2"
+                    ></path>
+                    <path
+                      d="M10.32 13.53l.67.67a3.79 3.79 0 005.37 0l4-4a3.81 3.81 0 000-5.38l-1.3-1.36a3.81 3.81 0 00-5.38 0L12.34 4.8"
+                      fill="none"
+                      stroke-linecap="round"
+                      stroke-width="2"
+                    ></path>
+                  </svg>
+                  <span class="u-hidden-visually"
+                    >Permalink to Download the checklist and get Cloud Four in
+                    your inbox</span
+                  >
+                </a>
+                <h2
+                  class="c-heading__content"
+                  id="download-the-checklist-and-get-cloud-four-in-your-inbox"
+                >
+                  Download the checklist and get Cloud Four in your inbox
+                </h2>
+              </div>
+            </div>
+
+            <div class="indicates-required">
+              <span class="asterisk">*</span> indicates required
+            </div>
+            <div class="mc-field-group">
+              <label for="mce-EMAIL"
+                >Email Address <span class="asterisk">*</span></label
+              ><input
+                type="email"
+                name="EMAIL"
+                class="required email"
+                id="mce-EMAIL"
+                required=""
+                value=""
+              />
+            </div>
+            <div hidden="">
+              <input type="hidden" name="tags" value="EXAMPLE" />
+            </div>
+            <div id="mce-responses" class="clear">
+              <div
+                class="response"
+                id="mce-error-response"
+                style="display: none"
+              ></div>
+              <div
+                class="response"
+                id="mce-success-response"
+                style="display: none"
+              ></div>
+            </div>
+            <div aria-hidden="true" style="position: absolute; left: -5000px">
+              <input type="text" name="EXAMPLE" tabindex="-1" value="" />
+            </div>
+            <div class="clear">
+              <input
+                type="submit"
+                name="subscribe"
+                id="mc-embedded-subscribe"
+                class="button"
+                value="Subscribe"
+              />
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/vendor/mailchimp/mailchimp.stories.mdx
+++ b/src/vendor/mailchimp/mailchimp.stories.mdx
@@ -1,0 +1,17 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import signupDemo from './demo/signup.twig';
+
+<Meta
+  title="Vendor/Mailchimp"
+  parameters={{
+    layout: 'fullscreen',
+  }}
+/>
+
+# Mailchimp
+
+For convenience, we apply some default styles to Mailchimp signup forms. These assume that the "Remove CSS styles" option has been checked when [building the form](https://mailchimp.com/help/customize-embedded-signup-form/#Customize_your_embedded_form).
+
+<Canvas>
+  <Story name="Signup Form">{signupDemo.bind(this)}</Story>
+</Canvas>


### PR DESCRIPTION
## Overview

This includes some custom styles for Mailchimp signup forms so custom forms may be embedded without requiring Mailchimp styles or custom block development. Custom? Custom.

## Screenshots

<img width="1070" alt="Screenshot 2023-08-17 at 2 38 47 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/4750f8f4-c76f-4a19-817f-514c9bf8b7df">

## Testing

Review [deploy preview](https://deploy-preview-2187--cloudfour-patterns.netlify.app/?path=/docs/vendor-mailchimp--signup-form)

