### PR TITLE
[NO MERGE] New Footer Prototypes

### DIFF
--- a/src/assets/illustrations/portland.svg
+++ b/src/assets/illustrations/portland.svg
@@ -1,67 +1,67 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="450" height="200" viewBox="0 0 450 200">
+<svg xmlns="http://www.w3.org/2000/svg" width="450" height="200" viewBox="0 0 450 200" preserveAspectRatio="xMaxYMax">
   <g>
-    <rect x="4" y="60" width="125" height="140" fill="#dae2e8"/>
-    <rect x="4" y="170" width="125" height="30" fill="#f2f5f7"/>
-    <rect x="0" y="60" width="129" height="15" fill="#dae2e8"/>
-    <rect x="4" y="75" width="125" height="3" fill="#c0cfd8"/>
+    <rect x="4" y="60" width="125" height="140" fill="#dae2e8" />
+    <rect x="4" y="170" width="125" height="30" fill="#f2f5f7" />
+    <rect x="0" y="60" width="129" height="15" fill="#dae2e8" />
+    <rect x="4" y="75" width="125" height="3" fill="#c0cfd8" />
   </g>
   <g>
-    <rect x="233.1" y="30" width="98" height="170" fill="#dae2e8"/>
-    <rect x="233.1" y="40" width="98" height="3" fill="#c0cfd8"/>
+    <rect x="233.1" y="30" width="98" height="170" fill="#dae2e8" />
+    <rect x="233.1" y="40" width="98" height="3" fill="#c0cfd8" />
   </g>
   <g>
-    <rect x="330.6" y="60.5" width="91.8" height="139.1" fill="#dae2e8"/>
-    <rect x="358.6" y="69.5" width="13.5" height="23.8" fill="#c0cfd8"/>
-    <rect x="380.8" y="69.5" width="13.5" height="23.8" fill="#c0cfd8"/>
-    <rect x="403" y="69.5" width="13.5" height="23.8" fill="#c0cfd8"/>
-    <rect x="380.8" y="101.9" width="13.5" height="23.8" fill="#c0cfd8"/>
-    <rect x="403" y="101.9" width="13.5" height="23.8" fill="#c0cfd8"/>
+    <rect x="330.6" y="60.5" width="91.8" height="139.1" fill="#dae2e8" />
+    <rect x="358.6" y="69.5" width="13.5" height="23.8" fill="#c0cfd8" />
+    <rect x="380.8" y="69.5" width="13.5" height="23.8" fill="#c0cfd8" />
+    <rect x="403" y="69.5" width="13.5" height="23.8" fill="#c0cfd8" />
+    <rect x="380.8" y="101.9" width="13.5" height="23.8" fill="#c0cfd8" />
+    <rect x="403" y="101.9" width="13.5" height="23.8" fill="#c0cfd8" />
   </g>
   <g>
-    <rect x="129.1" y="0" width="104" height="200" fill="#a4cdff"/>
-    <rect x="139.1" y="10" width="22.7" height="54.7" fill="#72adfc"/>
-    <rect x="169.8" y="10" width="22.7" height="54.7" fill="#72adfc"/>
-    <rect x="200.5" y="10" width="22.7" height="54.7" fill="#72adfc"/>
-    <rect x="139.1" y="72.7" width="22.7" height="54.7" fill="#72adfc"/>
-    <rect x="169.8" y="72.7" width="22.7" height="54.7" fill="#72adfc"/>
-    <rect x="200.5" y="72.7" width="22.7" height="54.7" fill="#72adfc"/>
-    <rect x="139.1" y="140.2" width="17.4" height="49.8" fill="#72adfc"/>
-    <rect x="169.8" y="135.3" width="22.7" height="54.7" fill="#72adfc"/>
-    <rect x="200.5" y="135.3" width="22.7" height="54.7" fill="#72adfc"/>
+    <rect x="129.1" y="0" width="104" height="200" fill="#a4cdff" />
+    <rect x="139.1" y="10" width="22.7" height="54.7" fill="#72adfc" />
+    <rect x="169.8" y="10" width="22.7" height="54.7" fill="#72adfc" />
+    <rect x="200.5" y="10" width="22.7" height="54.7" fill="#72adfc" />
+    <rect x="139.1" y="72.7" width="22.7" height="54.7" fill="#72adfc" />
+    <rect x="169.8" y="72.7" width="22.7" height="54.7" fill="#72adfc" />
+    <rect x="200.5" y="72.7" width="22.7" height="54.7" fill="#72adfc" />
+    <rect x="139.1" y="140.2" width="17.4" height="49.8" fill="#72adfc" />
+    <rect x="169.8" y="135.3" width="22.7" height="54.7" fill="#72adfc" />
+    <rect x="200.5" y="135.3" width="22.7" height="54.7" fill="#72adfc" />
   </g>
-  <polygon points="250.8,200 336.5,0 422.2,200" fill="#71f4ae"/>
+  <polygon points="250.8,200 336.5,0 422.2,200" fill="#71f4ae" />
   <g>
-    <polygon points="198.1,200 249.2,80.7 300.3,200" fill="#2cdd90"/>
-    <line x1="249.2" y1="136" x2="249.2" y2="200" fill="none" stroke="#f2f5f7" stroke-width="5"/>
-    <line x1="249.2" y1="161.8" x2="266.5" y2="147.9" fill="none" stroke="#f2f5f7" stroke-width="5"/>
-    <line x1="249.2" y1="179.8" x2="266.5" y2="165.9" fill="none" stroke="#f2f5f7" stroke-width="5"/>
-    <line x1="231.8" y1="156.9" x2="249.2" y2="170.8" fill="none" stroke="#f2f5f7" stroke-width="5"/>
-  </g>
-  <g>
-    <polygon points="52.4,200 120.6,41 188.7,200" fill="#2cdd90"/>
-    <line x1="120.6" y1="105.8" x2="120.6" y2="200" fill="none" stroke="#f2f5f7" stroke-width="5"/>
-    <line x1="120.6" y1="141.1" x2="144.1" y2="122.3" fill="none" stroke="#f2f5f7" stroke-width="5"/>
-    <line x1="120.6" y1="164.7" x2="144.1" y2="145.8" fill="none" stroke="#f2f5f7" stroke-width="5"/>
-    <line x1="97" y1="134.1" x2="120.6" y2="152.9" fill="none" stroke="#f2f5f7" stroke-width="5"/>
+    <polygon points="198.1,200 249.2,80.7 300.3,200" fill="#2cdd90" />
+    <line x1="249.2" y1="136" x2="249.2" y2="200" fill="none" stroke="#f2f5f7" stroke-width="5" />
+    <line x1="249.2" y1="161.8" x2="266.5" y2="147.9" fill="none" stroke="#f2f5f7" stroke-width="5" />
+    <line x1="249.2" y1="179.8" x2="266.5" y2="165.9" fill="none" stroke="#f2f5f7" stroke-width="5" />
+    <line x1="231.8" y1="156.9" x2="249.2" y2="170.8" fill="none" stroke="#f2f5f7" stroke-width="5" />
   </g>
   <g>
-    <rect x="320" y="118" width="129.9" height="82" fill="#72adfc"/>
-    <rect x="320" y="118" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="320.2" y="184.4" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="320.2" y="135.6" width="23.9" height="46.7" fill="#a4cdff"/>
-    <rect x="346.5" y="118" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="346.7" y="184.4" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="346.7" y="135.6" width="23.9" height="46.7" fill="#a4cdff"/>
-    <rect x="373" y="118" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="373.1" y="184.4" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="373.1" y="135.6" width="23.9" height="46.7" fill="#a4cdff"/>
-    <rect x="399.5" y="118" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="399.6" y="184.4" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="399.6" y="135.6" width="23.9" height="46.7" fill="#a4cdff"/>
-    <rect x="426" y="118" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="426.1" y="184.4" width="23.9" height="15.6" fill="#a4cdff"/>
-    <rect x="426.1" y="135.6" width="23.9" height="46.7" fill="#a4cdff"/>
-    <rect x="320.1" y="118" width="129.9" height="6" fill="#5596f8"/>
-    <rect x="320" y="108" width="130" height="10" fill="#72adfc"/>
+    <polygon points="52.4,200 120.6,41 188.7,200" fill="#2cdd90" />
+    <line x1="120.6" y1="105.8" x2="120.6" y2="200" fill="none" stroke="#f2f5f7" stroke-width="5" />
+    <line x1="120.6" y1="141.1" x2="144.1" y2="122.3" fill="none" stroke="#f2f5f7" stroke-width="5" />
+    <line x1="120.6" y1="164.7" x2="144.1" y2="145.8" fill="none" stroke="#f2f5f7" stroke-width="5" />
+    <line x1="97" y1="134.1" x2="120.6" y2="152.9" fill="none" stroke="#f2f5f7" stroke-width="5" />
+  </g>
+  <g>
+    <rect x="320" y="118" width="129.9" height="82" fill="#72adfc" />
+    <rect x="320" y="118" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="320.2" y="184.4" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="320.2" y="135.6" width="23.9" height="46.7" fill="#a4cdff" />
+    <rect x="346.5" y="118" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="346.7" y="184.4" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="346.7" y="135.6" width="23.9" height="46.7" fill="#a4cdff" />
+    <rect x="373" y="118" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="373.1" y="184.4" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="373.1" y="135.6" width="23.9" height="46.7" fill="#a4cdff" />
+    <rect x="399.5" y="118" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="399.6" y="184.4" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="399.6" y="135.6" width="23.9" height="46.7" fill="#a4cdff" />
+    <rect x="426" y="118" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="426.1" y="184.4" width="23.9" height="15.6" fill="#a4cdff" />
+    <rect x="426.1" y="135.6" width="23.9" height="46.7" fill="#a4cdff" />
+    <rect x="320.1" y="118" width="129.9" height="6" fill="#5596f8" />
+    <rect x="320" y="108" width="130" height="10" fill="#72adfc" />
   </g>
 </svg>

--- a/src/prototypes/new-footer/new-footer.stories.js
+++ b/src/prototypes/new-footer/new-footer.stories.js
@@ -150,9 +150,9 @@ export const r3 = () =>
       {
         icon: 'brands/linkedin',
       },
