### PR TITLE
Ground Nav v2

### DIFF
--- a/gulpfile.js/tasks/build-scripts.js
+++ b/gulpfile.js/tasks/build-scripts.js
@@ -2,6 +2,7 @@ const fs = require('node:fs').promises;
 const path = require('node:path');
 
 const { getBabelInputPlugin } = require('@rollup/plugin-babel');
+const json = require('@rollup/plugin-json');
 const nodeResolve = require('@rollup/plugin-node-resolve').default;
 const rollup = require('rollup');
 const dts = require('rollup-plugin-dts').default;
@@ -67,6 +68,7 @@ const buildJS = async () => {
       virtualRootPlugin(),
       getBabelInputPlugin({ extensions, babelHelpers: 'bundled' }),
       nodeResolve({ extensions }),
+      json(),
     ],
   });
   await Promise.all([

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudfour/patterns",
-  "version": "13.4.1",
+  "version": "15.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudfour/patterns",
-      "version": "13.4.1",
+      "version": "15.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.20.12",
@@ -16,6 +16,7 @@
         "@cloudfour/eslint-plugin": "21.1.0",
         "@etchteam/storybook-addon-status": "4.2.2",
         "@rollup/plugin-babel": "6.0.3",
+        "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "13.3.0",
         "@storybook/addon-a11y": "6.5.9",
         "@storybook/addon-docs": "6.5.9",
@@ -4598,6 +4599,60 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.0.0.tgz",
+      "integrity": "sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-json/node_modules/@rollup/pluginutils": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.3.tgz",
+      "integrity": "sha512-hfllNN4a80rwNQ9QCxhxuHCGHMAvabXqxNdaChUSSadMre7t4iEUI6fFAhBOn/eIYTgYVhBv7vCLsAJ4u3lf3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-json/node_modules/@types/estree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+      "dev": true
+    },
+    "node_modules/@rollup/plugin-json/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "13.3.0",
@@ -42173,6 +42228,40 @@
           "requires": {
             "brace-expansion": "^2.0.1"
           }
+        }
+      }
+    },
+    "@rollup/plugin-json": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.0.0.tgz",
+      "integrity": "sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.3.tgz",
+          "integrity": "sha512-hfllNN4a80rwNQ9QCxhxuHCGHMAvabXqxNdaChUSSadMre7t4iEUI6fFAhBOn/eIYTgYVhBv7vCLsAJ4u3lf3g==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "^1.0.0",
+            "estree-walker": "^2.0.2",
+            "picomatch": "^2.3.1"
+          }
+        },
+        "@types/estree": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+          "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+          "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@cloudfour/eslint-plugin": "21.1.0",
     "@etchteam/storybook-addon-status": "4.2.2",
     "@rollup/plugin-babel": "6.0.3",
+    "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@storybook/addon-a11y": "6.5.9",
     "@storybook/addon-docs": "6.5.9",

--- a/src/assets/illustrations/portland.svg
+++ b/src/assets/illustrations/portland.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="450" height="200" viewBox="0 0 450 200">
+<svg xmlns="http://www.w3.org/2000/svg" width="450" height="200" viewBox="0 0 450 200" preserveAspectRatio="xMaxYMax">
   <g>
     <rect x="4" y="60" width="125" height="140" fill="#dae2e8"/>
     <rect x="4" y="170" width="125" height="30" fill="#f2f5f7"/>

--- a/src/components/ground-nav/demo/menu.json
+++ b/src/components/ground-nav/demo/menu.json
@@ -1,10 +1,5 @@
 {
   "items": [
-    { "link": "/portland-device-lab", "title": "Device Lab" },
-    { "link": "https://cloudfour-patterns.netlify.app/", "title": "Patterns" },
-    {
-      "link": "https://www.responsivefieldday.com/",
-      "title": "Responsive Field Day"
-    }
+    { "link": "https://cloudfour-patterns.netlify.app/", "title": "Patterns" }
   ]
 }

--- a/src/components/ground-nav/demo/social.json
+++ b/src/components/ground-nav/demo/social.json
@@ -1,14 +1,14 @@
 {
   "items": [
     {
-      "link": "https://twitter.com/cloudfour",
-      "title": "Follow us on Twitter",
-      "icon": "brands/twitter"
+      "link": "https://www.linkedin.com/company/cloud-four",
+      "title": "Follow us on LinkedIn",
+      "icon": "brands/linkedin"
     },
     {
-      "link": "https://github.com/cloudfour",
-      "title": "Find us on GitHub",
-      "icon": "brands/github"
+      "link": "https://www.youtube.com/channel/UC39ZT0CMds5z0K0Z7RWa98A",
+      "title": "Follow us on YouTube",
+      "icon": "brands/youtube"
     },
     {
       "link": "https://www.instagram.com/cloudfourpdx/",
@@ -16,9 +16,14 @@
       "icon": "brands/instagram"
     },
     {
-      "link": "https://www.linkedin.com/company/cloud-four",
-      "title": "Follow us on LinkedIn",
-      "icon": "brands/linkedin"
+      "link": "https://github.com/cloudfour",
+      "title": "Find us on GitHub",
+      "icon": "brands/github"
+    },
+    {
+      "link": "/feed/atom/",
+      "title": "Subscribe to our RSS Feed",
+      "icon": "feed"
     }
   ]
 }

--- a/src/components/ground-nav/demo/topics.json
+++ b/src/components/ground-nav/demo/topics.json
@@ -1,0 +1,12 @@
+{
+  "items": [
+    { "link": "/topics/rwd", "title": "Responsive Web Design" },
+    { "link": "/topics/ecommerce", "title": "Ecommerce" },
+    { "link": "/topics/performance", "title": "Performance" },
+    { "link": "/topics/images", "title": "Images" },
+    { "link": "/topics/accessibility", "title": "Accessibility" },
+    { "link": "/topics/spotlight", "title": "Cloud Four Spotlight" },
+    { "link": "/topics/css", "title": "CSS" },
+    { "link": "/topics/essentials", "title": "Essentials" }
+  ]
+}

