### PR TITLE
Add styles for `details` and `.wp-block-details`

### DIFF
--- a/.changeset/honest-paws-hug.md
+++ b/.changeset/honest-paws-hug.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add styles for WordPress core "Details" block.

--- a/.changeset/violet-grapes-teach.md
+++ b/.changeset/violet-grapes-teach.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add default styles for `details` element.

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -282,6 +282,11 @@ details {
     list-style: none; // 3
     padding-inline-start: size.$spacing-type-block-indent; // 4
     position: relative; // 3
+
+    /// Safari 16.6 demands more than `list-style: none`
+    &::-webkit-details-marker {
+      display: none;
+    }
   }
 
   /// Icon affordance for summary. We use a pseudo element so we can rotate it

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -306,11 +306,17 @@ details {
 
     // Vary the icon color based on the theme.
     @include theme.styles {
-      background-image: svg-load('icons/caret-right.svg', fill=color.$text-dark);
+      background-image: svg-load(
+        'icons/caret-right.svg',
+        fill=color.$text-dark
+      );
     }
 
     @include theme.styles(dark) {
-      background-image: svg-load('icons/caret-right.svg', fill=color.$text-light-emphasis);
+      background-image: svg-load(
+        'icons/caret-right.svg',
+        fill=color.$text-light-emphasis
+      );
     }
 
     // Animate the icon rotation if the user has no reduced motion preference.

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -1,6 +1,10 @@
 @use 'sass:math';
 @use '../compiled/tokens/scss/color';
+@use '../compiled/tokens/scss/ease';
+@use '../compiled/tokens/scss/font-weight';
+@use '../compiled/tokens/scss/line-height';
 @use '../compiled/tokens/scss/size';
+@use '../compiled/tokens/scss/transition';
 @use '../mixins/border-radius';
 @use '../mixins/emdash';
 @use '../mixins/ms';
@@ -255,6 +259,69 @@ blockquote > footer > cite {
     @include emdash.content;
     inset-inline-start: 0;
     position: absolute;
+  }
+}
+
+/// Details/Summary
+///
+/// 1. Apply vertical rhythm between child elements, similar to `blockquote`
+
+details {
+  @include spacing.vertical-rhythm; // 1
+
+  /// 1. Offset the summary text a bit from its contents
+  /// 2. Use the same interaction affordance as buttons
+  /// 3. Set up our custom marker. Because Safari for `::marker` is poor, we
+  ///    have to use some hackery instead.
+  /// 4. Apply padding that is consistent with lists.
+  ///
+  > summary {
+    color: var(--theme-color-text-emphasis); // 1
+    cursor: pointer; // 2
+    font-weight: font-weight.$medium;
+    list-style: none; // 3
+    padding-inline-start: size.$spacing-type-block-indent; // 4
+    position: relative; // 3
+  }
+
+  /// Icon affordance for summary. We use a pseudo element so we can rotate it
+  /// without an additional asset.
+  ///
+  /// 1. Align nicely with adjacent text, using the default `line-height` as a
+  ///    fallback when line-height units aren't supported.
+  /// 2. Offset just a bit visually so the pointer aligns nicely with the
+  ///    content below. We use `translate` instead of `transform` so we can
+  ///    modify the rotation without repeating this style.
+  > summary::before {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    block-size: line-height.$loose * 1em; // 1
+    block-size: 1lh; // 1
+    content: '';
+    inline-size: 1em;
+    inset-inline-start: 0;
+    position: absolute;
+    translate: -33% 0; // 2
+
+    // Vary the icon color based on the theme.
+    @include theme.styles {
+      background-image: svg-load('icons/caret-right.svg', fill=color.$text-dark);
+    }
+
+    @include theme.styles(dark) {
+      background-image: svg-load('icons/caret-right.svg', fill=color.$text-light-emphasis);
+    }
+
+    // Animate the icon rotation if the user has no reduced motion preference.
+    @media (prefers-reduced-motion: no-preference) {
+      transition: rotate transition.$immediate ease.$out;
+    }
+  }
+
+  // Rotate the icon when the details element is open.
+  &[open] > summary::before {
+    rotate: 90deg;
   }
 }
 