-      {
-        icon: 'brands/mastodon',
-      },
+      // {
+      //   icon: 'brands/mastodon',
+      // },
       {
         icon: 'brands/youtube',
       },

--- a/src/prototypes/new-footer/new-footer.stories.js
+++ b/src/prototypes/new-footer/new-footer.stories.js
@@ -1,0 +1,12 @@
+import r1Prototype from './r1.twig';
+import './r1.scss';
+
+export default {
+  title: 'Prototypes/New Footer',
+  parameters: {
+    docs: { page: null },
+    layout: 'fullscreen',
+  },
+};
+
+export const r1 = () => r1Prototype({});

--- a/src/prototypes/new-footer/new-footer.stories.js
+++ b/src/prototypes/new-footer/new-footer.stories.js
@@ -1,7 +1,9 @@
 import r1Prototype from './r1.twig';
 import r2Prototype from './r2.twig';
+import r3Prototype from './r3.twig';
 import './r1.scss';
 import './r2.scss';
+import './r3.scss';
 
 export default {
   title: 'Prototypes/New Footer',
@@ -15,6 +17,81 @@ export const r1 = () => r1Prototype({});
 
 export const r2 = () =>
   r2Prototype({
+    organization: {
+      name: 'Cloud Four, Inc.',
+      url: 'https://cloudfour.com/',
+      address1: '510 SW 3rd Ave, Suite 420',
+      address2: 'Portland, OR 97204 USA',
+      phone: '+1 (503) 290-1090',
+      email: 'info@cloudfour.com',
+    },
+    nav: [
+      {
+        title: 'What We Do',
+      },
+      {
+        title: 'Our Approach',
+      },
+      {
+        title: 'Our Work',
+      },
+      {
+        title: 'Articles',
+      },
+      {
+        title: 'Speaking',
+      },
+      {
+        title: 'Team',
+      },
+      {
+        title: 'Hire Us',
+      },
+    ],
+    topics: [
+      {
+        title: 'Responsive Web Design',
+      },
+      {
+        title: 'Ecommerce',
+      },
+      {
+        title: 'Performance',
+      },
+      {
+        title: 'Images',
+      },
+      {
+        title: 'Accessibility',
+      },
+      {
+        title: 'Cloud Four Spotlight',
+      },
+      {
+        title: 'CSS',
+      },
+    ],
+    social: [
+      {
+        icon: 'brands/linkedin',
+      },
+      {
+        icon: 'brands/mastodon',
+      },
+      {
+        icon: 'brands/youtube',
+      },
+      {
+        icon: 'brands/instagram',
+      },
+      {
+        icon: 'feed',
+      },
+    ],
+  });
+
+export const r3 = () =>
+  r3Prototype({
     organization: {
       name: 'Cloud Four, Inc.',
       url: 'https://cloudfour.com/',

--- a/src/prototypes/new-footer/new-footer.stories.js
+++ b/src/prototypes/new-footer/new-footer.stories.js
@@ -1,5 +1,7 @@
 import r1Prototype from './r1.twig';
+import r2Prototype from './r2.twig';
 import './r1.scss';
+import './r2.scss';
 
 export default {
   title: 'Prototypes/New Footer',
@@ -10,3 +12,78 @@ export default {
 };
 
 export const r1 = () => r1Prototype({});
+
+export const r2 = () =>
+  r2Prototype({
+    organization: {
+      name: 'Cloud Four, Inc.',
+      url: 'https://cloudfour.com/',
+      address1: '510 SW 3rd Ave, Suite 420',
+      address2: 'Portland, OR 97204 USA',
+      phone: '+1 (503) 290-1090',
+      email: 'info@cloudfour.com',
+    },
+    nav: [
+      {
+        title: 'What We Do',
+      },
+      {
+        title: 'Our Approach',
+      },
+      {
+        title: 'Our Work',
+      },
+      {
+        title: 'Articles',
+      },
+      {
+        title: 'Speaking',
+      },
+      {
+        title: 'Team',
+      },
+      {
+        title: 'Hire Us',
+      },
+    ],
+    topics: [
+      {
+        title: 'Responsive Web Design',
+      },
+      {
+        title: 'Ecommerce',
+      },
+      {
+        title: 'Performance',
+      },
+      {
+        title: 'Images',
+      },
+      {
+        title: 'Accessibility',
+      },
+      {
+        title: 'Cloud Four Spotlight',
+      },
+      {
+        title: 'CSS',
+      },
+    ],
+    social: [
+      {
+        icon: 'brands/linkedin',
+      },
+      {
+        icon: 'brands/mastodon',
+      },
+      {
+        icon: 'brands/youtube',
+      },
+      {
+        icon: 'brands/instagram',
+      },
+      {
+        icon: 'feed',
+      },
+    ],
+  });

--- a/src/prototypes/new-footer/r1.scss
+++ b/src/prototypes/new-footer/r1.scss
@@ -1,0 +1,164 @@
+@use '../../compiled/tokens/scss/breakpoint';
+@use '../../compiled/tokens/scss/color';
+@use '../../compiled/tokens/scss/font-weight';
+@use '../../compiled/tokens/scss/size';
+@use '../../mixins/border-radius';
+@use '../../mixins/ms';
+@use '../../mixins/spacing';
+
+._new-footer {
+  display: grid;
+  margin-top: 6vh;
+}
+
+._new-footer::before {
+  content: '';
+  background: linear-gradient(to top, var(--theme-color-background-secondary) 0% 50%, transparent 50%);
+  grid-column: 1;
+  grid-row: 1;
+}
+
+._new-footer__primary {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+@media (min-width: breakpoint.$l) {
+  ._new-footer__primary {
+    @include border-radius.conditional;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+
+    margin: 0 auto;
+    max-inline-size: (size.$max-width-spread + 6em);
+    contain: paint;
+  }
+}
+
+._new-footer__newsletter,
+._new-footer__newsletter > *,
+._new-footer__newsletter > * > * {
+  display: grid;
+}
+
+._new-footer__newsletter>*,
+._new-footer__newsletter>*>* {
+  width: 100%;
+}
+
+._new-footer__newsletter form {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) minmax(0, auto);
+}
+
+._new-footer__secondary {
+  --theme-color-text-base: var(--theme-color-text-muted);
+}
+
+._new-footer__secondary a {
+  text-decoration-color: color.$base-blue-lighter;
+  text-decoration-thickness: 1px;
+}
+
+._new-footer__heading {
+  color: inherit;
+  font: inherit;
+  font-weight: font-weight.$medium;
+}
+
+._new-footer__secondary > * > * {
+  display: grid;
+  gap: spacing.$fluid-gap;
+  grid-template-areas: "contact"
+    "nav"
+    "articles"
+    "social"
+    "byline";
+    position: relative;
+
+  @media (width >= breakpoint.$m) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    // grid-template-rows: repeat(3, minmax(0, auto));
+    grid-template-areas: "contact contact"
+      "nav articles"
+      "social social"
+      "byline byline";
+  }
+
+  @media (width >= breakpoint.$l) {
+    grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(0, auto);
+    grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+    grid-template-areas: "contact nav articles . social"
+      "contact nav articles . ."
+      "byline nav articles . .";
+    row-gap: 0;
+  //   grid-template-rows: repeat(2, minmax(0, auto));
+  //   grid-template-areas: "nav articles contact social"
+  //     "byline byline byline byline";
+  //     white-space: nowrap;
+  }
+}
+
+// @media (width >=breakpoint.$m) {
+
+  ._new-footer__nav {
+    grid-area: nav;
+  }
+
+  ._new-footer__articles {
+    grid-area: articles;
+  }
+
+  ._new-footer__contact {
+    grid-area: contact;
+  }
+
+  ._new-footer__social {
+    grid-area: social;
+  }
+
+  ._new-footer__search {
+    grid-area: search;
+  }
+
+  ._new-footer__byline {
+    // align-self: baseline;
+    grid-area: byline;
+    // justify-self: end;
+  }
+
+// }
+
+._new-footer__social {
+  --icon-size: #{ms.step(2)};
+  // a {
+  //   display: inline-block;
+  //   padding-left: calc(1em + 1ch);
+  //   position: relative;
+  // }
+
+  // .c-icon {
+  //   left: 0;
+  //   position: absolute;
+  //   top: 50%;
+  //   translate: 0 -50%;
+  // }
+}
+
+._new-footer__byline {
+  font-size: ms.step(-1);
+  line-height: ms.step(3, 1);
+}
+
+._new-footer__portland {
+  @media (width < breakpoint.$l) {
+    display: none;
+  }
+
+  bottom: spacing.$fluid-spacing-block-negative;
+  position: absolute;
+  // right: spacing.$fluid-spacing-inline-negative;
+  right: 0;
+  width: 25%;
+  mix-blend-mode: multiply;
+}

--- a/src/prototypes/new-footer/r1.twig
+++ b/src/prototypes/new-footer/r1.twig
@@ -1,0 +1,235 @@
+<div class="_new-footer">
+  <div class="_new-footer__primary t-dark">
+    <div class="_new-footer__cta t-alternate">
+      <div class="o-container o-container--pad">
+        <div class="o-container__content">
+          <div class="o-rhythm o-rhythm--condensed">
+            <div class="o-rhythm o-rhythm--compact">
+              {% embed '@cloudfour/components/heading/heading.twig' with {
+                "tag_name": "h2",
+                "level": 1,
+                "weight": "light"
+              } only %}
+                {% block content %}
+                  Nice to meet you
+                {% endblock %}
+              {% endembed %}
+              <p>
+                Cloud Four helps organizations solve complex responsive web design and development challenges every day.
+                Let's connect so we can tailor a solution to fit your needs.
+              </p>
+            </div>
+            {% embed '@cloudfour/objects/button-group/button-group.twig' only %}
+              {% block content %}
+                {% include '@cloudfour/components/button/button.twig' with {
+                  label: 'See our work',
+                  class: 'c-button--secondary'
+                } only %}
+                {% include '@cloudfour/components/button/button.twig' with {
+                  label: 'Get in touch',
+                  class: 'c-button--secondary'
+                } only %}
+              {% endblock %}
+            {% endembed %}
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="_new-footer__newsletter">
+      <div class="o-container o-container--pad">
+        <div class="o-container__content">
+          <form class="o-rhythm o-rhythm--condensed" action="#">
+            <div class="o-rhythm o-rhythm--compact">
+              {% embed '@cloudfour/components/heading/heading.twig' with {
+                "tag_name": "h2",
+                "level": 1,
+                "weight": "light"
+              } only %}
+                {% block content %}
+                  Cloud Four, in your inbox
+                {% endblock %}
+              {% endembed %}
+              <p>Our latest articles, updates, quick tips and insights in one convenient, occassional newsletter.</p>
+            </div>
+            {% embed '@cloudfour/objects/input-group/input-group.twig' only %}
+              {% block content %}
+                {% include '@cloudfour/components/input/input.twig' with {
+                  placeholder: 'Your Email',
+                  type: 'email',
+                } only %}
+                {% include '@cloudfour/components/button/button.twig' with {
+                  label: 'Sign up'
+                } only %}
+              {% endblock %}
+            {% endembed %}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="_new-footer__secondary t-alternate">
+    <div class="o-container o-container--pad">
+      <div class="o-container__content">
+        {% include '@cloudfour/assets/illustrations/portland.svg.twig' with {
+          class: '_new-footer__portland'
+        } %}
+        <div class="_new-footer__nav">
+          <h2 class="_new-footer__heading">
+            Explore
+          </h2>
+          <ul class="o-list">
+            <li><a href="#">What We Do</a></li>
+            <li><a href="#">Our Approach</a></li>
+            <li><a href="#">Our Work</a></li>
+            <li><a href="#">Articles</a></li>
+            <li><a href="#">Speaking</a></li>
+            <li><a href="#">Team</a></li>
+            <li><a href="#">Hire Us</a></li>
+          </ul>
+        </div>
+        <div class="_new-footer__articles">
+          <h2 class="_new-footer__heading">
+            Topics
+          </h2>
+          <ul class="o-list">
+            <li><a href="#">Responsive Web Design</a></li>
+            <li><a href="#">Performance</a></li>
+            <li><a href="#">Images</a></li>
+            <li><a href="#">Accessibility</a></li>
+            <li><a href="#">Ecommerce</a></li>
+            <li><a href="#">Progressive Web Apps</a></li>
+            <li><a href="#">Cloud Four Spotlight</a></li>
+          </ul>
+        </div>
+        <div class="_new-footer__contact">
+          <address>
+            <a style="font-weight: 500;" href="https://cloudfour.com">
+              Cloud Four, Inc.
+            </a><br>
+            510 SW 3rd Ave, Suite 420<br>
+            Portland, Oregon 97204 USA<br>
+            <div class="u-space-block-start-2">
+              <a href="mailto:info@cloudfour.com">info@cloudfour.com</a><br>
+              <a href="tel:+1-503-290-1090">+1 (503) 290-1090</a>
+            </div>
+          </address>
+        </div>
+        <div class="_new-footer__social">
+          <ul class="o-list o-list--inline">
+            <li>
+              <a href="#">
+                {% include '@cloudfour/components/icon/icon.twig' with {
+                  "name": "brands/linkedin",
+                  "inline": false
+                } only %}
+                <span class="u-hidden-visually">LinkedIn</span>
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                  <path d="m23.02,6.46c-.26-.99-1.04-1.77-2.03-2.03-1.79-.48-8.99-.48-8.99-.48,0,0-7.19,0-8.99.48-.99.26-1.77,1.04-2.03,2.03-.48,1.79-.48,5.54-.48,5.54,0,0,0,3.74.48,5.54.26.99,1.04,1.77,2.03,2.03,1.79.48,8.99.48,8.99.48,0,0,7.19,0,8.99-.48.99-.26,1.77-1.04,2.03-2.03.48-1.79.48-5.54.48-5.54,0,0,0-3.74-.48-5.54Zm-13.32,8.99v-6.9l5.98,3.45-5.98,3.45Z" stroke-width="0"/>
+                </svg>
+                <span class="u-hidden-visually">YouTube</span>
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                {% include '@cloudfour/components/icon/icon.twig' with {
+                  "name": "brands/instagram",
+                  "inline": false
+                } only %}
+                <span class="u-hidden-visually">Instagram</span>
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                {% include '@cloudfour/components/icon/icon.twig' with {
+                  "name": "brands/mastodon",
+                  "inline": false
+                } only %}
+                <span class="u-hidden-visually">Mastodon</span>
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                {% include '@cloudfour/components/icon/icon.twig' with {
+                  "name": "feed",
+                  "inline": false
+                } only %}
+                <span class="u-hidden-visually">RSS</span>
+              </a>
+            </li>
+          </ul>
+          {# <h2 class="_new-footer__heading">
+            Connect
+          </h2>
+          <ul class="o-list">
+            <li>
+              <a href="#">
+                {% include '@cloudfour/components/icon/icon.twig' with {
+                  "name": "brands/linkedin",
+                  "inline": false
+                } only %}
+                LinkedIn
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                <svg class="c-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                  <path d="m23.02,6.46c-.26-.99-1.04-1.77-2.03-2.03-1.79-.48-8.99-.48-8.99-.48,0,0-7.19,0-8.99.48-.99.26-1.77,1.04-2.03,2.03-.48,1.79-.48,5.54-.48,5.54,0,0,0,3.74.48,5.54.26.99,1.04,1.77,2.03,2.03,1.79.48,8.99.48,8.99.48,0,0,7.19,0,8.99-.48.99-.26,1.77-1.04,2.03-2.03.48-1.79.48-5.54.48-5.54,0,0,0-3.74-.48-5.54Zm-13.32,8.99v-6.9l5.98,3.45-5.98,3.45Z" stroke-width="0"/>
+                </svg>
+                YouTube
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                {% include '@cloudfour/components/icon/icon.twig' with {
+                  "name": "brands/instagram",
+                  "inline": false
+                } only %}
+                Instagram
+              </a>
+            </li>
+            <li>
+              <a href="#">
+                {% include '@cloudfour/components/icon/icon.twig' with {
+                  "name": "feed",
+                  "inline": false
+                } only %}
+                RSS
+              </a>
+            </li>
+          </ul> #}
+        </div>
+        {# <div class="_new-footer__search">
+          <h2 class="_new-footer__heading">
+            Search
+          </h2>
+          <form action="#">
+            {% embed '@cloudfour/objects/input-group/input-group.twig' only %}
+              {% block content %}
+                {% include '@cloudfour/components/input/input.twig' with {
+                  placeholder: 'Keywords, topics, etc.',
+                } only %}
+                {% embed '@cloudfour/components/button/button.twig' with {
+                } only %}
+                  {% block content %}
+                    {% include '@cloudfour/components/icon/icon.twig' with {
+                      "name": "magnifying-glass",
+                      "size": "medium",
+                      "inline": true
+                    } only %}
+                  {% endblock %}
+                {% endembed %}
+              {% endblock %}
+            {% endembed %}
+          </form>
+        </div> #}
+        <div class="_new-footer__byline">
+          &copy; 2007&ndash;{{ "now"|date("Y") }} Cloud Four, Inc.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/prototypes/new-footer/r2.scss
+++ b/src/prototypes/new-footer/r2.scss
@@ -57,12 +57,6 @@
       ". scene";
     grid-template-columns: minmax(0, auto) minmax(0, 1fr);
     grid-template-rows: repeat(6, minmax(0, auto));
-    // grid-template-areas: "address address"
-    //   "social social"
-    //   "primary-nav secondary-nav"
-    //   "colophon scene"
-    //   " . scene";
-    // grid-template-columns: minmax(0, auto) minmax(0, 1fr);
   }
 
   @media (width >= breakpoint.$m) {
@@ -73,11 +67,6 @@
       "colophon colophon scene"
       ". . scene";
     grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
-    // grid-template-areas: "address primary-nav secondary-nav"
-    //     "social primary-nav secondary-nav"
-    //     "colophon colophon scene"
-    //     ". . scene";
-    // grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
   }
 
   @media (width >= breakpoint.$xl) {
@@ -87,9 +76,6 @@
       ". . . scene scene";
     grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(0, auto);
     grid-template-rows: repeat(3, minmax(0, auto)) spacing.$fluid-spacing-block;
-    // grid-template-areas: "address primary-nav secondary-nav social"
-    //     "colophon primary-nav secondary-nav scene";
-    // grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr);
   }
 }
 
@@ -99,14 +85,6 @@
 
 ._c-ground-nav__social {
   grid-area: social;
-
-  // @media (width < breakpoint.$xl) {
-  //   align-self: end;
-  // }
-
-  // @media (width >= breakpoint.$xl) {
-  //   justify-self: end;
-  // }
 }
 
 ._c-ground-nav__primary-nav {
@@ -123,19 +101,9 @@
   @media (width >=breakpoint.$xl) {
     align-self: end;
   }
-
-  // @media (width < breakpoint.$l) {
-    // align-self: end;
-  // }
 }
 
 ._c-ground-nav__scene {
-  // align-self: end;
-  // margin-block-end: spacing.$fluid-spacing-block-negative;
-  // margin-inline-start: auto;
-  // justify-self: end;
-  // max-height: ms.step(8);
-
   block-size: 100%;
   max-block-size: ms.step(10);
   grid-area: scene;

--- a/src/prototypes/new-footer/r2.scss
+++ b/src/prototypes/new-footer/r2.scss
@@ -1,0 +1,107 @@
+@use '../../mixins/ms';
+@use '../../mixins/spacing';
+@use '../../compiled/tokens/scss/breakpoint';
+@use '../../compiled/tokens/scss/font-weight';
+
+._c-heading--medium {
+  font-weight: font-weight.$medium;
+}
+
+._c-ground-nav {
+  display: grid;
+  grid-template-rows: repeat(3, minmax(0, auto));
+}
+
+._c-ground-nav::before {
+  background: var(--theme-color-background-secondary);
+  content: '';
+  grid-column: 1;
+  grid-row: 2 / span 2;
+}
+
+._c-ground-nav__features {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+}
+
+._c-ground-nav__inner {
+  grid-column: 1;
+  grid-row: 3;
+  position: relative;
+}
+
+._c-ground-nav__content {
+  color: var(--theme-color-text-muted);
+  column-gap: spacing.$fluid-gap;
+  display: grid;
+  grid-template-areas: "address address address"
+      "social social social"
+      "primary-nav primary-nav primary-nav"
+      "secondary-nav secondary-nav secondary-nav"
+      "colophon colophon colophon"
+      ". scene scene";
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  row-gap: ms.step(2);
+
+  @media (width >= breakpoint.$s) {
+    grid-template-areas: "address address"
+      "social social"
+      "primary-nav secondary-nav"
+      "colophon scene";
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (width >= breakpoint.$m) {
+    grid-template-areas: "address primary-nav secondary-nav"
+        "social primary-nav secondary-nav"
+        "colophon colophon scene";
+    grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
+  }
+
+  @media (width >= breakpoint.$xl) {
+    grid-template-areas: "address primary-nav secondary-nav social"
+        "colophon primary-nav secondary-nav scene";
+    grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr);
+  }
+}
+
+._c-ground-nav__scene {
+  align-self: end;
+  grid-area: scene;
+  margin-block-end: spacing.$fluid-spacing-block-negative;
+  margin-inline-start: auto;
+  max-height: ms.step(8);
+  mix-blend-mode: multiply;
+}
+
+._c-ground-nav__address {
+  grid-area: address;
+}
+
+._c-ground-nav__social {
+  grid-area: social;
+
+  @media (width < breakpoint.$xl) {
+    align-self: end;
+  }
+
+  @media (width >= breakpoint.$xl) {
+    justify-self: end;
+  }
+}
+
+._c-ground-nav__primary-nav {
+  grid-area: primary-nav;
+}
+
+._c-ground-nav__secondary-nav {
+  grid-area: secondary-nav;
+}
+
+._c-ground-nav__colophon {
+  grid-area: colophon;
+
+  // @media (width < breakpoint.$l) {
+    align-self: end;
+  // }
+}

--- a/src/prototypes/new-footer/r2.scss
+++ b/src/prototypes/new-footer/r2.scss
@@ -5,159 +5,162 @@
 @use '../../compiled/tokens/scss/font-weight';
 @use '../../compiled/tokens/scss/size';
 
-._o-container--pad-block-start {
-  padding-block-start: spacing.$fluid-spacing-block;
-}
+#_new-footer-r2 {
 
-._c-heading--medium {
-  font-weight: font-weight.$medium;
-}
-
-._c-ground-nav {
-  display: grid;
-  grid-template-rows: repeat(3, minmax(0, auto));
-}
-
-._c-ground-nav::before {
-  background: var(--theme-color-background-secondary);
-  content: '';
-  grid-column: 1;
-  grid-row: 2 / span 2;
-}
-
-._c-ground-nav__features {
-  grid-column: 1;
-  grid-row: 1 / span 2;
-}
-
-._c-ground-nav__features-inner {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-
-  @media (width >= breakpoint.$l) {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  ._o-container--pad-block-start {
+    padding-block-start: spacing.$fluid-spacing-block;
   }
-}
 
-._c-ground-nav__feature {
-  @include border-radius.conditional;
-  @include spacing.fluid-padding-block;
-  width: 100%;
+  ._c-heading--medium {
+    font-weight: font-weight.$medium;
+  }
 
-  &:only-child {
-    margin-inline: auto;
-    max-width: size.$max-width-prose;
+  ._c-ground-nav {
+    display: grid;
+    grid-template-rows: repeat(3, minmax(0, auto));
+  }
+
+  ._c-ground-nav::before {
+    background: var(--theme-color-background-secondary);
+    content: '';
+    grid-column: 1;
+    grid-row: 2 / span 2;
+  }
+
+  ._c-ground-nav__features {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+  }
+
+  ._c-ground-nav__features-inner {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
 
     @media (width >= breakpoint.$l) {
-      grid-column: span 2;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
-  @media (width < breakpoint.$l) {
-    &:not(:last-child) {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+  ._c-ground-nav__feature {
+    @include border-radius.conditional;
+    @include spacing.fluid-padding-block;
+    width: 100%;
+
+    &:only-child {
+      margin-inline: auto;
+      max-width: size.$max-width-prose;
+
+      @media (width >= breakpoint.$l) {
+        grid-column: span 2;
+      }
     }
 
-    &:not(:first-child) {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
+    @media (width < breakpoint.$l) {
+      &:not(:last-child) {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+
+      &:not(:first-child) {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+      }
+    }
+
+    @media (width >= breakpoint.$l) {
+      &:not(:last-child) {
+        border-bottom-right-radius: 0;
+        border-top-right-radius: 0;
+      }
+
+      &:not(:first-child) {
+        border-bottom-left-radius: 0;
+        border-top-left-radius: 0;
+      }
     }
   }
 
-  @media (width >= breakpoint.$l) {
-    &:not(:last-child) {
-      border-bottom-right-radius: 0;
-      border-top-right-radius: 0;
+  ._c-ground-nav__inner {
+    grid-column: 1;
+    grid-row: 3;
+    position: relative;
+  }
+
+  ._c-ground-nav__content {
+    color: var(--theme-color-text-muted);
+    column-gap: spacing.$fluid-gap;
+    display: grid;
+    grid-template-areas: "address"
+      "social"
+      "primary-nav"
+      "secondary-nav"
+      "colophon"
+      "scene";
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: repeat(5, minmax(0, auto)) ms.step(6);
+    row-gap: ms.step(2);
+
+    @media (width >= breakpoint.$s) {
+      grid-template-areas: "address address"
+        "social social"
+        "primary-nav secondary-nav"
+        ". scene"
+        "colophon scene"
+        ". scene";
+      grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+      grid-template-rows: repeat(6, minmax(0, auto));
     }
 
-    &:not(:first-child) {
-      border-bottom-left-radius: 0;
-      border-top-left-radius: 0;
+    @media (width >= breakpoint.$m) {
+      grid-template-areas: "address primary-nav secondary-nav"
+        ". primary-nav secondary-nav"
+        "social primary-nav secondary-nav"
+        ". . scene"
+        "colophon colophon scene"
+        ". . scene";
+      grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
+    }
+
+    @media (width >= breakpoint.$xl) {
+      grid-template-areas: "address primary-nav secondary-nav . social"
+        "address primary-nav secondary-nav scene scene"
+        "colophon primary-nav secondary-nav scene scene"
+        ". . . scene scene";
+      grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(0, auto);
+      grid-template-rows: repeat(3, minmax(0, auto)) spacing.$fluid-spacing-block;
     }
   }
-}
 
-._c-ground-nav__inner {
-  grid-column: 1;
-  grid-row: 3;
-  position: relative;
-}
-
-._c-ground-nav__content {
-  color: var(--theme-color-text-muted);
-  column-gap: spacing.$fluid-gap;
-  display: grid;
-  grid-template-areas: "address"
-    "social"
-    "primary-nav"
-    "secondary-nav"
-    "colophon"
-    "scene";
-  grid-template-columns: minmax(0, 1fr);
-  grid-template-rows: repeat(5, minmax(0, auto)) ms.step(6);
-  row-gap: ms.step(2);
-
-  @media (width >= breakpoint.$s) {
-    grid-template-areas: "address address"
-      "social social"
-      "primary-nav secondary-nav"
-      ". scene"
-      "colophon scene"
-      ". scene";
-    grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-    grid-template-rows: repeat(6, minmax(0, auto));
+  ._c-ground-nav__address {
+    grid-area: address;
   }
 
-  @media (width >= breakpoint.$m) {
-    grid-template-areas: "address primary-nav secondary-nav"
-      ". primary-nav secondary-nav"
-      "social primary-nav secondary-nav"
-      ". . scene"
-      "colophon colophon scene"
-      ". . scene";
-    grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
+  ._c-ground-nav__social {
+    grid-area: social;
   }
 
-  @media (width >= breakpoint.$xl) {
-    grid-template-areas: "address primary-nav secondary-nav . social"
-      "address primary-nav secondary-nav scene scene"
-      "colophon primary-nav secondary-nav scene scene"
-      ". . . scene scene";
-    grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(0, auto);
-    grid-template-rows: repeat(3, minmax(0, auto)) spacing.$fluid-spacing-block;
+  ._c-ground-nav__primary-nav {
+    grid-area: primary-nav;
   }
-}
 
-._c-ground-nav__address {
-  grid-area: address;
-}
-
-._c-ground-nav__social {
-  grid-area: social;
-}
-
-._c-ground-nav__primary-nav {
-  grid-area: primary-nav;
-}
-
-._c-ground-nav__secondary-nav {
-  grid-area: secondary-nav;
-}
-
-._c-ground-nav__colophon {
-  grid-area: colophon;
-
-  @media (width >=breakpoint.$xl) {
-    align-self: end;
+  ._c-ground-nav__secondary-nav {
+    grid-area: secondary-nav;
   }
-}
 
-._c-ground-nav__scene {
-  block-size: 100%;
-  max-block-size: ms.step(10);
-  grid-area: scene;
-  inline-size: 100%;
-  mix-blend-mode: multiply;
-  place-self: end;
+  ._c-ground-nav__colophon {
+    grid-area: colophon;
+
+    @media (width >=breakpoint.$xl) {
+      align-self: end;
+    }
+  }
+
+  ._c-ground-nav__scene {
+    block-size: 100%;
+    max-block-size: ms.step(10);
+    grid-area: scene;
+    inline-size: 100%;
+    mix-blend-mode: multiply;
+    place-self: end;
+  }
 }

--- a/src/prototypes/new-footer/r2.scss
+++ b/src/prototypes/new-footer/r2.scss
@@ -1,7 +1,9 @@
+@use '../../mixins/border-radius';
 @use '../../mixins/ms';
 @use '../../mixins/spacing';
 @use '../../compiled/tokens/scss/breakpoint';
 @use '../../compiled/tokens/scss/font-weight';
+@use '../../compiled/tokens/scss/size';
 
 ._o-container--pad-block-start {
   padding-block-start: spacing.$fluid-spacing-block;
@@ -26,6 +28,54 @@
 ._c-ground-nav__features {
   grid-column: 1;
   grid-row: 1 / span 2;
+}
+
+._c-ground-nav__features-inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+
+  @media (width >= breakpoint.$l) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+._c-ground-nav__feature {
+  @include border-radius.conditional;
+  @include spacing.fluid-padding-block;
+  width: 100%;
+
+  &:only-child {
+    margin-inline: auto;
+    max-width: size.$max-width-prose;
+
+    @media (width >= breakpoint.$l) {
+      grid-column: span 2;
+    }
+  }
+
+  @media (width < breakpoint.$l) {
+    &:not(:last-child) {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    &:not(:first-child) {
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+    }
+  }
+
+  @media (width >= breakpoint.$l) {
+    &:not(:last-child) {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+    }
+
+    &:not(:first-child) {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+    }
+  }
 }
 
 ._c-ground-nav__inner {

--- a/src/prototypes/new-footer/r2.scss
+++ b/src/prototypes/new-footer/r2.scss
@@ -3,6 +3,10 @@
 @use '../../compiled/tokens/scss/breakpoint';
 @use '../../compiled/tokens/scss/font-weight';
 
+._o-container--pad-block-start {
+  padding-block-start: spacing.$fluid-spacing-block;
+}
+
 ._c-heading--medium {
   font-weight: font-weight.$medium;
 }
@@ -34,44 +38,59 @@
   color: var(--theme-color-text-muted);
   column-gap: spacing.$fluid-gap;
   display: grid;
-  grid-template-areas: "address address address"
-      "social social social"
-      "primary-nav primary-nav primary-nav"
-      "secondary-nav secondary-nav secondary-nav"
-      "colophon colophon colophon"
-      ". scene scene";
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-areas: "address"
+    "social"
+    "primary-nav"
+    "secondary-nav"
+    "colophon"
+    "scene";
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: repeat(5, minmax(0, auto)) ms.step(6);
   row-gap: ms.step(2);
 
   @media (width >= breakpoint.$s) {
     grid-template-areas: "address address"
       "social social"
       "primary-nav secondary-nav"
-      "colophon scene";
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+      ". scene"
+      "colophon scene"
+      ". scene";
+    grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+    grid-template-rows: repeat(6, minmax(0, auto));
+    // grid-template-areas: "address address"
+    //   "social social"
+    //   "primary-nav secondary-nav"
+    //   "colophon scene"
+    //   " . scene";
+    // grid-template-columns: minmax(0, auto) minmax(0, 1fr);
   }
 
   @media (width >= breakpoint.$m) {
     grid-template-areas: "address primary-nav secondary-nav"
-        "social primary-nav secondary-nav"
-        "colophon colophon scene";
+      ". primary-nav secondary-nav"
+      "social primary-nav secondary-nav"
+      ". . scene"
+      "colophon colophon scene"
+      ". . scene";
     grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
+    // grid-template-areas: "address primary-nav secondary-nav"
+    //     "social primary-nav secondary-nav"
+    //     "colophon colophon scene"
+    //     ". . scene";
+    // grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
   }
 
   @media (width >= breakpoint.$xl) {
-    grid-template-areas: "address primary-nav secondary-nav social"
-        "colophon primary-nav secondary-nav scene";
-    grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr);
+    grid-template-areas: "address primary-nav secondary-nav . social"
+      "address primary-nav secondary-nav scene scene"
+      "colophon primary-nav secondary-nav scene scene"
+      ". . . scene scene";
+    grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(0, auto);
+    grid-template-rows: repeat(3, minmax(0, auto)) spacing.$fluid-spacing-block;
+    // grid-template-areas: "address primary-nav secondary-nav social"
+    //     "colophon primary-nav secondary-nav scene";
+    // grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr);
   }
-}
-
-._c-ground-nav__scene {
-  align-self: end;
-  grid-area: scene;
-  margin-block-end: spacing.$fluid-spacing-block-negative;
-  margin-inline-start: auto;
-  max-height: ms.step(8);
-  mix-blend-mode: multiply;
 }
 
 ._c-ground-nav__address {
@@ -81,13 +100,13 @@
 ._c-ground-nav__social {
   grid-area: social;
 
-  @media (width < breakpoint.$xl) {
-    align-self: end;
-  }
+  // @media (width < breakpoint.$xl) {
+  //   align-self: end;
+  // }
 
-  @media (width >= breakpoint.$xl) {
-    justify-self: end;
-  }
+  // @media (width >= breakpoint.$xl) {
+  //   justify-self: end;
+  // }
 }
 
 ._c-ground-nav__primary-nav {
@@ -101,7 +120,26 @@
 ._c-ground-nav__colophon {
   grid-area: colophon;
 
-  // @media (width < breakpoint.$l) {
+  @media (width >=breakpoint.$xl) {
     align-self: end;
+  }
+
+  // @media (width < breakpoint.$l) {
+    // align-self: end;
   // }
+}
+
+._c-ground-nav__scene {
+  // align-self: end;
+  // margin-block-end: spacing.$fluid-spacing-block-negative;
+  // margin-inline-start: auto;
+  // justify-self: end;
+  // max-height: ms.step(8);
+
+  block-size: 100%;
+  max-block-size: ms.step(10);
+  grid-area: scene;
+  inline-size: 100%;
+  mix-blend-mode: multiply;
+  place-self: end;
 }

--- a/src/prototypes/new-footer/r2.twig
+++ b/src/prototypes/new-footer/r2.twig
@@ -2,7 +2,14 @@
   <div class="_c-ground-nav__features">
     <div class="o-container o-container--pad-inline">
       <div class="o-container__content">
-        (Features)
+        <div class="o-container__fill _c-ground-nav__features-inner">
+          <div class="_c-ground-nav__feature t-dark t-alternate o-container__pad">
+            (Feature)
+          </div>
+          <div class="_c-ground-nav__feature t-dark o-container__pad">
+            (Feature)
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/prototypes/new-footer/r2.twig
+++ b/src/prototypes/new-footer/r2.twig
@@ -1,0 +1,77 @@
+<footer class="_c-ground-nav">
+  <div class="_c-ground-nav__features">
+    <div class="o-container o-container--pad-inline">
+      <div class="o-container__content">
+        (Features)
+      </div>
+    </div>
+  </div>
+  <div class="_c-ground-nav__inner">
+    <div class="o-container o-container--pad">
+      <div class="o-container__content _c-ground-nav__content">
+        <address class="_c-ground-nav__address">
+          <a class="c-heading _c-heading--medium" href="{{organization.url}}">
+            {{organization.name}}
+          </a><br>
+          {{organization.address1}}<br>
+          {{organization.address2}}<br>
+          <a href="mailto:{{ organization.email }}">{{ organization.email }}</a><br>
+          <a href="tel:{{ organization.phone|replace({
+            '.': '-',
+            '(': '-',
+            ')': '-',
+            ' ': ''
+          }) }}">{{ organization.phone }}</a>
+        </address>
+
+        <div class="_c-ground-nav__social">
+          <ul class="o-list o-list--inline">
+            {% for item in social %}
+              <li>
+                <a href="#">
+                  {% include '@cloudfour/components/icon/icon.twig' with {
+                    "name": item.icon,
+                    "size": "medium"
+                  } only %}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+
+        <nav class="_c-ground-nav__primary-nav">
+          <h2 class="c-heading _c-heading--medium">Explore</h2>
+          <ul class="o-list">
+            {% for item in nav %}
+              <li>
+                <a href="{{item.href|default('#')}}">
+                  {{item.title}}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+        <nav class="_c-ground-nav__secondary-nav">
+          <h2 class="c-heading _c-heading--medium">Topics</h2>
+          <ul class="o-list">
+            {% for item in topics %}
+              <li>
+                <a href="{{item.href|default('#')}}">
+                  {{item.title}}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+
+        <p class="_c-ground-nav__colophon">
+          &copy; 2007&ndash;{{ "now"|date("Y") }} {{organization.name}}
+        </p>
+
+        {% include '@cloudfour/assets/illustrations/portland.svg.twig' with {
+          class: '_c-ground-nav__scene'
+        } %}
+      </div>
+    </div>
+  </div>
+</footer>

--- a/src/prototypes/new-footer/r2.twig
+++ b/src/prototypes/new-footer/r2.twig
@@ -1,84 +1,86 @@
-<footer class="_c-ground-nav">
-  <div class="_c-ground-nav__features">
-    <div class="o-container o-container--pad-inline">
-      <div class="o-container__content">
-        <div class="o-container__fill _c-ground-nav__features-inner">
-          <div class="_c-ground-nav__feature t-dark t-alternate o-container__pad">
-            (Feature)
-          </div>
-          <div class="_c-ground-nav__feature t-dark o-container__pad">
-            (Feature)
+<div id="_new-footer-r2">
+  <footer class="_c-ground-nav">
+    <div class="_c-ground-nav__features">
+      <div class="o-container o-container--pad-inline">
+        <div class="o-container__content">
+          <div class="o-container__fill _c-ground-nav__features-inner">
+            <div class="_c-ground-nav__feature t-dark t-alternate o-container__pad">
+              (Feature)
+            </div>
+            <div class="_c-ground-nav__feature t-dark o-container__pad">
+              (Feature)
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  <div class="_c-ground-nav__inner">
-    <div class="o-container o-container--pad-inline _o-container--pad-block-start">
-      <div class="o-container__content _c-ground-nav__content">
-        <address class="_c-ground-nav__address">
-          <a class="c-heading _c-heading--medium" href="{{organization.url}}">
-            {{organization.name}}
-          </a><br>
-          {{organization.address1}}<br>
-          {{organization.address2}}<br>
-          <a href="mailto:{{ organization.email }}">{{ organization.email }}</a><br>
-          <a href="tel:{{ organization.phone|replace({
-            '.': '-',
-            '(': '-',
-            ')': '-',
-            ' ': ''
-          }) }}">{{ organization.phone }}</a>
-        </address>
+    <div class="_c-ground-nav__inner">
+      <div class="o-container o-container--pad-inline _o-container--pad-block-start">
+        <div class="o-container__content _c-ground-nav__content">
+          <address class="_c-ground-nav__address">
+            <a class="c-heading _c-heading--medium" href="{{organization.url}}">
+              {{organization.name}}
+            </a><br>
+            {{organization.address1}}<br>
+            {{organization.address2}}<br>
+            <a href="mailto:{{ organization.email }}">{{ organization.email }}</a><br>
+            <a href="tel:{{ organization.phone|replace({
+              '.': '-',
+              '(': '-',
+              ')': '-',
+              ' ': ''
+            }) }}">{{ organization.phone }}</a>
+          </address>
 
-        <div class="_c-ground-nav__social">
-          <ul class="o-list o-list--inline">
-            {% for item in social %}
-              <li>
-                <a href="#">
-                  {% include '@cloudfour/components/icon/icon.twig' with {
-                    "name": item.icon,
-                    "size": "medium"
-                  } only %}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
+          <div class="_c-ground-nav__social">
+            <ul class="o-list o-list--inline">
+              {% for item in social %}
+                <li>
+                  <a href="#">
+                    {% include '@cloudfour/components/icon/icon.twig' with {
+                      "name": item.icon,
+                      "size": "medium"
+                    } only %}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+
+          <nav class="_c-ground-nav__primary-nav">
+            <h2 class="c-heading _c-heading--medium">Explore</h2>
+            <ul class="o-list">
+              {% for item in nav %}
+                <li>
+                  <a href="{{item.href|default('#')}}">
+                    {{item.title}}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </nav>
+          <nav class="_c-ground-nav__secondary-nav">
+            <h2 class="c-heading _c-heading--medium">Topics</h2>
+            <ul class="o-list">
+              {% for item in topics %}
+                <li>
+                  <a href="{{item.href|default('#')}}">
+                    {{item.title}}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </nav>
+
+          <p class="_c-ground-nav__colophon">
+            &copy; 2007&ndash;{{ "now"|date("Y") }} {{organization.name}}
+          </p>
+
+          {% include '@cloudfour/assets/illustrations/portland.svg.twig' with {
+            class: '_c-ground-nav__scene',
+          } %}
         </div>
-
-        <nav class="_c-ground-nav__primary-nav">
-          <h2 class="c-heading _c-heading--medium">Explore</h2>
-          <ul class="o-list">
-            {% for item in nav %}
-              <li>
-                <a href="{{item.href|default('#')}}">
-                  {{item.title}}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
-        </nav>
-        <nav class="_c-ground-nav__secondary-nav">
-          <h2 class="c-heading _c-heading--medium">Topics</h2>
-          <ul class="o-list">
-            {% for item in topics %}
-              <li>
-                <a href="{{item.href|default('#')}}">
-                  {{item.title}}
-                </a>
-              </li>
-            {% endfor %}
-          </ul>
-        </nav>
-
-        <p class="_c-ground-nav__colophon">
-          &copy; 2007&ndash;{{ "now"|date("Y") }} {{organization.name}}
-        </p>
-
-        {% include '@cloudfour/assets/illustrations/portland.svg.twig' with {
-          class: '_c-ground-nav__scene',
-        } %}
       </div>
     </div>
-  </div>
-</footer>
+  </footer>
+</div>

--- a/src/prototypes/new-footer/r2.twig
+++ b/src/prototypes/new-footer/r2.twig
@@ -7,7 +7,7 @@
     </div>
   </div>
   <div class="_c-ground-nav__inner">
-    <div class="o-container o-container--pad">
+    <div class="o-container o-container--pad-inline _o-container--pad-block-start">
       <div class="o-container__content _c-ground-nav__content">
         <address class="_c-ground-nav__address">
           <a class="c-heading _c-heading--medium" href="{{organization.url}}">
@@ -69,7 +69,7 @@
         </p>
 
         {% include '@cloudfour/assets/illustrations/portland.svg.twig' with {
-          class: '_c-ground-nav__scene'
+          class: '_c-ground-nav__scene',
         } %}
       </div>
     </div>

--- a/src/prototypes/new-footer/r3.scss
+++ b/src/prototypes/new-footer/r3.scss
@@ -1,10 +1,19 @@
 @use '../../mixins/border-radius';
 @use '../../mixins/ms';
 @use '../../mixins/spacing';
+@use '../../mixins/theme';
 @use '../../compiled/tokens/scss/breakpoint';
 @use '../../compiled/tokens/scss/font-weight';
 @use '../../compiled/tokens/scss/size';
 @use 'sass:math';
+
+@include theme.props() {
+  --theme-blend-mode-background: multiply;
+}
+
+@include theme.props(dark) {
+  --theme-blend-mode-background: hard-light;
+}
 
 #_new-footer-r3 {
   ._c-heading--medium {
@@ -31,7 +40,7 @@
 
   ._c-ground-nav__main {
     --theme-color-text-emphasis: var(--theme-color-text-muted);
-    background-blend-mode: multiply;
+    background-blend-mode: var(--theme-blend-mode-background);
     background-color: var(--theme-color-background-secondary);
     background-image: svg-load('illustrations/portland.svg');
     background-position: right bottom;
@@ -42,7 +51,8 @@
     grid-row: 3;
 
     @media (width >= breakpoint.$xxxl) {
-      background-position: right calc(50vw - #{math.div(size.$max-width-spread, 2)}) bottom;
+      background-position: right calc(50vw - #{math.div(size.$max-width-spread, 2)} - #{spacing.$fluid-spacing-inline-max}) bottom;
+      // background-size: auto ms.step(10);
     }
   }
 
@@ -83,9 +93,11 @@
     }
 
     @media (width >= breakpoint.$xxl) {
-            // grid-template-areas: "address primary-nav secondary-nav social"
-            //     "colophon primary-nav secondary-nav .";
       grid-template-columns: minmax(0, 1fr) repeat(2, minmax(0, auto)) minmax(0, 1fr);
+    }
+
+    @media (width >= breakpoint.$xxxl) {
+      grid-template-columns: minmax(0, 2fr) repeat(2, minmax(0, 1fr)) minmax(0, 2fr);
     }
   }
 
@@ -109,9 +121,11 @@
   }
 
   ._c-ground-nav__social {
+    --icon-size: #{size.$icon-medium};
     grid-area: social;
 
     @media (width >= breakpoint.$xl) {
+      --icon-size: #{size.$icon-large};
       justify-self: end;
     }
   }
@@ -123,166 +137,4 @@
       margin-top: ms.step(2);
     }
   }
-
-  // ._c-ground-nav__bump {
-  //   display: inline-block;
-  //   margin-top: ms.step(2);
-  // }
-
-  // ._o-container--pad-block-start {
-  //   padding-block-start: spacing.$fluid-spacing-block;
-  // }
-
-  // ._c-heading--medium {
-  //   font-weight: font-weight.$medium;
-  // }
-
-  // ._c-ground-nav {
-  //   display: grid;
-  //   grid-template-rows: repeat(3, minmax(0, auto));
-  // }
-
-  // ._c-ground-nav::before {
-  //   background: var(--theme-color-background-secondary);
-  //   content: '';
-  //   grid-column: 1;
-  //   grid-row: 2 / span 2;
-  // }
-
-  // ._c-ground-nav__features {
-  //   grid-column: 1;
-  //   grid-row: 1 / span 2;
-  // }
-
-  // ._c-ground-nav__features-inner {
-  //   display: grid;
-  //   grid-template-columns: minmax(0, 1fr);
-
-  //   @media (width >= breakpoint.$l) {
-  //     grid-template-columns: repeat(2, minmax(0, 1fr));
-  //   }
-  // }
-
-  // ._c-ground-nav__feature {
-  //   @include border-radius.conditional;
-  //   @include spacing.fluid-padding-block;
-  //   width: 100%;
-
-  //   &:only-child {
-  //     margin-inline: auto;
-  //     max-width: size.$max-width-prose;
-
-  //     @media (width >= breakpoint.$l) {
-  //       grid-column: span 2;
-  //     }
-  //   }
-
-  //   @media (width < breakpoint.$l) {
-  //     &:not(:last-child) {
-  //       border-bottom-left-radius: 0;
-  //       border-bottom-right-radius: 0;
-  //     }
-
-  //     &:not(:first-child) {
-  //       border-top-left-radius: 0;
-  //       border-top-right-radius: 0;
-  //     }
-  //   }
-
-  //   @media (width >= breakpoint.$l) {
-  //     &:not(:last-child) {
-  //       border-bottom-right-radius: 0;
-  //       border-top-right-radius: 0;
-  //     }
-
-  //     &:not(:first-child) {
-  //       border-bottom-left-radius: 0;
-  //       border-top-left-radius: 0;
-  //     }
-  //   }
-  // }
-
-  // ._c-ground-nav__inner {
-  //   grid-column: 1;
-  //   grid-row: 3;
-  //   position: relative;
-  // }
-
-  // ._c-ground-nav__content {
-  //   color: var(--theme-color-text-muted);
-  //   column-gap: spacing.$fluid-gap;
-  //   display: grid;
-  //   grid-template-areas: "address"
-  //     "social"
-  //     "primary-nav"
-  //     "secondary-nav"
-  //     "colophon"
-  //     "scene";
-  //   grid-template-columns: minmax(0, 1fr);
-  //   grid-template-rows: repeat(5, minmax(0, auto)) ms.step(6);
-  //   row-gap: ms.step(2);
-
-  //   @media (width >= breakpoint.$s) {
-  //     grid-template-areas: "address address"
-  //       "social social"
-  //       "primary-nav secondary-nav"
-  //       ". scene"
-  //       "colophon scene"
-  //       ". scene";
-  //     grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  //     grid-template-rows: repeat(6, minmax(0, auto));
-  //   }
-
-  //   @media (width >= breakpoint.$m) {
-  //     grid-template-areas: "address primary-nav secondary-nav"
-  //       ". primary-nav secondary-nav"
-  //       "social primary-nav secondary-nav"
-  //       ". . scene"
-  //       "colophon colophon scene"
-  //       ". . scene";
-  //     grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
-  //   }
-
-  //   @media (width >= breakpoint.$xl) {
-  //     grid-template-areas: "address primary-nav secondary-nav . social"
-  //       "address primary-nav secondary-nav scene scene"
-  //       "colophon primary-nav secondary-nav scene scene"
-  //       ". . . scene scene";
-  //     grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(0, auto);
-  //     grid-template-rows: repeat(3, minmax(0, auto)) spacing.$fluid-spacing-block;
-  //   }
-  // }
-
-  // ._c-ground-nav__address {
-  //   grid-area: address;
-  // }
-
-  // ._c-ground-nav__social {
-  //   grid-area: social;
-  // }
-
-  // ._c-ground-nav__primary-nav {
-  //   grid-area: primary-nav;
-  // }
-
-  // ._c-ground-nav__secondary-nav {
-  //   grid-area: secondary-nav;
-  // }
-
-  // ._c-ground-nav__colophon {
-  //   grid-area: colophon;
-
-  //   @media (width >=breakpoint.$xl) {
-  //     align-self: end;
-  //   }
-  // }
-
-  // ._c-ground-nav__scene {
-  //   block-size: 100%;
-  //   max-block-size: ms.step(10);
-  //   grid-area: scene;
-  //   inline-size: 100%;
-  //   mix-blend-mode: multiply;
-  //   place-self: end;
-  // }
 }

--- a/src/prototypes/new-footer/r3.scss
+++ b/src/prototypes/new-footer/r3.scss
@@ -50,9 +50,12 @@
     grid-column: 1;
     grid-row: 3;
 
+    @media (width >= breakpoint.$xxl) {
+      background-size: auto ms.step(10);
+    }
+
     @media (width >= breakpoint.$xxxl) {
       background-position: right calc(50vw - #{math.div(size.$max-width-spread, 2)} - #{spacing.$fluid-spacing-inline-max}) bottom;
-      // background-size: auto ms.step(10);
     }
   }
 

--- a/src/prototypes/new-footer/r3.scss
+++ b/src/prototypes/new-footer/r3.scss
@@ -1,0 +1,288 @@
+@use '../../mixins/border-radius';
+@use '../../mixins/ms';
+@use '../../mixins/spacing';
+@use '../../compiled/tokens/scss/breakpoint';
+@use '../../compiled/tokens/scss/font-weight';
+@use '../../compiled/tokens/scss/size';
+@use 'sass:math';
+
+#_new-footer-r3 {
+  ._c-heading--medium {
+    font-weight: font-weight.$medium;
+  }
+
+  ._c-ground-nav {
+    background-color: var(--theme-color-background-base);
+    display: grid;
+    grid-template-rows: repeat(3, minmax(0, auto));
+  }
+
+  ._c-ground-nav::before {
+    background-color: var(--theme-color-background-secondary);
+    content: '';
+    grid-column: 1;
+    grid-row: 2 / span 2;
+  }
+
+  ._c-ground-nav__lead-in {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+  }
+
+  ._c-ground-nav__main {
+    --theme-color-text-emphasis: var(--theme-color-text-muted);
+    background-blend-mode: multiply;
+    background-color: var(--theme-color-background-secondary);
+    background-image: svg-load('illustrations/portland.svg');
+    background-position: right bottom;
+    background-repeat: no-repeat;
+    background-size: auto clamp(ms.step(6), 15vw, ms.step(9));
+    color: var(--theme-color-text-muted);
+    grid-column: 1;
+    grid-row: 3;
+
+    @media (width >= breakpoint.$xxxl) {
+      background-position: right calc(50vw - #{math.div(size.$max-width-spread, 2)}) bottom;
+    }
+  }
+
+  ._c-ground-nav__content {
+    column-gap: spacing.$fluid-gap;
+    display: grid;
+    grid-template-areas: "address"
+      "primary-nav"
+      "secondary-nav"
+      "social"
+      "colophon";
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: ms.step(2);
+
+    @media (width < breakpoint.$s) {
+      padding-bottom: ms.step(6);
+    }
+
+    @media (width >= breakpoint.$s) {
+      grid-template-areas: "address address"
+        "primary-nav secondary-nav"
+        "social social"
+        "colophon colophon";
+      grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+    }
+
+    @media (width >= breakpoint.$m) {
+      grid-template-areas: "address primary-nav secondary-nav"
+        "social primary-nav secondary-nav"
+        "colophon colophon colophon";
+      grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
+    }
+
+    @media (width >= breakpoint.$xl) {
+      grid-template-areas: "address primary-nav secondary-nav social"
+        "colophon primary-nav secondary-nav .";
+      grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr);
+    }
+
+    @media (width >= breakpoint.$xxl) {
+            // grid-template-areas: "address primary-nav secondary-nav social"
+            //     "colophon primary-nav secondary-nav .";
+      grid-template-columns: minmax(0, 1fr) repeat(2, minmax(0, auto)) minmax(0, 1fr);
+    }
+  }
+
+  ._c-ground-nav__address {
+    grid-area: address;
+  }
+
+  ._c-ground-nav__address-section {
+    @media (width >= breakpoint.$m) {
+      display: inline-block;
+      margin-top: ms.step(2);
+    }
+  }
+
+  ._c-ground-nav__primary-nav {
+    grid-area: primary-nav;
+  }
+
+  ._c-ground-nav__secondary-nav {
+    grid-area: secondary-nav;
+  }
+
+  ._c-ground-nav__social {
+    grid-area: social;
+
+    @media (width >= breakpoint.$xl) {
+      justify-self: end;
+    }
+  }
+
+  ._c-ground-nav__colophon {
+    grid-area: colophon;
+
+    @media (breakpoint.$xl > width >= breakpoint.$m) {
+      margin-top: ms.step(2);
+    }
+  }
+
+  // ._c-ground-nav__bump {
+  //   display: inline-block;
+  //   margin-top: ms.step(2);
+  // }
+
+  // ._o-container--pad-block-start {
+  //   padding-block-start: spacing.$fluid-spacing-block;
+  // }
+
+  // ._c-heading--medium {
+  //   font-weight: font-weight.$medium;
+  // }
+
+  // ._c-ground-nav {
+  //   display: grid;
+  //   grid-template-rows: repeat(3, minmax(0, auto));
+  // }
+
+  // ._c-ground-nav::before {
+  //   background: var(--theme-color-background-secondary);
+  //   content: '';
+  //   grid-column: 1;
+  //   grid-row: 2 / span 2;
+  // }
+
+  // ._c-ground-nav__features {
+  //   grid-column: 1;
+  //   grid-row: 1 / span 2;
+  // }
+
+  // ._c-ground-nav__features-inner {
+  //   display: grid;
+  //   grid-template-columns: minmax(0, 1fr);
+
+  //   @media (width >= breakpoint.$l) {
+  //     grid-template-columns: repeat(2, minmax(0, 1fr));
+  //   }
+  // }
+
+  // ._c-ground-nav__feature {
+  //   @include border-radius.conditional;
+  //   @include spacing.fluid-padding-block;
+  //   width: 100%;
+
+  //   &:only-child {
+  //     margin-inline: auto;
+  //     max-width: size.$max-width-prose;
+
+  //     @media (width >= breakpoint.$l) {
+  //       grid-column: span 2;
+  //     }
+  //   }
+
+  //   @media (width < breakpoint.$l) {
+  //     &:not(:last-child) {
+  //       border-bottom-left-radius: 0;
+  //       border-bottom-right-radius: 0;
+  //     }
+
+  //     &:not(:first-child) {
+  //       border-top-left-radius: 0;
+  //       border-top-right-radius: 0;
+  //     }
+  //   }
+
+  //   @media (width >= breakpoint.$l) {
+  //     &:not(:last-child) {
+  //       border-bottom-right-radius: 0;
+  //       border-top-right-radius: 0;
+  //     }
+
+  //     &:not(:first-child) {
+  //       border-bottom-left-radius: 0;
+  //       border-top-left-radius: 0;
+  //     }
+  //   }
+  // }
+
+  // ._c-ground-nav__inner {
+  //   grid-column: 1;
+  //   grid-row: 3;
+  //   position: relative;
+  // }
+
+  // ._c-ground-nav__content {
+  //   color: var(--theme-color-text-muted);
+  //   column-gap: spacing.$fluid-gap;
+  //   display: grid;
+  //   grid-template-areas: "address"
+  //     "social"
+  //     "primary-nav"
+  //     "secondary-nav"
+  //     "colophon"
+  //     "scene";
+  //   grid-template-columns: minmax(0, 1fr);
+  //   grid-template-rows: repeat(5, minmax(0, auto)) ms.step(6);
+  //   row-gap: ms.step(2);
+
+  //   @media (width >= breakpoint.$s) {
+  //     grid-template-areas: "address address"
+  //       "social social"
+  //       "primary-nav secondary-nav"
+  //       ". scene"
+  //       "colophon scene"
+  //       ". scene";
+  //     grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+  //     grid-template-rows: repeat(6, minmax(0, auto));
+  //   }
+
+  //   @media (width >= breakpoint.$m) {
+  //     grid-template-areas: "address primary-nav secondary-nav"
+  //       ". primary-nav secondary-nav"
+  //       "social primary-nav secondary-nav"
+  //       ". . scene"
+  //       "colophon colophon scene"
+  //       ". . scene";
+  //     grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
+  //   }
+
+  //   @media (width >= breakpoint.$xl) {
+  //     grid-template-areas: "address primary-nav secondary-nav . social"
+  //       "address primary-nav secondary-nav scene scene"
+  //       "colophon primary-nav secondary-nav scene scene"
+  //       ". . . scene scene";
+  //     grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(0, auto);
+  //     grid-template-rows: repeat(3, minmax(0, auto)) spacing.$fluid-spacing-block;
+  //   }
+  // }
+
+  // ._c-ground-nav__address {
+  //   grid-area: address;
+  // }
+
+  // ._c-ground-nav__social {
+  //   grid-area: social;
+  // }
+
+  // ._c-ground-nav__primary-nav {
+  //   grid-area: primary-nav;
+  // }
+
+  // ._c-ground-nav__secondary-nav {
+  //   grid-area: secondary-nav;
+  // }
+
+  // ._c-ground-nav__colophon {
+  //   grid-area: colophon;
+
+  //   @media (width >=breakpoint.$xl) {
+  //     align-self: end;
+  //   }
+  // }
+
+  // ._c-ground-nav__scene {
+  //   block-size: 100%;
+  //   max-block-size: ms.step(10);
+  //   grid-area: scene;
+  //   inline-size: 100%;
+  //   mix-blend-mode: multiply;
+  //   place-self: end;
+  // }
+}

--- a/src/prototypes/new-footer/r3.twig
+++ b/src/prototypes/new-footer/r3.twig
@@ -52,7 +52,6 @@
                 <a href="#">
                   {% include '@cloudfour/components/icon/icon.twig' with {
                     "name": item.icon,
-                    "size": "medium"
                   } only %}
                 </a>
               </li>
@@ -65,88 +64,4 @@
       </div>
     </div>
   </footer>
-  {# <footer class="_c-ground-nav">
-    <div class="_c-ground-nav__features">
-      <div class="o-container o-container--pad-inline">
-        <div class="o-container__content">
-          <div class="o-container__fill _c-ground-nav__features-inner">
-            <div class="_c-ground-nav__feature t-dark t-alternate o-container__pad">
-              (Feature)
-            </div>
-            <div class="_c-ground-nav__feature t-dark o-container__pad">
-              (Feature)
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="_c-ground-nav__inner">
-      <div class="o-container o-container--pad-inline _o-container--pad-block-start">
-        <div class="o-container__content _c-ground-nav__content">
-          <address class="_c-ground-nav__address">
-            <a class="c-heading _c-heading--medium" href="{{organization.url}}">
-              {{organization.name}}
-            </a><br>
-            {{organization.address1}}<br>
-            {{organization.address2}}<br>
-            <a href="mailto:{{ organization.email }}">{{ organization.email }}</a><br>
-            <a href="tel:{{ organization.phone|replace({
-              '.': '-',
-              '(': '-',
-              ')': '-',
-              ' ': ''
-            }) }}">{{ organization.phone }}</a>
-          </address>
-
-          <div class="_c-ground-nav__social">
-            <ul class="o-list o-list--inline">
-              {% for item in social %}
-                <li>
-                  <a href="#">
-                    {% include '@cloudfour/components/icon/icon.twig' with {
-                      "name": item.icon,
-                      "size": "medium"
-                    } only %}
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-          </div>
-
-          <nav class="_c-ground-nav__primary-nav">
-            <h2 class="c-heading _c-heading--medium">Explore</h2>
-            <ul class="o-list">
-              {% for item in nav %}
-                <li>
-                  <a href="{{item.href|default('#')}}">
-                    {{item.title}}
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-          </nav>
-          <nav class="_c-ground-nav__secondary-nav">
-            <h2 class="c-heading _c-heading--medium">Topics</h2>
-            <ul class="o-list">
-              {% for item in topics %}
-                <li>
-                  <a href="{{item.href|default('#')}}">
-                    {{item.title}}
-                  </a>
-                </li>
-              {% endfor %}
-            </ul>
-          </nav>
-
-          <p class="_c-ground-nav__colophon">
-            &copy; 2007&ndash;{{ "now"|date("Y") }} {{organization.name}}
-          </p>
-
-          {% include '@cloudfour/assets/illustrations/portland.svg.twig' with {
-            class: '_c-ground-nav__scene',
-          } %}
-        </div>
-      </div>
-    </div>
-  </footer> #}
 </div>

--- a/src/prototypes/new-footer/r3.twig
+++ b/src/prototypes/new-footer/r3.twig
@@ -1,0 +1,152 @@
+<div id="_new-footer-r3">
+  <footer class="_c-ground-nav">
+    <div class="o-container o-container--pad-inline _c-ground-nav__lead-in">
+      <div class="o-container__content">
+        (lead-in)
+      </div>
+    </div>
+    <div class="o-container o-container--pad _c-ground-nav__main">
+      <div class="o-container__content _c-ground-nav__content">
+        <address class="_c-ground-nav__address">
+          <a class="c-heading _c-heading--medium" href="{{organization.url}}">
+            {{organization.name}}
+          </a><br>
+          {{organization.address1}}<br>
+          {{organization.address2}}<br>
+          <a class="_c-ground-nav__address-section" href="mailto:{{ organization.email }}">{{ organization.email }}</a><br>
+          <a href="tel:{{ organization.phone|replace({
+            '.': '-',
+            '(': '-',
+            ')': '-',
+            ' ': ''
+          }) }}">{{ organization.phone }}</a>
+        </address>
+        <nav class="_c-ground-nav__primary-nav">
+          <h2 class="c-heading _c-heading--medium">Explore</h2>
+          <ul class="o-list">
+            {% for item in nav %}
+              <li>
+                <a href="{{item.href|default('#')}}">
+                  {{item.title}}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+        <nav class="_c-ground-nav__secondary-nav">
+          <h2 class="c-heading _c-heading--medium">Topics</h2>
+          <ul class="o-list">
+            {% for item in topics %}
+              <li>
+                <a href="{{item.href|default('#')}}">
+                  {{item.title}}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
+        <div class="_c-ground-nav__social">
+          <ul class="o-list o-list--inline">
+            {% for item in social %}
+              <li>
+                <a href="#">
+                  {% include '@cloudfour/components/icon/icon.twig' with {
+                    "name": item.icon,
+                    "size": "medium"
+                  } only %}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+        <p class="_c-ground-nav__colophon">
+          &copy; 2007&ndash;{{ "now"|date("Y") }} {{organization.name}}
+        </p>
+      </div>
+    </div>
+  </footer>
+  {# <footer class="_c-ground-nav">
+    <div class="_c-ground-nav__features">
+      <div class="o-container o-container--pad-inline">
+        <div class="o-container__content">
+          <div class="o-container__fill _c-ground-nav__features-inner">
+            <div class="_c-ground-nav__feature t-dark t-alternate o-container__pad">
+              (Feature)
+            </div>
+            <div class="_c-ground-nav__feature t-dark o-container__pad">
+              (Feature)
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="_c-ground-nav__inner">
+      <div class="o-container o-container--pad-inline _o-container--pad-block-start">
+        <div class="o-container__content _c-ground-nav__content">
+          <address class="_c-ground-nav__address">
+            <a class="c-heading _c-heading--medium" href="{{organization.url}}">
+              {{organization.name}}
+            </a><br>
+            {{organization.address1}}<br>
+            {{organization.address2}}<br>
+            <a href="mailto:{{ organization.email }}">{{ organization.email }}</a><br>
+            <a href="tel:{{ organization.phone|replace({
+              '.': '-',
+              '(': '-',
+              ')': '-',
+              ' ': ''
+            }) }}">{{ organization.phone }}</a>
+          </address>
+
+          <div class="_c-ground-nav__social">
+            <ul class="o-list o-list--inline">
+              {% for item in social %}
+                <li>
+                  <a href="#">
+                    {% include '@cloudfour/components/icon/icon.twig' with {
+                      "name": item.icon,
+                      "size": "medium"
+                    } only %}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+
+          <nav class="_c-ground-nav__primary-nav">
+            <h2 class="c-heading _c-heading--medium">Explore</h2>
+            <ul class="o-list">
+              {% for item in nav %}
+                <li>
+                  <a href="{{item.href|default('#')}}">
+                    {{item.title}}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </nav>
+          <nav class="_c-ground-nav__secondary-nav">
+            <h2 class="c-heading _c-heading--medium">Topics</h2>
+            <ul class="o-list">
+              {% for item in topics %}
+                <li>
+                  <a href="{{item.href|default('#')}}">
+                    {{item.title}}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </nav>
+
+          <p class="_c-ground-nav__colophon">
+            &copy; 2007&ndash;{{ "now"|date("Y") }} {{organization.name}}
+          </p>
+
+          {% include '@cloudfour/assets/illustrations/portland.svg.twig' with {
+            class: '_c-ground-nav__scene',
+          } %}
+        </div>
+      </div>
+    </div>
+  </footer> #}
+</div>


