### PR TITLE
Mailchimp spacing fix

### DIFF
--- a/.changeset/spicy-badgers-wait.md
+++ b/.changeset/spicy-badgers-wait.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fixes Mailchimp forms appearing inconsistently spaced with adjacent content.

--- a/src/vendor/mailchimp/_mailchimp.scss
+++ b/src/vendor/mailchimp/_mailchimp.scss
@@ -13,6 +13,19 @@
 
 #mc_embed_signup_scroll {
   @include spacing.vertical-rhythm;
+
+  /// If the form is not the first item in a rhythm container and its first
+  /// child is not `1em` in font size, it can cause the form contents to look
+  /// inconsistent with surrounding content in terms of spacing. (Luckily, this
+  /// and the parent margin should collapse so there's no need to override the
+  /// container margin.)
+  #mc_embed_shell:not(:first-child) & > :first-child {
+    margin-block-start: var(--rhythm);
+
+    &:where(h1, h2, h3, h4, h5, h6, [class*='heading']) {
+      margin-block-start: var(--rhythm-headings, var(--rhythm));
+    }
+  }
 }
 
 #mc_embed_shell {

--- a/src/vendor/mailchimp/demo/signup.twig
+++ b/src/vendor/mailchimp/demo/signup.twig
@@ -1,5 +1,10 @@
 <div class="o-container o-container--pad o-container--prose">
-  <div class="o-container__content o-rhythm">
+  <div class="o-container__content o-rhythm o-rhythm--generous-headings">
+    {% if show_example_content %}
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vestibulum ut erat at suscipit. Aliquam viverra velit quam, sed condimentum ante posuere quis.</p>
+      <h2>Example Heading</h2>
+      <p>Morbi iaculis nisi at dolor pharetra, ut tempus purus porta. Sed condimentum est eu orci hendrerit suscipit. Vestibulum nec ex nisi.</p>
+    {% endif %}
     <div id="mc_embed_shell">
       <div id="mc_embed_signup">
         <form
@@ -12,45 +17,16 @@
           novalidate=""
         >
           <div id="mc_embed_signup_scroll">
-            <div class="c-heading c-heading--level-2 c-heading--with-permalink">
-              <div class="c-heading__main">
-                <a
-                  class="c-heading__permalink"
-                  href="#download-the-checklist-and-get-cloud-four-in-your-inbox"
-                >
-                  <svg
-                    width="24"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                    class="c-icon"
-                  >
-                    <path
-                      d="M13.68 10.17L13 9.5a3.8 3.8 0 00-5.37 0l-4 4a3.79 3.79 0 000 5.37l1.33 1.33a3.81 3.81 0 005.38 0l1.34-1.34"
-                      fill="none"
-                      stroke-linecap="round"
-                      stroke-width="2"
-                    ></path>
-                    <path
-                      d="M10.32 13.53l.67.67a3.79 3.79 0 005.37 0l4-4a3.81 3.81 0 000-5.38l-1.3-1.36a3.81 3.81 0 00-5.38 0L12.34 4.8"
-                      fill="none"
-                      stroke-linecap="round"
-                      stroke-width="2"
-                    ></path>
-                  </svg>
-                  <span class="u-hidden-visually"
-                    >Permalink to Download the checklist and get Cloud Four in
-                    your inbox</span
-                  >
-                </a>
-                <h2
-                  class="c-heading__content"
-                  id="download-the-checklist-and-get-cloud-four-in-your-inbox"
-                >
-                  Download the checklist and get Cloud Four in your inbox
-                </h2>
-              </div>
-            </div>
+            {% if transform_heading %}
+              {% include '@cloudfour/components/heading/heading.twig' with {
+                "content": "Download the checklist and get Cloud Four in your inbox",
+                "level": 2,
+                "permalink": true,
+                "id": "mailchimp-heading"
+              } only %}
+            {% else %}
+              <h2>Download the checklist and get Cloud Four in your inbox</h2>
+            {% endif %}
 
             <div class="indicates-required">
               <span class="asterisk">*</span> indicates required

--- a/src/vendor/mailchimp/mailchimp.stories.mdx
+++ b/src/vendor/mailchimp/mailchimp.stories.mdx
@@ -13,5 +13,21 @@ import signupDemo from './demo/signup.twig';
 For convenience, we apply some default styles to Mailchimp signup forms. These assume that the "Remove CSS styles" option has been checked when [building the form](https://mailchimp.com/help/customize-embedded-signup-form/#Customize_your_embedded_form).
 
 <Canvas>
-  <Story name="Signup Form">{signupDemo.bind(this)}</Story>
+  <Story
+    name="Signup Form"
+    argTypes={{
+      show_example_content: {
+        control: {
+          type: 'boolean',
+        },
+      },
+      transform_heading: {
+        control: {
+          type: 'boolean',
+        },
+      },
+    }}
+  >
+    {signupDemo.bind(this)}
+  </Story>
 </Canvas>


### PR DESCRIPTION
## Overview

When using a Mailchimp form within an article, the heading appeared much closer to the preceding content than intended. This was because the vertical rhythm was not being applied to the first child, which was usually a heading that exceeded `1em` in size.

This applies the initial vertical padding to the first element as long as the Mailchimp form is not the `:first-child` of its container.

## Screenshots

Before | After
--- | ---
<img width="476" alt="Screenshot 2023-08-21 at 4 09 44 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/aa5e4ff5-a75a-41c3-851e-4a8aa4a856d5"> | <img width="482" alt="Screenshot 2023-08-21 at 4 09 55 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/722b2fa4-07ba-48e3-bcbe-1b6c4e598e5d">

## Testing

- [x] Open [the Mailchimp Sign-up form story on the deploy preview](https://deploy-preview-2190--cloudfour-patterns.netlify.app/?path=/story/vendor-mailchimp--signup-form) in "Canvas" view.
- [x] Confirm that the Mailchimp form and the heading do not have top margin.
- [x] In the Storybook controls, toggle `show_example_content` to `true`. Confirm that the spacing that precedes the "Example Heading" is the same as the form heading.
- [x] In the Storybook controls, toggle `transform_heading` to `true`. Confirm that the spacing is the same as in the previous testing step.
