### PR TITLE
Fix some code snippets being too large in iOS

### DIFF
--- a/.changeset/perfect-needles-kick.md
+++ b/.changeset/perfect-needles-kick.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fixes issue where some code snippets had very large text in iOS Safari.

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -33,13 +33,17 @@ html {
  *    considered when calculating `min-content` intrinsic sizes, which means
  *    layout remains broken in any CSS Grid layout.
  *    @see https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#values
- * 2. Prevent size adjustments on orientation change.
+ * 2. Prevent size adjustments on orientation change. The `-webkit-` prefix is
+ *    still required for iOS Safari.
  */
 
 body {
   font-family: font-family.$sans-fallback;
   line-height: line-height.$loose;
   overflow-wrap: anywhere; /* 1 */
+
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-text-size-adjust: none; /* 2 */
   text-size-adjust: none; /* 2 */
 
   @supports (font-variation-settings: normal) {


### PR DESCRIPTION
## Overview

I was reading [one of our recent articles](https://cloudfour.com/thinks/progressively-enhanced-form-validation-part-3-validating-a-checkbox-group/) and noticed that some code snippets had very huge text.

This seems to be resolved by applying our `text-size-adjust` rule to `-webkit-text-size-adjust` as well. This matches [what caniuse says](https://caniuse.com/text-size-adjust) about support for this feature.

## Screenshots

Before | After
--- | ---
![IMG_6489](https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/6684639a-b40c-4110-8d50-698e5b5aeada) | ![IMG_6490](https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/20518f07-f389-48ad-a917-69a9a080f2ac)

## Testing

Unfortunately it's not super clear to me how to reproduce this outside of the context of a blog post, but at least review the code to verify that this seems like a not-very-risky change?