--- a/src/design/defaults.stories.mdx
+++ b/src/design/defaults.stories.mdx
@@ -126,3 +126,15 @@ To add space between the `hr` and adjacent elements, consider wrapping the secti
 <p>Shifting our focus to something else entirely…</p>`}
   </Story>
 </Canvas>
+
+## Details/Summary
+
+<Canvas>
+  <Story name="Details/Summary">
+    {`<details open>
+  <summary>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</summary>
+  <p>Mauris imperdiet est lectus, porttitor lobortis magna bibendum mattis.</p>
+  <p>Nullam feugiat ornare lorem id sollicitudin. </p>
+</details>`}
+  </Story>
+</Canvas>

--- a/src/vendor/wordpress/core-blocks.stories.mdx
+++ b/src/vendor/wordpress/core-blocks.stories.mdx
@@ -1,5 +1,6 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import blockCodeDemo from './demo/code.twig';
+import blockDetailsDemo from './demo/details.twig';
 import blockEmbedSpeakerDeckDemo from './demo/embed/speakerdeck.twig';
 import blockEmbedYouTubeDemo from './demo/embed/youtube.twig';
 import blockImageDemo from './demo/image.twig';
@@ -259,6 +260,27 @@ The text overlay inside the cover block its own `div` wrapper with a class of
           <p class="has-text-align-center has-large-font-size">Waterfall</p></p>
         </div>
       </div>`}
+  </Story>
+</Canvas>
+
+## Details
+
+A simple wrapper for the HTML `details` element.
+
+<Canvas>
+  <Story
+    name="Details"
+    parameters={{ layout: 'fullscreen' }}
+    argTypes={{
+      open: {
+        control: { type: 'boolean' },
+      },
+      background_color: {
+        control: { type: 'text' },
+      },
+    }}
+  >
+    {(args) => blockDetailsDemo(args)}
   </Story>
 </Canvas>
 

--- a/src/vendor/wordpress/demo/details.twig
+++ b/src/vendor/wordpress/demo/details.twig
@@ -1,0 +1,14 @@
+<div class="o-container o-container--pad o-container--prose">
+  <div class="o-container__content o-rhythm">
+    <p>This content precedes the details block.</p>
+    <details class="wp-block-details
+      {%- if background_color %} has-{{background_color}}-background-color has-background{% endif %}"
+      {%- if open %} open{% endif %}>
+      <summary>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</summary>
+      <p>Mauris imperdiet est lectus, porttitor lobortis magna bibendum mattis. Nullam feugiat ornare lorem id sollicitudin. </p>
+      <p>Vestibulum non tellus auctor, consectetur dui tincidunt, congue nisl. Morbi vehicula, ex et interdum pulvinar, turpis turpis gravida ligula, a imperdiet risus ipsum a risus.</p>
+      <p>Sed ante dolor, sollicitudin ut dictum in, convallis vitae justo. Phasellus pellentesque dui leo, tempus suscipit orci hendrerit non. Duis ante purus, cursus non enim sed, eleifend luctus sapien. Sed est elit, fringilla eget placerat aliquet, imperdiet nec lectus. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </details>
+    <p>This content follows the details block.</p>
+  </div>
+</div>

--- a/src/vendor/wordpress/styles/_utilities.scss
+++ b/src/vendor/wordpress/styles/_utilities.scss
@@ -48,6 +48,7 @@
 /// 2. …but if the alignment is not center, we use fluid inline padding instead
 ///    so that the inner content will align with its siblings.
 p,
+.wp-block-details,
 .wp-block-group,
 .wp-block-media-text,
 .wp-block-quote {


### PR DESCRIPTION
## Overview

WordPress 6.3 added a new core "Details" block. This adds some default styles for `defaults` and `summary`, and also makes sure the WordPress block is compatible with background color containers.

## Screenshots

Here's what a details block with a background color would look like before. Note the lack of padding or space between paragraphs:

<img width="928" alt="Screenshot 2023-08-31 at 10 29 54 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/e354b47f-b88e-47ac-a934-527d2d8a4785">

And here's what it looks like after these changes are applied:

<img width="930" alt="Screenshot 2023-08-31 at 10 29 12 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/a38986a7-f263-4856-8584-2e7164a1476f">

## Testing

On the deploy preview:
- [x] Review [the default `details` story](https://deploy-preview-2199--cloudfour-patterns.netlify.app/?path=/story/design-defaults--details-summary)
  - [x] Open
  - [x] Close
  - [x] Try different themes (paintbrush icon in Storybook toolbar)
- [x] Review [the WordPress core "details" block story](https://deploy-preview-2199--cloudfour-patterns.netlify.app/?path=/story/vendor-wordpress-core-blocks--details)
  - [x] Open
  - [x] Close
  - [x] Try adding `gray-lighter` to the `background_color` Storybook control

Browsers:
- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari

---

- See https://github.com/cloudfour/cloudfour.com-wp/issues/1011