--- a/src/components/ground-nav/ground-nav-args.js
+++ b/src/components/ground-nav/ground-nav-args.js
@@ -61,6 +61,7 @@ export const generateGroundNavProps = (args) => ({
   menu,
   social,
   topics,
+  features: true,
   action:
     args.buttonLeadIn && args.buttonTitle && args.buttonLink && args.buttonIcon
       ? {

--- a/src/components/ground-nav/ground-nav-args.js
+++ b/src/components/ground-nav/ground-nav-args.js
@@ -14,6 +14,7 @@ const menu = { items: [...skyNavMenu.items, ...groundNavMenu.items] };
  * @see https://github.com/storybookjs/storybook/issues/10979
  */
 export const defaultArgs = {
+  alternate: false,
   features: 2,
   organizationName: organization.name,
   organizationStreetAddress: organization.address.street_address,
@@ -31,6 +32,7 @@ export const defaultArgs = {
  * Storybook arg types for the defaultArgs
  */
 export const defaultArgTypes = {
+  alternate: { control: { type: 'boolean' } },
   features: { control: { type: 'number', min: 0, max: 2 } },
   organizationName: { type: { name: 'string' } },
   organizationStreetAddress: { type: { name: 'string' } },
@@ -55,6 +57,7 @@ export const generateGroundNavProps = (args) => ({
   menu,
   social,
   topics,
+  alternate: args.alternate,
   features: args.features,
   organization: {
     name: args.organizationName,

--- a/src/components/ground-nav/ground-nav-args.js
+++ b/src/components/ground-nav/ground-nav-args.js
@@ -14,10 +14,7 @@ const menu = { items: [...skyNavMenu.items, ...groundNavMenu.items] };
  * @see https://github.com/storybookjs/storybook/issues/10979
  */
 export const defaultArgs = {
-  buttonLeadIn: 'Let’s discuss your project!',
-  buttonTitle: 'Email us',
-  buttonLink: 'mailto:info@cloudfour.com',
-  buttonIcon: 'envelope',
+  features: 2,
   organizationName: organization.name,
   organizationStreetAddress: organization.address.street_address,
   organizationAddressLocality: organization.address.address_locality,
@@ -34,10 +31,7 @@ export const defaultArgs = {
  * Storybook arg types for the defaultArgs
  */
 export const defaultArgTypes = {
-  buttonLeadIn: { type: { name: 'string', required: false } },
-  buttonTitle: { type: { name: 'string', required: false } },
-  buttonLink: { type: { name: 'string', required: false } },
-  buttonIcon: { type: { name: 'string', required: false } },
+  features: { control: { type: 'number', min: 0, max: 2 } },
   organizationName: { type: { name: 'string' } },
   organizationStreetAddress: { type: { name: 'string' } },
   organizationAddressLocality: { type: { name: 'string' } },
@@ -61,16 +55,7 @@ export const generateGroundNavProps = (args) => ({
   menu,
   social,
   topics,
-  features: true,
-  action:
-    args.buttonLeadIn && args.buttonTitle && args.buttonLink && args.buttonIcon
-      ? {
-          lead_in: args.buttonLeadIn,
-          title: args.buttonTitle,
-          link: args.buttonLink,
-          icon: args.buttonIcon,
-        }
-      : null,
+  features: args.features,
   organization: {
     name: args.organizationName,
     address: {

--- a/src/components/ground-nav/ground-nav-args.js
+++ b/src/components/ground-nav/ground-nav-args.js
@@ -1,0 +1,87 @@
+// eslint-disable-next-line @cloudfour/import/order
+import skyNavMenu from '../sky-nav/demo/menu.json';
+import groundNavMenu from './demo/menu.json';
+import organization from './demo/organization.json';
+import social from './demo/social.json';
+import topics from './demo/topics.json';
+const menu = { items: [...skyNavMenu.items, ...groundNavMenu.items] };
+
+/**
+ * Default args for Ground Nav stories
+ *
+ * Currently storybook doesn't have support for nested or grouped args.
+ * @see https://github.com/storybookjs/storybook/issues/11525
+ * @see https://github.com/storybookjs/storybook/issues/10979
+ */
+export const defaultArgs = {
+  buttonLeadIn: 'Let’s discuss your project!',
+  buttonTitle: 'Email us',
+  buttonLink: 'mailto:info@cloudfour.com',
+  buttonIcon: 'envelope',
+  organizationName: organization.name,
+  organizationStreetAddress: organization.address.street_address,
+  organizationAddressLocality: organization.address.address_locality,
+  organizationAddressRegion: organization.address.address_region,
+  organizationPostalCode: organization.address.postal_code,
+  organizationAddressCountry: organization.address.address_country,
+  organizationEmail: organization.email,
+  organizationTelephone: organization.telephone,
+  organizationUrl: organization.url,
+  organizationFoundingDate: organization.founding_date,
+};
+
+/**
+ * Storybook arg types for the defaultArgs
+ */
+export const defaultArgTypes = {
+  buttonLeadIn: { type: { name: 'string', required: false } },
+  buttonTitle: { type: { name: 'string', required: false } },
+  buttonLink: { type: { name: 'string', required: false } },
+  buttonIcon: { type: { name: 'string', required: false } },
+  organizationName: { type: { name: 'string' } },
+  organizationStreetAddress: { type: { name: 'string' } },
+  organizationAddressLocality: { type: { name: 'string' } },
+  organizationAddressRegion: { type: { name: 'string' } },
+  organizationPostalCode: { type: { name: 'string' } },
+  organizationAddressCountry: { type: { name: 'string' } },
+  organizationEmail: { type: { name: 'string' } },
+  organizationTelephone: { type: { name: 'string' } },
+  organizationUrl: { type: { name: 'string' } },
+  organizationFoundingDate: { type: { name: 'string' } },
+};
+
+/**
+ * Generate Ground Nav Template Props
+ *
+ * Takes the flat args object and structures it as the template expects.
+ *
+ * @param {defaultArgs} args
+ */
+export const generateGroundNavProps = (args) => ({
+  menu,
+  social,
+  topics,
+  action:
+    args.buttonLeadIn && args.buttonTitle && args.buttonLink && args.buttonIcon
+      ? {
+          lead_in: args.buttonLeadIn,
+          title: args.buttonTitle,
+          link: args.buttonLink,
+          icon: args.buttonIcon,
+        }
+      : null,
+  organization: {
+    name: args.organizationName,
+    address: {
+      street_address: args.organizationStreetAddress,
+      address_locality: args.organizationAddressLocality,
+      address_region: args.organizationAddressRegion,
+      postal_code: args.organizationPostalCode,
+      address_country: args.organizationAddressCountry,
+    },
+    email: args.organizationEmail,
+    telephone: args.organizationTelephone,
+    url: args.organizationUrl,
+    founding_date: args.organizationFoundingDate,
+  },
+});

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -9,17 +9,6 @@
 @use '../../mixins/unit';
 @use 'sass:math';
 
-/**
- * REMAINING TODO
- * - [ ] Fix rounded corners on features
- * - [ ] Fix button colors in feature one
- * - [ ] Update storybook docs
- * - [ ] Updated storybook args to control number of features
- * - [ ] Browser test
- * - [ ] Stretch goal: storybook args for feature content
- * - [x] Pull all grid styles out of `@supports` block
- */
-
 @include theme.props {
   --theme-blend-mode-background: multiply;
 }
@@ -28,46 +17,59 @@
   --theme-blend-mode-background: hard-light;
 }
 
+/**
+ * 1. This grid layout creates 3 rows. The content takes up the last row,
+ *    and the features span the first two rows.
+ * 2. A pseudo-element is positioned behind the features covering the first row
+ * 3. To give the illustion that the page bg color extends behind the features.
+ */
 .c-ground-nav {
   background-color: var(--theme-color-background-base);
-  display: grid;
-  grid-template-rows: repeat(3, minmax(0, auto));
+  display: grid; // 1
+  grid-template-rows: repeat(3, minmax(0, auto)); // 1
 
-  // Pseudo-element positioned to look like page background extends behind features
   &::before {
-    background-color: var(--theme-color-background-secondary);
+    background-color: var(--theme-color-background-secondary); // 3
     content: '';
-    grid-column: 1;
-    grid-row: 2 / span 2;
+    grid-column: 1; // 2
+    grid-row: 2 / span 2; // 2
   }
 }
 
-/**
- * Features
- *
- * 1. Keep contents from overflowing border-radius
- */
 .c-ground-nav__features {
   grid-column: 1;
   grid-row: 1 / span 2;
 }
 
+/**
+ * 1. Used to center `features-inner` when there's only one feature.
+ *    We can't put `margin:auto` on `features-inner` because it has negative
+ *    margins from `o-container__fill`.
+ */
+.c-ground-nav__features-layout {
+  display: flex; // 1
+  justify-content: center; // 1
+}
+
+/**
+ * 1. Keep contents from overflowing border-radius
+ * 2. Used to position the features side-by-side on large screens
+ */
 .c-ground-nav__features-inner {
   @include border-radius.conditional;
   contain: paint; // 1
 
   @media (width >= breakpoint.$l) {
-    display: flex;
+    display: flex; // 2
   }
 }
 
 /**
  * 1. If there's only on feature, center it and use prose width
- * 2. Flex layout to keep feature's inner content full height
+ * 2. Flex layout to keep both features' form elements vertically aligned
  * 3. Features should take up an equal amount of the layout
  */
 .c-ground-nav__feature {
-  // @include border-radius.conditional;
   @include spacing.fluid-padding-block;
 
   &:only-child {
@@ -79,30 +81,6 @@
     display: flex; // 2
     flex: 1; // 3
   }
-
-  // @media (width < breakpoint.$l) {
-  //   &:not(:last-child) {
-  //     border-bottom-left-radius: 0;
-  //     border-bottom-right-radius: 0;
-  //   }
-
-  //   &:not(:first-child) {
-  //     border-top-left-radius: 0;
-  //     border-top-right-radius: 0;
-  //   }
-  // }
-
-  // @media (width >= breakpoint.$l) {
-  //   &:not(:last-child) {
-  //     border-bottom-right-radius: 0;
-  //     border-top-right-radius: 0;
-  //   }
-
-  //   &:not(:first-child) {
-  //     border-bottom-left-radius: 0;
-  //     border-top-left-radius: 0;
-  //   }
-  // }
 }
 
 /**
@@ -114,8 +92,6 @@
 }
 
 /**
- * Content
- *
  * 1. Background blend mode is to keep the illustration working on all colors
  * 2. Illustration size scales on small screens, up to a max width
  * 3. Align illustration to the right edge of the container or viewport

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -22,7 +22,7 @@
   display: grid;
   grid-template-rows: repeat(3, minmax(0, auto));
 
-  // Extends the background color behind the features a bit
+  // Pseudo-element positioned to look like page background extends behind features
   &::before {
     background-color: var(--theme-color-background-secondary);
     content: '';
@@ -32,60 +32,114 @@
 }
 
 /**
- * Feature
+ * Features
+ *
+ * 1. Keep contents from overflowing border-radius
  */
 .c-ground-nav__features {
-  @include border-radius.conditional;
   grid-column: 1;
   grid-row: 1 / span 2;
-  overflow: hidden; // Prevents content from overflowing the border radius
+}
+
+.c-ground-nav__features-inner {
+  @include border-radius.conditional;
+  contain: paint; // 1
+
+  @media (width >= breakpoint.$l) {
+    display: flex;
+  }
 }
 
 /**
- * Feature
+ * 1. If there's only on feature, center it and use prose width
+ * 2. Flex layout to keep feature's inner content full height
+ * 3. Features should take up an equal amount of the layout
  */
 .c-ground-nav__feature {
+  // @include border-radius.conditional;
   @include spacing.fluid-padding-block;
-  inline-size: 100%;
+
+  &:only-child {
+    margin-inline: auto; // 1
+    max-inline-size: size.$max-width-prose; // 1
+  }
+
+  @media (width >= breakpoint.$l) {
+    display: flex; // 2
+    flex: 1; // 3
+  }
+
+  // @media (width < breakpoint.$l) {
+  //   &:not(:last-child) {
+  //     border-bottom-left-radius: 0;
+  //     border-bottom-right-radius: 0;
+  //   }
+
+  //   &:not(:first-child) {
+  //     border-top-left-radius: 0;
+  //     border-top-right-radius: 0;
+  //   }
+  // }
+
+  // @media (width >= breakpoint.$l) {
+  //   &:not(:last-child) {
+  //     border-bottom-right-radius: 0;
+  //     border-top-right-radius: 0;
+  //   }
+
+  //   &:not(:first-child) {
+  //     border-bottom-left-radius: 0;
+  //     border-top-left-radius: 0;
+  //   }
+  // }
+}
+
+/**
+ * 1. Apply grid layout to keep feature actions aligned to the bottom
+ */
+.c-ground-nav__feature-inner {
+  display: grid; // 1
+  grid-template-rows: minmax(0, 1fr) minmax(0, auto); // 1
 }
 
 /**
  * Content
+ *
+ * 1. Background blend mode is to keep the illustration working on all colors
+ * 2. Illustration size scales on small screens, up to a max width
+ * 3. Align illustration to the right edge of the container or viewport
  */
 .c-ground-nav__content {
   --theme-color-text-emphasis: var(--theme-color-text-muted);
-  background-blend-mode: var(--theme-blend-mode-background);
+  background-blend-mode: var(--theme-blend-mode-background); // 1
   background-color: var(--theme-color-background-secondary);
   background-image: svg-load('illustrations/portland.svg');
   background-position: right bottom;
   background-repeat: no-repeat;
-  background-size: auto clamp(ms.step(6), 15vw, ms.step(9));
+  background-size: auto clamp(ms.step(6), 15vw, ms.step(9)); // 2
   color: var(--theme-color-text-muted);
   grid-column: 1;
   grid-row: 3;
 
   @media (width >= breakpoint.$xxl) {
-    background-size: auto ms.step(10);
+    background-size: auto ms.step(10); // 2
   }
 
-  /**
-   * Align image to the right edge of the container or viewport
-   */
   @media (width >= breakpoint.$xxxl) {
     $size-half-spread: math.div(size.$max-width-spread, 2);
     $size-inline-spacing: spacing.$fluid-spacing-inline-max;
     $right-container: calc(
       50vw - #{$size-half-spread} - #{$size-inline-spacing}
     );
-    background-position: right #{$right-container} bottom;
+    background-position: right #{$right-container} bottom; // 3
   }
 }
 
 /**
- * Creates vertical space between elements when grid isn't supported.
+ * 1. Creates vertical space between elements when grid isn't supported.
  */
 .c-ground-nav__content-inner > * + * {
-  margin-block-start: ms.step(2);
+  margin-block-start: ms.step(2); // 1
 }
 
 .c-ground-nav__social-icon {
@@ -122,12 +176,12 @@
     grid-template-columns: minmax(0, 1fr);
     row-gap: ms.step(2);
 
-    // Reserve a bit of space for the illustration
+    // XS Only: Reserve a bit of space for the illustration
     @media (width < breakpoint.$s) {
       padding-block-end: ms.step(6);
     }
 
-    // Pop the menus side by side
+    // S: Pop the menus side by side
     @media (width >= breakpoint.$s) {
       grid-template-areas:
         'address address'
@@ -137,7 +191,7 @@
       grid-template-columns: minmax(0, auto) minmax(0, 1fr);
     }
 
-    // Switch to a horizontal layout
+    // M: Switch to a horizontal layout
     @media (width >= breakpoint.$m) {
       grid-template-areas:
         'address menu topics'
@@ -146,7 +200,7 @@
       grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
     }
 
-    // Now we have space to pop the social icons to the right
+    // XL: Now we have space to pop the social icons to the right
     @media (width >= breakpoint.$xl) {
       grid-template-areas:
         'address menu topics social'
@@ -154,13 +208,13 @@
       grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr);
     }
 
-    // Add a bit more breathing room between items
+    // XXL: Add a bit more breathing room between items
     @media (width >= breakpoint.$xxl) {
       // prettier-ignore
       grid-template-columns: minmax(0, 1fr) repeat(2, minmax(0, auto)) minmax(0, 1fr);
     }
 
-    // Allow generous breathing room between items
+    // XXXL: Allow generous breathing room between items
     @media (width >= breakpoint.$xxxl) {
       // prettier-ignore
       grid-template-columns: minmax(0, 2fr) repeat(2, minmax(0, 1fr)) minmax(0, 2fr);
@@ -168,21 +222,24 @@
   }
 
   /**
-   * Removes the margin used by our fallback design. Grid allows us to
-   * use `grid-gap` to create consistent space between elements.
+   * 1. Removes the margin used by our fallback design.
+   *    Grid allows us to use `gap` to create consistent space between elements.
    */
   .c-ground-nav__content-inner > * + * {
-    margin: 0;
+    margin: 0; // 1
   }
 
   .c-ground-nav__address {
     grid-area: address;
   }
 
+  /**
+   * 1. Add a bit of space between street address and email
+   */
   .c-ground-nav__address-section {
     @media (width >= breakpoint.$m) {
-      display: inline-block;
-      margin-block-start: ms.step(2);
+      display: inline-block; // 1
+      margin-block-start: ms.step(2); // 1
     }
   }
 
@@ -194,23 +251,30 @@
     grid-area: topics;
   }
 
+  /**
+   * 1. Bottom-align to align with last menu items
+   * 2. Reposition in top-right corner
+   */
   .c-ground-nav__social {
-    align-self: end;
+    align-self: end; // 1
     grid-area: social;
 
     @media (width >= breakpoint.$xl) {
-      align-self: start;
-      justify-self: end;
+      align-self: start; // 2
+      justify-self: end; // 2
     }
   }
 
+  /**
+   * 1. Bottom-align to align with last menu items
+   * 2. Gives a little breathing room to the illustration
+   */
   .c-ground-nav__legal {
-    align-self: end;
+    align-self: end; // 1
     grid-area: legal;
 
-    // Gives a little breathing room to the illustration
     @media (breakpoint.$xl > width >= breakpoint.$m) {
-      margin-block-start: ms.step(2);
+      margin-block-start: ms.step(2); // 2
     }
   }
 }

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -17,23 +17,28 @@
   --theme-blend-mode-background: hard-light;
 }
 
-// Whitespace used for gaps, padding and margin
-// (It uses `rem` so space will be consistent throughout the component)
-$_ground-nav-space: ms.step(3, 1rem);
+.c-ground-nav {
+  background-color: var(--theme-color-background-base);
+  display: grid;
+  grid-template-rows: repeat(3, minmax(0, auto));
 
-// Negative value used to reduce the space around elements as well as position elements.
-$_ground-nav-negative-space: ($_ground-nav-space * -1);
-$_ground-nav-border-width: size.$edge-medium;
-$_ground-nav-border-style: solid;
-$_ground-nav-border-color: var(--theme-color-border-base);
-$_ground-nav-border-color-fallback: color.$base-gray-light;
+  // Extends the background color behind the features a bit
+  &::before {
+    background-color: var(--theme-color-background-secondary);
+    content: '';
+    grid-column: 1;
+    grid-row: 2 / span 2;
+  }
+}
 
 /**
  * Feature
  */
 .c-ground-nav__features {
   @include border-radius.conditional;
-  overflow: hidden;
+  grid-column: 1;
+  grid-row: 1 / span 2;
+  overflow: hidden; // Prevents content from overflowing the border radius
 }
 
 /**
@@ -45,73 +50,8 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
 }
 
 /**
- * 1. We establish vertical whitespace for the action to simplify alignment of
- *    the illustration, but other whitespace is assumed to be handled by the
- *    container object to promote alignment with adjacent sections.
- * 2. Allow illustration to be positioned relative to this container.
+ * Content
  */
-
-.c-ground-nav__action {
-  padding-block: $_ground-nav-space; /* 1 */
-  position: relative; /* 2 */
-}
-
-.c-ground-nav__action-inner {
-  /**
-   * Starting at this viewport, we want to position the illustration relative to
-   * the inner element (away from the nearest horizontal edge).
-   */
-
-  @media (min-width: breakpoint.$m) {
-    position: relative;
-  }
-
-  @media (min-width: breakpoint.$l) {
-    align-items: center;
-    display: flex;
-  }
-}
-
-/**
- * 1. Creates space between the action lead in and action title.
- * 2. Adds horizontal space when these elements are side by side.
- */
-.c-ground-nav__action-title {
-  margin-block-start: $_ground-nav-space; /* 1 */
-
-  @media (min-width: breakpoint.$l) {
-    margin: ms.step(4) $_ground-nav-space; /* 2 */
-  }
-}
-
-/**
- * The illustration is aligned with the footer content.
- * As the screen size increases, we decrease the size
- * of the illustration so that it doesn't get too large.
- */
-
-.c-ground-nav__action-illustration {
-  inline-size: 40%;
-  inset-block-end: 0;
-  inset-inline-end: 0;
-  position: absolute;
-
-  /**
-   * We position ourselves relative to a max-width container starting at this
-   * breakpoint, so we have to adjust the bottom position to account for the
-   * change in whitespace.
-   */
-
-  @media (min-width: breakpoint.$m) {
-    inline-size: calc(100% / 3);
-    inset-block-end: $_ground-nav-negative-space;
-  }
-
-  @media (min-width: breakpoint.$l) {
-    inline-size: 25%;
-  }
-}
-
 .c-ground-nav__content {
   --theme-color-text-emphasis: var(--theme-color-text-muted);
   background-blend-mode: var(--theme-blend-mode-background);
@@ -121,8 +61,8 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
   background-repeat: no-repeat;
   background-size: auto clamp(ms.step(6), 15vw, ms.step(9));
   color: var(--theme-color-text-muted);
-  // grid-column: 1;
-  // grid-row: 3;
+  grid-column: 1;
+  grid-row: 3;
 
   @media (width >= breakpoint.$xxl) {
     background-size: auto ms.step(10);
@@ -148,17 +88,12 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
   margin-block-start: ms.step(2);
 }
 
-.c-ground-nav__address {
-}
-
 .c-ground-nav__social-icon {
-  --icon-size: #{size.$icon-large};
-}
+  --icon-size: #{size.$icon-medium};
 
-.c-ground-nav__menu {
-}
-
-.c-ground-nav__menu-items {
+  @media (width >= breakpoint.$xl) {
+    --icon-size: #{size.$icon-large};
+  }
 }
 
 .c-ground-nav__legal {
@@ -240,11 +175,6 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
     margin: 0;
   }
 
-  /**
-   * The visual order of the footer content is different than the
-   * semantic order. We explicitly define where content should
-   * be placed within the grid.
-   */
   .c-ground-nav__address {
     grid-area: address;
   }
@@ -265,12 +195,10 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
   }
 
   .c-ground-nav__social {
-    --icon-size: #{size.$icon-medium};
     align-self: end;
     grid-area: social;
 
     @media (width >= breakpoint.$xl) {
-      --icon-size: #{size.$icon-large};
       align-self: start;
       justify-self: end;
     }
@@ -280,6 +208,7 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
     align-self: end;
     grid-area: legal;
 
+    // Gives a little breathing room to the illustration
     @media (breakpoint.$xl > width >= breakpoint.$m) {
       margin-block-start: ms.step(2);
     }

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -2,9 +2,12 @@
 @use '../../compiled/tokens/scss/color';
 @use '../../compiled/tokens/scss/font-weight';
 @use '../../compiled/tokens/scss/size';
+@use '../../mixins/border-radius';
 @use '../../mixins/ms';
+@use '../../mixins/spacing';
 @use '../../mixins/theme';
 @use '../../mixins/unit';
+@use 'sass:math';
 
 @include theme.props {
   --theme-blend-mode-background: multiply;
@@ -24,6 +27,22 @@ $_ground-nav-border-width: size.$edge-medium;
 $_ground-nav-border-style: solid;
 $_ground-nav-border-color: var(--theme-color-border-base);
 $_ground-nav-border-color-fallback: color.$base-gray-light;
+
+/**
+ * Feature
+ */
+.c-ground-nav__features {
+  @include border-radius.conditional;
+  overflow: hidden;
+}
+
+/**
+ * Feature
+ */
+.c-ground-nav__feature {
+  @include spacing.fluid-padding-block;
+  inline-size: 100%;
+}
 
 /**
  * 1. We establish vertical whitespace for the action to simplify alignment of
@@ -93,19 +112,43 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
   }
 }
 
+.c-ground-nav__content {
+  --theme-color-text-emphasis: var(--theme-color-text-muted);
+  background-blend-mode: var(--theme-blend-mode-background);
+  background-color: var(--theme-color-background-secondary);
+  background-image: svg-load('illustrations/portland.svg');
+  background-position: right bottom;
+  background-repeat: no-repeat;
+  background-size: auto clamp(ms.step(6), 15vw, ms.step(9));
+  color: var(--theme-color-text-muted);
+  // grid-column: 1;
+  // grid-row: 3;
+
+  @media (width >= breakpoint.$xxl) {
+    background-size: auto ms.step(10);
+  }
+
+  /**
+   * Align image to the right edge of the container or viewport
+   */
+  @media (width >= breakpoint.$xxxl) {
+    $size-half-spread: math.div(size.$max-width-spread, 2);
+    $size-inline-spacing: spacing.$fluid-spacing-inline-max;
+    $right-container: calc(
+      50vw - #{$size-half-spread} - #{$size-inline-spacing}
+    );
+    background-position: right #{$right-container} bottom;
+  }
+}
+
 /**
  * Creates vertical space between elements when grid isn't supported.
  */
 .c-ground-nav__content-inner > * + * {
-  margin-block-start: $_ground-nav-space;
+  margin-block-start: ms.step(2);
 }
 
-/**
- * 1. Removes `margin-top` so the organization information is
- *    aligned with the other footer elements
- */
 .c-ground-nav__address {
-  margin-block-start: 0; /* 1 */
 }
 
 .c-ground-nav__social-icon {
@@ -113,48 +156,79 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
 }
 
 .c-ground-nav__menu {
-  border-color: $_ground-nav-border-color-fallback;
-  border-color: $_ground-nav-border-color;
-  border-style: $_ground-nav-border-style;
-  border-width: $_ground-nav-border-width 0;
-  padding: $_ground-nav-space 0;
 }
 
-/**
- * Divides the menu into 2 columns.
- */
 .c-ground-nav__menu-items {
-  // column-gap: $_ground-nav-space;
-  // columns: 2;
 }
 
-.c-ground-nav__kudos,
 .c-ground-nav__legal {
   font-size: size.$font-small;
 }
 
 /**
  * We use CSS grid when supported by the browser.
+ *
+ * As the screen size increases, the number of columns increases.
+ * Instead of making all the columns the same size, we use `minmax`
+ * for some of the columns to make sure the content in these sections
+ * don't have any line breaks, but can still grow as horizontal
+ * space allows.
  */
 @supports (display: grid) {
   .c-ground-nav__content-inner {
+    column-gap: spacing.$fluid-gap;
     display: grid;
-    grid-gap: $_ground-nav-space;
-    margin: 0 auto;
+    grid-template-areas:
+      'address'
+      'menu'
+      'topics'
+      'social'
+      'legal';
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: ms.step(2);
 
-    /**
-     * As the screen size increases, the number of columns increases.
-     * Instead of making all the columns the same size, we use `minmax`
-     * for one of the columns to make sure the content in this section
-     * doesn't have any line breaks, but can still grow as horizontal
-     * space allows.
-     */
-    @media (min-width: breakpoint.$m) {
-      grid-template-columns: 1fr minmax(max-content, 1fr);
+    // Reserve a bit of space for the illustration
+    @media (width < breakpoint.$s) {
+      padding-block-end: ms.step(6);
     }
 
-    @media (min-width: breakpoint.$l) {
-      grid-template-columns: 1fr minmax(max-content, 1fr) 1fr;
+    // Pop the menus side by side
+    @media (width >= breakpoint.$s) {
+      grid-template-areas:
+        'address address'
+        'menu topics'
+        'social social'
+        'legal legal';
+      grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+    }
+
+    // Switch to a horizontal layout
+    @media (width >= breakpoint.$m) {
+      grid-template-areas:
+        'address menu topics'
+        'social menu topics'
+        'legal legal legal';
+      grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
+    }
+
+    // Now we have space to pop the social icons to the right
+    @media (width >= breakpoint.$xl) {
+      grid-template-areas:
+        'address menu topics social'
+        'legal menu topics .';
+      grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr);
+    }
+
+    // Add a bit more breathing room between items
+    @media (width >= breakpoint.$xxl) {
+      // prettier-ignore
+      grid-template-columns: minmax(0, 1fr) repeat(2, minmax(0, auto)) minmax(0, 1fr);
+    }
+
+    // Allow generous breathing room between items
+    @media (width >= breakpoint.$xxxl) {
+      // prettier-ignore
+      grid-template-columns: minmax(0, 2fr) repeat(2, minmax(0, 1fr)) minmax(0, 2fr);
     }
   }
 
@@ -172,50 +246,42 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
    * be placed within the grid.
    */
   .c-ground-nav__address {
-    @media (min-width: breakpoint.$m) {
-      grid-column: 1/2;
-      grid-row: 1/3;
+    grid-area: address;
+  }
+
+  .c-ground-nav__address-section {
+    @media (width >= breakpoint.$m) {
+      display: inline-block;
+      margin-block-start: ms.step(2);
     }
   }
 
   .c-ground-nav__menu {
-    @media (min-width: breakpoint.$m) {
-      border: none;
-      grid-column: 2/3;
-      grid-row: 1/3;
-      padding: 0;
-    }
+    grid-area: menu;
+  }
+
+  .c-ground-nav__topics {
+    grid-area: topics;
   }
 
   .c-ground-nav__social {
-    border: 0 $_ground-nav-border-style $_ground-nav-border-color-fallback;
-    border-color: $_ground-nav-border-color;
+    --icon-size: #{size.$icon-medium};
+    align-self: end;
+    grid-area: social;
 
-    @media (min-width: breakpoint.$m) {
-      border-block-end-width: $_ground-nav-border-width;
-      grid-column: 1/3;
-      padding-block-end: $_ground-nav-space;
-    }
-
-    @media (min-width: breakpoint.$l) {
-      border-block-end-width: 0;
-      grid-column: 3/4;
-      grid-row: 1/2;
+    @media (width >= breakpoint.$xl) {
+      --icon-size: #{size.$icon-large};
+      align-self: start;
       justify-self: end;
-      padding-block-end: 0;
-    }
-  }
-
-  .c-ground-nav__kudos {
-    @media (min-width: breakpoint.$m) {
-      grid-column: 1/3;
     }
   }
 
   .c-ground-nav__legal {
-    @media (min-width: breakpoint.$l) {
-      align-self: end;
-      justify-self: end;
+    align-self: end;
+    grid-area: legal;
+
+    @media (breakpoint.$xl > width >= breakpoint.$m) {
+      margin-block-start: ms.step(2);
     }
   }
 }

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -248,7 +248,6 @@
  */
 .c-ground-nav__legal {
   align-self: end; // 1
-  font-size: size.$font-small;
   grid-area: legal;
 
   @media (breakpoint.$xl > width >= breakpoint.$m) {

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -85,7 +85,7 @@
 }
 
 /**
- * 1. If there's only on feature, center it and use prose width
+ * 1. If there's only one feature, center it and use prose width
  * 2. Flex layout to keep both features' form elements vertically aligned
  * 3. Features should take up an equal amount of the layout
  */

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -3,7 +3,16 @@
 @use '../../compiled/tokens/scss/font-weight';
 @use '../../compiled/tokens/scss/size';
 @use '../../mixins/ms';
+@use '../../mixins/theme';
 @use '../../mixins/unit';
+
+@include theme.props {
+  --theme-blend-mode-background: multiply;
+}
+
+@include theme.props(dark) {
+  --theme-blend-mode-background: hard-light;
+}
 
 // Whitespace used for gaps, padding and margin
 // (It uses `rem` so space will be consistent throughout the component)
@@ -95,12 +104,8 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
  * 1. Removes `margin-top` so the organization information is
  *    aligned with the other footer elements
  */
-.c-ground-nav__organization {
+.c-ground-nav__address {
   margin-block-start: 0; /* 1 */
-}
-
-.c-ground-nav__organization-name {
-  font-weight: font-weight.$bold;
 }
 
 .c-ground-nav__social-icon {
@@ -166,7 +171,7 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
    * semantic order. We explicitly define where content should
    * be placed within the grid.
    */
-  .c-ground-nav__organization {
+  .c-ground-nav__address {
     @media (min-width: breakpoint.$m) {
       grid-column: 1/2;
       grid-row: 1/3;

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -112,7 +112,7 @@
 }
 
 /**
- * 1. Background blend mode is to keep the illustration working on all colors
+ * 1. Background blend mode is set to keep the illustration working on all colors
  * 2. Illustration size scales on small screens, up to a max width
  * 3. Align illustration to the right edge of the container or viewport
  */

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -17,8 +17,7 @@
  * - [ ] Updated storybook args to control number of features
  * - [ ] Browser test
  * - [ ] Stretch goal: storybook args for feature content
- * - [ ] Depending on Tyler's feedback, either pull all grid styles out
- *       of `@supports` block or move them all inside.
+ * - [x] Pull all grid styles out of `@supports` block
  */
 
 @include theme.props {
@@ -147,11 +146,97 @@
   }
 }
 
+.c-ground-nav__content-inner {
+  column-gap: spacing.$fluid-gap;
+  display: grid;
+  grid-template-areas:
+    'address'
+    'menu'
+    'topics'
+    'social'
+    'legal';
+  grid-template-columns: minmax(0, 1fr);
+  row-gap: ms.step(2);
+
+  // XS Only: Reserve a bit of space for the illustration
+  @media (width < breakpoint.$s) {
+    padding-block-end: ms.step(6);
+  }
+
+  // S: Pop the menus side by side
+  @media (width >= breakpoint.$s) {
+    grid-template-areas:
+      'address address'
+      'menu topics'
+      'social social'
+      'legal legal';
+    grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+  }
+
+  // M: Switch to a horizontal layout
+  @media (width >= breakpoint.$m) {
+    grid-template-areas:
+      'address menu topics'
+      'social menu topics'
+      'legal legal legal';
+    grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
+  }
+
+  // XL: Now we have space to pop the social icons to the right
+  @media (width >= breakpoint.$xl) {
+    grid-template-areas:
+      'address menu topics social'
+      'legal menu topics .';
+    grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr);
+  }
+
+  // XXL: Add a bit more breathing room between items
+  @media (width >= breakpoint.$xxl) {
+    // prettier-ignore
+    grid-template-columns: minmax(0, 1fr) repeat(2, minmax(0, auto)) minmax(0, 1fr);
+  }
+
+  // XXXL: Allow generous breathing room between items
+  @media (width >= breakpoint.$xxxl) {
+    // prettier-ignore
+    grid-template-columns: minmax(0, 2fr) repeat(2, minmax(0, 1fr)) minmax(0, 2fr);
+  }
+}
+
+.c-ground-nav__address {
+  grid-area: address;
+}
+
 /**
- * 1. Creates vertical space between elements when grid isn't supported.
+ * 1. Add a bit of space between street address and email
  */
-.c-ground-nav__content-inner > * + * {
-  margin-block-start: ms.step(2); // 1
+.c-ground-nav__address-section {
+  @media (width >= breakpoint.$m) {
+    display: inline-block; // 1
+    margin-block-start: ms.step(2); // 1
+  }
+}
+
+.c-ground-nav__menu {
+  grid-area: menu;
+}
+
+.c-ground-nav__topics {
+  grid-area: topics;
+}
+
+/**
+ * 1. Bottom-align to align with last menu items
+ * 2. Reposition in top-right corner
+ */
+.c-ground-nav__social {
+  align-self: end; // 1
+  grid-area: social;
+
+  @media (width >= breakpoint.$xl) {
+    align-self: start; // 2
+    justify-self: end; // 2
+  }
 }
 
 .c-ground-nav__social-icon {
@@ -162,131 +247,16 @@
   }
 }
 
-.c-ground-nav__legal {
-  font-size: size.$font-small;
-}
-
 /**
- * We use CSS grid when supported by the browser.
- *
- * As the screen size increases, the number of columns increases.
- * Instead of making all the columns the same size, we use `minmax`
- * for some of the columns to make sure the content in these sections
- * don't have any line breaks, but can still grow as horizontal
- * space allows.
+ * 1. Bottom-align to align with last menu items
+ * 2. Gives a little breathing room to the illustration
  */
-@supports (display: grid) {
-  .c-ground-nav__content-inner {
-    column-gap: spacing.$fluid-gap;
-    display: grid;
-    grid-template-areas:
-      'address'
-      'menu'
-      'topics'
-      'social'
-      'legal';
-    grid-template-columns: minmax(0, 1fr);
-    row-gap: ms.step(2);
+.c-ground-nav__legal {
+  align-self: end; // 1
+  font-size: size.$font-small;
+  grid-area: legal;
 
-    // XS Only: Reserve a bit of space for the illustration
-    @media (width < breakpoint.$s) {
-      padding-block-end: ms.step(6);
-    }
-
-    // S: Pop the menus side by side
-    @media (width >= breakpoint.$s) {
-      grid-template-areas:
-        'address address'
-        'menu topics'
-        'social social'
-        'legal legal';
-      grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-    }
-
-    // M: Switch to a horizontal layout
-    @media (width >= breakpoint.$m) {
-      grid-template-areas:
-        'address menu topics'
-        'social menu topics'
-        'legal legal legal';
-      grid-template-columns: repeat(2, minmax(0, auto)) minmax(0, 1fr);
-    }
-
-    // XL: Now we have space to pop the social icons to the right
-    @media (width >= breakpoint.$xl) {
-      grid-template-areas:
-        'address menu topics social'
-        'legal menu topics .';
-      grid-template-columns: repeat(3, minmax(0, auto)) minmax(0, 1fr);
-    }
-
-    // XXL: Add a bit more breathing room between items
-    @media (width >= breakpoint.$xxl) {
-      // prettier-ignore
-      grid-template-columns: minmax(0, 1fr) repeat(2, minmax(0, auto)) minmax(0, 1fr);
-    }
-
-    // XXXL: Allow generous breathing room between items
-    @media (width >= breakpoint.$xxxl) {
-      // prettier-ignore
-      grid-template-columns: minmax(0, 2fr) repeat(2, minmax(0, 1fr)) minmax(0, 2fr);
-    }
-  }
-
-  /**
-   * 1. Removes the margin used by our fallback design.
-   *    Grid allows us to use `gap` to create consistent space between elements.
-   */
-  .c-ground-nav__content-inner > * + * {
-    margin: 0; // 1
-  }
-
-  .c-ground-nav__address {
-    grid-area: address;
-  }
-
-  /**
-   * 1. Add a bit of space between street address and email
-   */
-  .c-ground-nav__address-section {
-    @media (width >= breakpoint.$m) {
-      display: inline-block; // 1
-      margin-block-start: ms.step(2); // 1
-    }
-  }
-
-  .c-ground-nav__menu {
-    grid-area: menu;
-  }
-
-  .c-ground-nav__topics {
-    grid-area: topics;
-  }
-
-  /**
-   * 1. Bottom-align to align with last menu items
-   * 2. Reposition in top-right corner
-   */
-  .c-ground-nav__social {
-    align-self: end; // 1
-    grid-area: social;
-
-    @media (width >= breakpoint.$xl) {
-      align-self: start; // 2
-      justify-self: end; // 2
-    }
-  }
-
-  /**
-   * 1. Bottom-align to align with last menu items
-   * 2. Gives a little breathing room to the illustration
-   */
-  .c-ground-nav__legal {
-    align-self: end; // 1
-    grid-area: legal;
-
-    @media (breakpoint.$xl > width >= breakpoint.$m) {
-      margin-block-start: ms.step(2); // 2
-    }
+  @media (breakpoint.$xl > width >= breakpoint.$m) {
+    margin-block-start: ms.step(2); // 2
   }
 }

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -119,8 +119,8 @@ $_ground-nav-border-color-fallback: color.$base-gray-light;
  * Divides the menu into 2 columns.
  */
 .c-ground-nav__menu-items {
-  column-gap: $_ground-nav-space;
-  columns: 2;
+  // column-gap: $_ground-nav-space;
+  // columns: 2;
 }
 
 .c-ground-nav__kudos,

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -34,6 +34,26 @@
     grid-column: 1; // 2
     grid-row: 2 / span 2; // 2
   }
+
+  .c-ground-nav__content {
+    background-color: var(--theme-color-background-secondary);
+  }
+}
+
+/**
+ * Alternate modifier uses background-secondary for use cases where
+ * the previous block uses background-base.
+ */
+.c-ground-nav--alternate {
+  background-color: var(--theme-color-background-secondary);
+
+  &::before {
+    background-color: var(--theme-color-background-base);
+  }
+
+  .c-ground-nav__content {
+    background-color: var(--theme-color-background-base);
+  }
 }
 
 .c-ground-nav__features {
@@ -99,7 +119,6 @@
 .c-ground-nav__content {
   --theme-color-text-emphasis: var(--theme-color-text-muted);
   background-blend-mode: var(--theme-blend-mode-background); // 1
-  background-color: var(--theme-color-background-secondary);
   background-image: svg-load('illustrations/portland.svg');
   background-position: right bottom;
   background-repeat: no-repeat;

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -9,6 +9,16 @@
 @use '../../mixins/unit';
 @use 'sass:math';
 
+/**
+ * REMAINING TODO
+ * - [ ] Fix rounded corners on features
+ * - [ ] Fix button colors in feature one
+ * - [ ] Update storybook docs
+ * - [ ] Updated storybook args to control number of features
+ * - [ ] Browser test
+ * - [ ] Stretch goal: storybook args for feature content
+ */
+
 @include theme.props {
   --theme-blend-mode-background: multiply;
 }

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -17,6 +17,8 @@
  * - [ ] Updated storybook args to control number of features
  * - [ ] Browser test
  * - [ ] Stretch goal: storybook args for feature content
+ * - [ ] Depending on Tyler's feedback, either pull all grid styles out
+ *       of `@supports` block or move them all inside.
  */
 
 @include theme.props {

--- a/src/components/ground-nav/ground-nav.stories.mdx
+++ b/src/components/ground-nav/ground-nav.stories.mdx
@@ -39,7 +39,7 @@ If you only define a single feature block, it will be centered.
 <Canvas>
   <Story
     name="One Feature"
-    height="815px"
+    height="800px"
     args={{
       ...defaultArgs,
       features: 1,
@@ -62,6 +62,28 @@ If you don't define any feature blocks, the layout will collapse appropriately.
     args={{
       ...defaultArgs,
       features: 0,
+    }}
+    argTypes={defaultArgTypes}
+    parameters={{
+      layout: 'fullscreen',
+    }}
+  >
+    {(args) => template(generateGroundNavProps(args))}
+  </Story>
+</Canvas>
+
+Note that the Ground Nav uses a pseudo-element to fake the page background color
+bleeding down behind the feature blocks on large screens. If the previous block
+is using `background-secondary`, you can set `c-ground-nav--alternate` to swap
+the background colors of the Ground Nav to match.
+
+<Canvas>
+  <Story
+    name="Alternate"
+    height="815px"
+    args={{
+      ...defaultArgs,
+      alternate: true,
     }}
     argTypes={defaultArgTypes}
     parameters={{

--- a/src/components/ground-nav/ground-nav.stories.mdx
+++ b/src/components/ground-nav/ground-nav.stories.mdx
@@ -23,7 +23,7 @@ The yin to [Sky Nav](/docs/components-sky-nav--dark)'s yang, the Ground Nav sits
 <Canvas>
   <Story
     name="Cloud Four"
-    height="500px"
+    height="815px"
     args={defaultArgs}
     argTypes={defaultArgTypes}
     parameters={{
@@ -34,18 +34,34 @@ The yin to [Sky Nav](/docs/components-sky-nav--dark)'s yang, the Ground Nav sits
   </Story>
 </Canvas>
 
-To render a Ground Nav with no call to action, do not pass the `action` property.
+If you only define a single feature block, it will be centered.
 
 <Canvas>
   <Story
-    name="No Action"
-    height="275px"
+    name="One Feature"
+    height="815px"
     args={{
       ...defaultArgs,
-      buttonLeadIn: null,
-      buttonTitle: null,
-      buttonLink: null,
-      buttonIcon: null,
+      features: 1,
+    }}
+    argTypes={defaultArgTypes}
+    parameters={{
+      layout: 'fullscreen',
+    }}
+  >
+    {(args) => template(generateGroundNavProps(args))}
+  </Story>
+</Canvas>
+
+If you don't define any feature blocks, the layout will collapse appropriately.
+
+<Canvas>
+  <Story
+    name="No Features"
+    height="475px"
+    args={{
+      ...defaultArgs,
+      features: 0,
     }}
     argTypes={defaultArgTypes}
     parameters={{
@@ -58,11 +74,7 @@ To render a Ground Nav with no call to action, do not pass the `action` property
 
 ## Template Properties
 
-- `action`: Object containing settings for the "call to action" section.
-  - `lead_in`: The heading text that precedes the button.
-  - `title`: The title of the action link. Named `title` for consistency with menus.
-  - `link`: The URL for the action link. Named `link` for consistency with menus.
-  - `icon`: Optional key to one of [our icons](/docs/design-icons--page) for display in the link.
+- `features`: The number of feature blocks to display. Defaults to 2.
 - `organization`: Object containing Cloud Four details for contact information and copyright. Structure and property names are based on the [the Organization schema](https://schema.org/Organization).
   - `name`
   - `address`

--- a/src/components/ground-nav/ground-nav.stories.mdx
+++ b/src/components/ground-nav/ground-nav.stories.mdx
@@ -1,84 +1,10 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
-import skyNavMenu from '../sky-nav/demo/menu.json';
-import groundNavMenu from './demo/menu.json';
-import organization from './demo/organization.json';
-import social from './demo/social.json';
+import {
+  defaultArgTypes,
+  defaultArgs,
+  generateGroundNavProps,
+} from './ground-nav-args.js';
 import template from './ground-nav.twig';
-// The '!!raw-loader!' syntax is a non-standard, Webpack-specific, syntax.
-// See: https://github.com/webpack-contrib/raw-loader#examples
-// For now, it seems likely Storybook is pretty tied to Webpack, therefore, we are
-// okay with the following Webpack-specific raw loader syntax. It's better to leave
-// the ESLint rule enabled globally, and only thoughtfully disable as needed (e.g.
-// within a Storybook docs page and not within an actual component).
-// This can be revisited in the future if Storybook no longer relies on Webpack.
-// eslint-disable-next-line @cloudfour/import/no-webpack-loader-syntax
-import pwaStatsDemoSource from '!!raw-loader!./demo/pwa-stats.twig';
-import pwaStatsDemo from './demo/pwa-stats.twig';
-const menu = { items: [...skyNavMenu.items, ...groundNavMenu.items] };
-const defaultArgTypes = {
-  buttonLeadIn: { type: { name: 'string', required: false } },
-  buttonTitle: { type: { name: 'string', required: false } },
-  buttonLink: { type: { name: 'string', required: false } },
-  buttonIcon: { type: { name: 'string', required: false } },
-  organizationName: { type: { name: 'string' } },
-  organizationStreetAddress: { type: { name: 'string' } },
-  organizationAddressLocality: { type: { name: 'string' } },
-  organizationAddressRegion: { type: { name: 'string' } },
-  organizationPostalCode: { type: { name: 'string' } },
-  organizationAddressCountry: { type: { name: 'string' } },
-  organizationEmail: { type: { name: 'string' } },
-  organizationTelephone: { type: { name: 'string' } },
-  organizationUrl: { type: { name: 'string' } },
-  organizationFoundingDate: { type: { name: 'string' } },
-};
-const defaultArgs = {
-  buttonLeadIn: 'Let’s discuss your project!',
-  buttonTitle: 'Email us',
-  buttonLink: 'mailto:info@cloudfour.com',
-  buttonIcon: 'envelope',
-  organizationName: organization.name,
-  organizationStreetAddress: organization.address.street_address,
-  organizationAddressLocality: organization.address.address_locality,
-  organizationAddressRegion: organization.address.address_region,
-  organizationPostalCode: organization.address.postal_code,
-  organizationAddressCountry: organization.address.address_country,
-  organizationEmail: organization.email,
-  organizationTelephone: organization.telephone,
-  organizationUrl: organization.url,
-  organizationFoundingDate: organization.founding_date,
-};
-/**
- * Generate Ground Nav Args
- * Takes the flat args object and structures it as the template expects.
- * @param {object} args
- */
-const generateGroundNavProps = (args) => ({
-  menu,
-  social,
-  action:
-    args.buttonLeadIn && args.buttonTitle && args.buttonLink && args.buttonIcon
-      ? {
-          lead_in: args.buttonLeadIn,
-          title: args.buttonTitle,
-          link: args.buttonLink,
-          icon: args.buttonIcon,
-        }
-      : null,
-  organization: {
-    name: args.organizationName,
-    address: {
-      street_address: args.organizationStreetAddress,
-      address_locality: args.organizationAddressLocality,
-      address_region: args.organizationAddressRegion,
-      postal_code: args.organizationPostalCode,
-      address_country: args.organizationAddressCountry,
-    },
-    email: args.organizationEmail,
-    telephone: args.organizationTelephone,
-    url: args.organizationUrl,
-    founding_date: args.organizationFoundingDate,
-  },
-});
 
 <!--
 Inline stories disabled so media queries will behave as expected within
@@ -92,18 +18,12 @@ embedded examples.
 
 # Ground Nav
 
-**Note:** This component is currently a work in progress.
-
 The yin to [Sky Nav](/docs/components-sky-nav--dark)'s yang, the Ground Nav sits at the bottom of all our pages. It includes a call to action, contact information, an expanded navigation menu for lost users and any legal copy.
 
 <Canvas>
   <Story
     name="Cloud Four"
     height="500px"
-    // Currently storybook doesn't have support for nested or grouped args
-    // So for now we are just making them all top-level
-    // https://github.com/storybookjs/storybook/issues/11525
-    // https://github.com/storybookjs/storybook/issues/10979
     args={defaultArgs}
     argTypes={defaultArgTypes}
     parameters={{
@@ -111,34 +31,6 @@ The yin to [Sky Nav](/docs/components-sky-nav--dark)'s yang, the Ground Nav sits
     }}
   >
     {(args) => template(generateGroundNavProps(args))}
-  </Story>
-</Canvas>
-
-The menu’s contents may differ between projects. This example is based on the footer of our [PWA Stats](https://www.pwastats.com/) resource.
-
-<Canvas>
-  <Story
-    name="PWA Stats"
-    height="550px"
-    argTypes={defaultArgTypes}
-    args={{
-      ...defaultArgs,
-      buttonLeadIn: 'Help us build this resource!',
-      buttonTitle: 'Contribute a story',
-      buttonLink:
-        'https://github.com/cloudfour/pwastats/issues/new?title=Submission:+New+Story',
-      buttonIcon: 'brands/github',
-    }}
-    parameters={{
-      layout: 'fullscreen',
-      docs: {
-        source: {
-          code: pwaStatsDemoSource,
-        },
-      },
-    }}
-  >
-    {(args) => pwaStatsDemo(generateGroundNavProps(args))}
   </Story>
 </Canvas>
 
@@ -164,10 +56,6 @@ To render a Ground Nav with no call to action, do not pass the `action` property
   </Story>
 </Canvas>
 
-## Accessibility
-
-Stay tuned!
-
 ## Template Properties
 
 - `action`: Object containing settings for the "call to action" section.
@@ -188,4 +76,6 @@ Stay tuned!
   - `url`
   - `founding_date`: Used for start date of default legal content.
 - `menu`: An object containing navigation menu `items` to iterate over in the same structure as that expected by [Timber menus](https://timber.github.io/docs/guides/menus/).
+- `topics`: The same structure as `menu` but for content topics.
 - `social`: The same structure as `menu` but for social links. Each item must also contain an `icon` property corresponding to a key from [our icon library](/docs/design-icons--page).
+- `legal`: Optional HTML content to display in the legal section. If not provided, a copyright statement will be displayed by default.

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -1,12 +1,3 @@
-{% set legal %}
-  {% block legal %}
-    <p class="c-ground-nav__legal">
-      © {{ organization.founding_date|date('Y') }}–{{ 'now'|date('Y') }}
-      {{ organization.name }}
-    </p>
-  {% endblock %}
-{% endset %}
-
 {% set feature_one %}
   <div class="o-rhythm o-rhythm--condensed">
     <div class="o-rhythm o-rhythm--compact">
@@ -52,7 +43,10 @@
           Cloud Four, in your inbox
         {% endblock %}
       {% endembed %}
-      <p>Our latest articles, updates, quick tips and insights in one convenient, occassional newsletter.</p>
+      <p>
+        Our latest articles, updates, quick tips and insights in one
+        convenient, occasional newsletter.
+      </p>
     </div>
     {% embed '@cloudfour/objects/input-group/input-group.twig' only %}
       {% block content %}
@@ -66,6 +60,15 @@
       {% endblock %}
     {% endembed %}
   </form>
+{% endset %}
+
+{% set legal %}
+  {% block legal %}
+    <p class="c-ground-nav__legal">
+      © {{ organization.founding_date|date('Y') }}–{{ 'now'|date('Y') }}
+      {{ organization.name }}
+    </p>
+  {% endblock %}
 {% endset %}
 
 <footer class="c-ground-nav">

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -113,10 +113,10 @@
 
       {% with organization|default({}) %}
         <div class="c-ground-nav__address">
-          <h2 class="u-hidden-visually">
+          <h2 id="contact-info-label" hidden>
             Contact info
           </h2>
-          <address>{# 1 #}
+          <address aria-labelledby="contact-info-label">{# 1, 3 #}
             <a href="{{ url }}" class="c-heading c-heading--medium">
               {{ name }}
             </a><br>
@@ -181,10 +181,13 @@
       </nav>
 
       <div class="c-ground-nav__social">
-        <h2 class="u-hidden-visually">
-          Social
+        <h2 id="social-links-label" hidden>
+          Social Links
         </h2>
-        <ul class="c-ground-nav__social-list o-list o-list--inline" role="list">{# 5 #}
+        <ul
+          aria-labelledby="social-links-label"
+          class="c-ground-nav__social-list o-list o-list--inline"
+          role="list">{# 5 #}
           {% for item in social.items %}
             <li class="c-ground-nav__social-item">
               <a class="c-ground-nav__social-action" href="{{ item.link }}">

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -1,12 +1,89 @@
 {% set legal %}
   {% block legal %}
     <p class="c-ground-nav__legal">
-      © {{ organization.founding_date|date('Y') }}–{{ 'now'|date('Y') }} {{ organization.name }}
+      © {{ organization.founding_date|date('Y') }}–{{ 'now'|date('Y') }}
+      {{ organization.name }}
     </p>
   {% endblock %}
 {% endset %}
 
+{% set feature_one %}
+  <div class="o-rhythm o-rhythm--condensed">
+    <div class="o-rhythm o-rhythm--compact">
+      {% embed '@cloudfour/components/heading/heading.twig' with {
+        "tag_name": "h2",
+        "level": 1,
+        "weight": "light"
+      } only %}
+        {% block content %}
+          Nice to meet you
+        {% endblock %}
+      {% endembed %}
+      <p>
+        Cloud Four helps organizations solve complex responsive web
+        design and development challenges every day.
+        Let's connect so we can tailor a solution to fit your needs.
+      </p>
+    </div>
+    {% embed '@cloudfour/objects/button-group/button-group.twig' only %}
+      {% block content %}
+        {% include '@cloudfour/components/button/button.twig' with {
+          label: 'See our work',
+          class: 'c-button--secondary'
+        } only %}
+        {% include '@cloudfour/components/button/button.twig' with {
+          label: 'Get in touch',
+          class: 'c-button--secondary'
+        } only %}
+      {% endblock %}
+    {% endembed %}
+  </div>
+{% endset %}
+
+{% set feature_two %}
+  <form class="o-rhythm o-rhythm--condensed" action="#">
+    <div class="o-rhythm o-rhythm--compact">
+      {% embed '@cloudfour/components/heading/heading.twig' with {
+        "tag_name": "h2",
+        "level": 1,
+        "weight": "light"
+      } only %}
+        {% block content %}
+          Cloud Four, in your inbox
+        {% endblock %}
+      {% endembed %}
+      <p>Our latest articles, updates, quick tips and insights in one convenient, occassional newsletter.</p>
+    </div>
+    {% embed '@cloudfour/objects/input-group/input-group.twig' only %}
+      {% block content %}
+        {% include '@cloudfour/components/input/input.twig' with {
+          placeholder: 'Your Email',
+          type: 'email',
+        } only %}
+        {% include '@cloudfour/components/button/button.twig' with {
+          label: 'Sign up'
+        } only %}
+      {% endblock %}
+    {% endembed %}
+  </form>
+{% endset %}
+
 <footer class="c-ground-nav">
+  {% if features %}
+    <div class="c-ground-nav__features o-container o-container--pad-inline">
+      <div class="o-container__content">
+        <div class="c-ground-nav__features-inner o-container__fill">
+          <div class="_c-ground-nav__feature t-dark t-alternate o-container__pad">
+            {{ feature_one }}
+          </div>
+          <div class="_c-ground-nav__feature t-dark o-container__pad">
+            {{ feature_two }}
+          </div>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
   {% if action %}
     {% with action|default({}) %}
       <div class="c-ground-nav__action o-container o-container--pad-inline">
@@ -52,26 +129,33 @@
     <div class="c-ground-nav__content-inner o-container__content">
 
       {% with organization|default({}) %}
-        <h2 class="u-hidden-visually">Contact info</h2>
-        <address class="c-ground-nav__organization">{# 1 #}
-          <a href="{{ url }}" class="c-ground-nav__organization-name">
-            {{ name }}
-          </a><br>
-          {% with address|default({}) %}
-            {{ street_address }}<br>
-            {{ address_locality }},
-            {{ address_region }}
-            {{ postal_code }}
-            {{ address_country }}<br>
-          {% endwith %}
-          <a class="c-ground-nav__section" href="mailto:{{ email }}">{{ email }}</a><br>
-          <a href="tel:{{ telephone|replace({
-            '.': '-',
-            '(': '-',
-            ')': '-',
-            ' ': ''
-          }) }}">{{ telephone }}</a>{# 2 #}
-        </address>
+        <div class="c-ground-nav__contact">
+          <h2 class="u-hidden-visually">
+            Contact info
+          </h2>
+          <address class="c-ground-nav__address">{# 1 #}
+            <a href="{{ url }}" class="c-heading c-heading--medium">
+              {{ name }}
+            </a><br>
+            {% with address|default({}) %}
+              {{ street_address }}<br>
+              {{ address_locality }},
+              {{ address_region }}
+              {{ postal_code }}
+              {{ address_country }}<br>
+            {% endwith %}
+            <a
+              class="c-ground-nav__address-section"
+              href="mailto:{{ email }}"
+            >{{ email }}</a><br>
+            <a href="tel:{{ telephone|replace({
+              '.': '-',
+              '(': '-',
+              ')': '-',
+              ' ': ''
+            }) }}">{{ telephone }}</a>{# 2 #}
+          </address>
+        </div>
       {% endwith %}
 
       <nav class="c-ground-nav__menu" aria-labelledby="explore-menu-label">{# 3 #}
@@ -94,8 +178,10 @@
         </ul>
       </nav>
 
-      <nav class="c-ground-nav__menu" aria-labelledby="topics-menu-label">
-        <h2 id="topics-menu-label" class="c-heading c-heading--medium">Topics</h2>
+      <nav class="c-ground-nav__topics" aria-labelledby="topics-menu-label">{# 3 #}
+        <h2 id="topics-menu-label" class="c-heading c-heading--medium">
+          Topics
+        </h2>
         <ul class="c-ground-nav__menu-items o-list" role="list">{# 5 #}
           {% for item in topics.items %}
             <li class="c-ground-nav__menu-item">
@@ -112,8 +198,10 @@
       </nav>
 
       <div class="c-ground-nav__social">
-        <h2 class="u-hidden-visually">Social</h2>
-        <ul class="c-ground-nav__social-list o-list o-list--inline" role="list">{# 4 #}
+        <h2 class="u-hidden-visually">
+          Social
+        </h2>
+        <ul class="c-ground-nav__social-list o-list o-list--inline" role="list">{# 5 #}
           {% for item in social.items %}
             <li class="c-ground-nav__social-item">
               <a class="c-ground-nav__social-action" href="{{ item.link }}">

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -1,7 +1,3 @@
-{% set kudos %}
-  {% block kudos %}{% endblock %}
-{% endset %}
-
 {% set legal %}
   {% block legal %}
     <p class="c-ground-nav__legal">
@@ -34,58 +30,56 @@
     {% endwith %}
   {% endif %}
 
+  {#
+    Ground Nav Content:
+    1. Usage of the `address` element
+      @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
+    2. Format phone numbers for click-to-call
+      @see https://web.dev/click-to-call/
+    3. Prefer `aria-labelledby` to `aria-label` for translation
+      @see https://heydonworks.com/article/aria-label-is-a-xenophobe/
+    4. We want different text for screenreaders than sighted users.
+      For sighted users "Explore" is a better label, but for screenreaders,
+      who may be navigating by roles or headings, indicating that this menu
+      contains the main menu contents plus some links is more meaningful.
+    5. Add `role="list"` to list elements to retain screenreader semantics
+      @see https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
+    6. Add `focusable="false"` to SVGs to retain screenreader semantics
+      @see https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html#svgs-that-are-decorative
+  #}
+
   <div class="c-ground-nav__content o-container o-container--pad t-alternate">
     <div class="c-ground-nav__content-inner o-container__content">
-      <h2 class="u-hidden-visually">
-        Contact info
-      </h2>
-      {# https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address #}
+
       {% with organization|default({}) %}
-        <address class="c-ground-nav__organization">
+        <h2 class="u-hidden-visually">Contact info</h2>
+        <address class="c-ground-nav__organization">{# 1 #}
           <a href="{{ url }}" class="c-ground-nav__organization-name">
             {{ name }}
           </a><br>
           {% with address|default({}) %}
             {{ street_address }}<br>
-            {{ address_locality }}, {{ address_region }} {{ postal_code }} {{ address_country }}<br>
+            {{ address_locality }},
+            {{ address_region }}
+            {{ postal_code }}
+            {{ address_country }}<br>
           {% endwith %}
-          <a href="mailto:{{ email }}">{{ email }}</a><br>
-          {# https://developers.google.com/web/fundamentals/native-hardware/click-to-call/ #}
+          <a class="c-ground-nav__section" href="mailto:{{ email }}">{{ email }}</a><br>
           <a href="tel:{{ telephone|replace({
             '.': '-',
             '(': '-',
             ')': '-',
             ' ': ''
-          }) }}">{{ telephone }}</a>
+          }) }}">{{ telephone }}</a>{# 2 #}
         </address>
       {% endwith %}
-      {# https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html #}
-      <div class="c-ground-nav__social">
-        <ul class="c-ground-nav__social-list o-list o-list--inline" role="list">
-          {% for item in social.items %}
-            <li class="c-ground-nav__social-item">
-              <a class="c-ground-nav__social-action" href="{{ item.link }}">
-                {# https://heydonworks.com/article/aria-label-is-a-xenophobe/ #}
-                <span class="u-hidden-visually">{{ item.title }}</span>
-                {# http://simplyaccessible.com/article/7-solutions-svgs/#acc-heading-4 #}
-                {% include '@cloudfour/components/icon/icon.twig' with {
-                  name: item.icon,
-                  fallback: 'link',
-                  focusable: 'false',
-                  class: 'c-ground-nav__social-icon'
-                } only %}
-              </a>
-            </li>
-          {% endfor %}
-        </ul>
-      </div>
 
-      <nav class="c-ground-nav__menu" aria-labelledby="footer-menu-label">
-        <h2 id="footer-menu-label" class="u-hidden-visually">
-          Extended Menu
+      <nav class="c-ground-nav__menu" aria-labelledby="explore-menu-label">{# 3 #}
+        <h2 id="explore-menu-label" class="c-heading c-heading--medium">
+          <span aria-hidden="true">Explore</span>{# 4 #}
+          <span class="u-hidden-visually">Extended Menu</span>{# 4 #}
         </h2>
-        {# https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html #}
-        <ul class="c-ground-nav__menu-items o-list" role="list">
+        <ul class="c-ground-nav__menu-items o-list" role="list">{# 5 #}
           {% for item in menu.items %}
             <li class="c-ground-nav__menu-item">
               <a class="c-ground-nav__menu-action"
@@ -100,9 +94,41 @@
         </ul>
       </nav>
 
-      {% if kudos %}
-        {{ kudos }}
-      {% endif %}
+      <nav class="c-ground-nav__menu" aria-labelledby="topics-menu-label">
+        <h2 id="topics-menu-label" class="c-heading c-heading--medium">Topics</h2>
+        <ul class="c-ground-nav__menu-items o-list" role="list">{# 5 #}
+          {% for item in topics.items %}
+            <li class="c-ground-nav__menu-item">
+              <a class="c-ground-nav__menu-action"
+                href="{{ item.link }}"
+                {% if item.current %}
+                  aria-current="page"
+                {% endif %}>
+                {{ item.title }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </nav>
+
+      <div class="c-ground-nav__social">
+        <h2 class="u-hidden-visually">Social</h2>
+        <ul class="c-ground-nav__social-list o-list o-list--inline" role="list">{# 4 #}
+          {% for item in social.items %}
+            <li class="c-ground-nav__social-item">
+              <a class="c-ground-nav__social-action" href="{{ item.link }}">
+                <span class="u-hidden-visually">{{ item.title }}</span>
+                {% include '@cloudfour/components/icon/icon.twig' with {
+                  name: item.icon,
+                  fallback: 'link',
+                  focusable: 'false',
+                  class: 'c-ground-nav__social-icon'
+                } only %}{# 6 #}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
 
       {% if legal %}
         {{ legal }}

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -72,16 +72,19 @@
 {% endset %}
 
 <footer class="c-ground-nav">
-  {% if features %}
+  {% if features > 0 %}
     <div class="c-ground-nav__features o-container o-container--pad-inline">
-      <div class="o-container__content">
-        <div class="c-ground-nav__features-inner o-container__fill">
-          <div class="c-ground-nav__feature t-dark t-alternate o-container__pad">
+      <div class="c-ground-nav__features-layout o-container__content">
+        <div class="c-ground-nav__features-inner t-dark o-container__fill">
+          <div class="c-ground-nav__feature o-container__pad
+                      {% if features > 1 %}t-alternate{% endif %}">
             {{ feature_one }}
           </div>
-          <div class="c-ground-nav__feature t-dark o-container__pad">
-            {{ feature_two }}
-          </div>
+          {% if features > 1 %}
+            <div class="c-ground-nav__feature o-container__pad">
+              {{ feature_two }}
+            </div>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -76,38 +76,15 @@
     <div class="c-ground-nav__features o-container o-container--pad-inline">
       <div class="o-container__content">
         <div class="c-ground-nav__features-inner o-container__fill">
-          <div class="_c-ground-nav__feature t-dark t-alternate o-container__pad">
+          <div class="c-ground-nav__feature t-dark t-alternate o-container__pad">
             {{ feature_one }}
           </div>
-          <div class="_c-ground-nav__feature t-dark o-container__pad">
+          <div class="c-ground-nav__feature t-dark o-container__pad">
             {{ feature_two }}
           </div>
         </div>
       </div>
     </div>
-  {% endif %}
-
-  {% if action %}
-    {% with action|default({}) %}
-      <div class="c-ground-nav__action o-container o-container--pad-inline">
-        <div class="o-container__content c-ground-nav__action-inner">
-          <h2 class="c-ground-nav__action-lead-in">
-            {{ lead_in }}
-          </h2>
-          <p class="c-ground-nav__action-title">
-            {% include '@cloudfour/components/button/button.twig' with {
-              class: 'c-button--primary',
-              href: link,
-              label: title,
-              content_start_icon: icon ?? 'link'
-            } only %}
-          </p>
-          {% include '@cloudfour/assets/illustrations/portland.svg.twig' with {
-            class: 'c-ground-nav__action-illustration'
-          } %}
-        </div>
-      </div>
-    {% endwith %}
   {% endif %}
 
   {#
@@ -132,11 +109,11 @@
     <div class="c-ground-nav__content-inner o-container__content">
 
       {% with organization|default({}) %}
-        <div class="c-ground-nav__contact">
+        <div class="c-ground-nav__address">
           <h2 class="u-hidden-visually">
             Contact info
           </h2>
-          <address class="c-ground-nav__address">{# 1 #}
+          <address>{# 1 #}
             <a href="{{ url }}" class="c-heading c-heading--medium">
               {{ name }}
             </a><br>

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -71,7 +71,7 @@
   {% endblock %}
 {% endset %}
 
-<footer class="c-ground-nav">
+<footer class="c-ground-nav {% if alternate %}c-ground-nav--alternate{% endif %}">
   {% if features > 0 %}
     <div class="c-ground-nav__features o-container o-container--pad-inline">
       <div class="c-ground-nav__features-layout o-container__content">
@@ -108,7 +108,7 @@
       @see https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html#svgs-that-are-decorative
   #}
 
-  <div class="c-ground-nav__content o-container o-container--pad t-alternate">
+  <div class="c-ground-nav__content o-container o-container--pad">
     <div class="c-ground-nav__content-inner o-container__content">
 
       {% with organization|default({}) %}

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -1,5 +1,5 @@
 {% set feature_one %}
-  <div class="o-rhythm o-rhythm--condensed">
+  <div class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed">
     <div class="o-rhythm o-rhythm--compact">
       {% embed '@cloudfour/components/heading/heading.twig' with {
         "tag_name": "h2",
@@ -32,7 +32,7 @@
 {% endset %}
 
 {% set feature_two %}
-  <form class="o-rhythm o-rhythm--condensed" action="#">
+  <form class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed" action="#">
     <div class="o-rhythm o-rhythm--compact">
       {% embed '@cloudfour/components/heading/heading.twig' with {
         "tag_name": "h2",

--- a/src/components/heading/heading.scss
+++ b/src/components/heading/heading.scss
@@ -61,8 +61,8 @@ $max-width-permalink-shift: math.div($min-width-permalink-shift * 16 - 1, 16);
 /// maintain the importance of headings without drowning out other content.
 ///
 /// 1. Restore default font weight for bold/emphasis elements nested within
-///    light and medium headings. Without this, `b` and `strong` elements will only be one
-///    step up in weight.
+///    light and medium headings. Without this, `b` and `strong` elements will
+///    only be one step up in weight.
 
 .c-heading--light {
   font-weight: font-weight.$light;

--- a/src/components/heading/heading.scss
+++ b/src/components/heading/heading.scss
@@ -61,7 +61,7 @@ $max-width-permalink-shift: math.div($min-width-permalink-shift * 16 - 1, 16);
 /// maintain the importance of headings without drowning out other content.
 ///
 /// 1. Restore default font weight for bold/emphasis elements nested within
-///    light headings. Without this, `b` and `strong` elements will only be one
+///    light and medium headings. Without this, `b` and `strong` elements will only be one
 ///    step up in weight.
 
 .c-heading--light {

--- a/src/components/heading/heading.scss
+++ b/src/components/heading/heading.scss
@@ -59,15 +59,26 @@ $max-width-permalink-shift: math.div($min-width-permalink-shift * 16 - 1, 16);
 /// The default font weight for headings is normally defined by heading level.
 /// This modifier will change the heading to font-weight.$light. We do this to
 /// maintain the importance of headings without drowning out other content.
+///
+/// 1. Restore default font weight for bold/emphasis elements nested within
+///    light headings. Without this, `b` and `strong` elements will only be one
+///    step up in weight.
+
 .c-heading--light {
   font-weight: font-weight.$light;
 
-  // Restore default font weight for bold/emphasis elements nested within light
-  // headings. Without this, `b` and `strong` elements will only be one step
-  // up in weight.
   b,
   strong {
-    font-weight: font-weight.$bold;
+    font-weight: font-weight.$bold; // 1
+  }
+}
+
+.c-heading--medium {
+  font-weight: font-weight.$medium;
+
+  b,
+  strong {
+    font-weight: font-weight.$bold; // 1
   }
 }
 

--- a/src/components/heading/heading.stories.mdx
+++ b/src/components/heading/heading.stories.mdx
@@ -138,6 +138,16 @@ By default, headings use the value of our `font-weight.$bold` token so they'll s
     {(args) => demo(args)}
   </Story>
   <Story
+    name="Medium weight"
+    args={{
+      level: 1,
+      weight: 'medium',
+      content: 'Medium weight with <b>bold</b> word',
+    }}
+  >
+    {(args) => demo(args)}
+  </Story>
+  <Story
     name="Light weight"
     args={{
       level: 1,

--- a/src/components/sky-nav/demo/menu.json
+++ b/src/components/sky-nav/demo/menu.json
@@ -5,7 +5,7 @@
     { "link": "/made", "title": "Our Work" },
     { "link": "/thinks", "title": "Articles" },
     { "link": "/presents", "title": "Speaking" },
-    { "link": "/contributes", "title": "Labs" },
-    { "link": "/is", "title": "Team" }
+    { "link": "/is", "title": "Team" },
+    { "link": "/and-you", "title": "Hire Us" }
   ]
 }

--- a/src/components/sky-nav/sky-nav.test.ts
+++ b/src/components/sky-nav/sky-nav.test.ts
@@ -83,11 +83,11 @@ test(
               link "Speaking"
                 text "Speaking"
             listitem
-              link "Labs"
-                text "Labs"
-            listitem
               link "Team"
                 text "Team"
+            listitem
+              link "Hire Us"
+                text "Hire Us"
     `);
   })
 );
@@ -131,11 +131,11 @@ test(
               link "Speaking"
                 text "Speaking"
             listitem
-              link "Labs"
-                text "Labs"
-            listitem
               link "Team"
                 text "Team"
+            listitem
+              link "Hire Us"
+                text "Hire Us"
     `);
   })
 );


### PR DESCRIPTION
## Overview

This PR updates the Ground Nav component to version two. This version intentionally drops the "PWA Stats" use case, and so is a breaking change.

The intent of this redesign is largely to allow for two "feature" blocks which could be configured. The layout is meant to handle zero, one, or two features automatically.

## Screenshots

<img width="1620" alt="Screenshot 2023-08-28 at 3 22 56 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/257309/56823aa8-91a0-4c3d-a2a6-1d9cc1844ace">

## Testing

1. Review the preview deploy and check out all four Ground Nav stories (compare to the prototypes in #2192)
    - [x] Default
    - [x] One Feature
    - [x] No Features
    - [x] Alternate
3. Test in the following browsers:
    - [x] Chrome
    - [x] Edge
    - [x] Firefox
    - [x] Desktop Safari
    - [x] Mobile Safari
    - [x] VoiceOver

### Known Issues

The rounded corners on the features block are meant to be removed when they fill the viewport. This behavior does not work properly with visible scrollbars. This is a known issue affecting other patterns, and not a release blocker here.