### PR DESCRIPTION
## Overview

The intent is for this to replace the existing Ground Nav. It's okay for this to be a breaking change that foregoes the "PWA Stats" use case and changes the data requirements.

I have three revisions of prototypes that are all relevant for different reasons. Below I've highlighted those details, and included screenshots where I mark the key points of reference in each.

---

### [New Footer R1](https://deploy-preview-2192--cloudfour-patterns.netlify.app/?path=/story/prototypes-new-footer--r-1)

<img width="1632" alt="Screenshot 2023-08-22 at 9 46 37 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/f42912c4-3d14-47f5-a0e6-c93f60e3cda2">

- Only prototype with actual "lead-in" promotional content.

---

### [New Footer R2](https://deploy-preview-2192--cloudfour-patterns.netlify.app/?path=/story/prototypes-new-footer--r-2)

Feature Count | Behavior | Screenshot
:---: | --- | ---
0 | No space is reserved for features | <img width="1896" alt="Screenshot 2023-08-22 at 9 49 29 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/5d954dbf-10a6-49be-bf59-fd06312b58c6">
1 | The single feature has a "prose" maximum width | <img width="1895" alt="Screenshot 2023-08-22 at 9 49 16 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/1e3d8b34-4b66-4ca2-961a-2db6747f45be">
2 | The two features stack on small screens, on large screens they fill the default maximum width | <img width="1892" alt="Screenshot 2023-08-22 at 9 49 02 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/a8d3257a-4414-4e7c-a80f-2f8229dca4b0">

- The "lead-in" content adapts to there being zero, one or two items therein.

---

### [New Footer R3](https://deploy-preview-2192--cloudfour-patterns.netlify.app/?path=/story/prototypes-new-footer--r-3)

<img width="1632" alt="Screenshot 2023-08-22 at 9 55 06 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/d14b70ac-25cb-4bbc-9687-196a02856ba5">

- The main footer content (below the "lead-in") is much more worked out here. Also, the overall element adapts to themes better.
- The background uses blend modes so the illustration works well against any color.
- I'm really happy with the grid layout in this one.
- If we plan to start with the HTML/CSS of one of these prototypes, this is the one I'd recommend starting from.

---

### Unresolved Issues
- I would like the footer to work well even if the preceding element is silver (so its color would be white in those cases).
- The conditional border radius for the "lead-in" elements doesn't seem to work super reliably here. I've been thinking it might make sense to replace that mixin's technique with a solution that uses container queries: If need be, we can use this as a testing ground for that idea?