### PR TITLE
Improve "diff" highlight support

### DIFF
--- a/.changeset/pink-bulldogs-invent.md
+++ b/.changeset/pink-bulldogs-invent.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Improves support for the "diff" language in our custom Highlight theme.

--- a/src/vendor/highlight/_theme.scss
+++ b/src/vendor/highlight/_theme.scss
@@ -38,6 +38,7 @@
   color: color.$base-orange-lighter;
 }
 
+.hljs-deletion,
 .hljs-literal,
 .hljs-selector-tag,
 .hljs-symbol,
@@ -58,6 +59,7 @@
   );
 }
 
+.hljs-addition,
 .hljs-string {
   color: color.$base-green-lighter;
 }

--- a/src/vendor/highlight/demo/samples/diff.txt
+++ b/src/vendor/highlight/demo/samples/diff.txt
@@ -1,0 +1,19 @@
+Index: languages/ini.js
+===================================================================
+--- languages/ini.js    (revision 199)
++++ languages/ini.js    (revision 200)
+@@ -1,8 +1,7 @@
+ hljs.LANGUAGES.ini =
+ {
+   case_insensitive: true,
+-  defaultMode:
+-  {
++  defaultMode: {
+     contains: ['comment', 'title', 'setting'],
+     illegal: '[^\\s]'
+   },
+
+*** /path/to/original timestamp
+--- /path/to/new      timestamp
+***************
+*** 1,3 ****


### PR DESCRIPTION
## Overview

Adds styles for the Highlight `-addition` and `-deletion` token classes. These only set `color` to maintain compatibility with syntax-highlighting code block features like highlighted lines and line numbers, while also maintaining our existing color contrast.

## Screenshots

<img width="558" alt="Screenshot 2023-08-28 at 3 42 14 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/346d93bb-a6d3-4a76-919d-25b22503e558">

## Testing

On the deploy preview, view the Highlight story with the "diff" language selected: https://deploy-preview-2195--cloudfour-patterns.netlify.app/?path=/story/vendor-highlight--theme&args=language:diff

Confirm that the deleted line appears red and the added line appears green.

