### PR TITLE
Radio component

### DIFF
--- a/.changeset/moody-bottles-agree.md
+++ b/.changeset/moody-bottles-agree.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Style radio inputs in Jetpack contact forms.

--- a/.changeset/poor-icons-tan.md
+++ b/.changeset/poor-icons-tan.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add Radio component to style `input type="radio"` elements.

--- a/src/components/checkbox/checkbox.stories.mdx
+++ b/src/components/checkbox/checkbox.stories.mdx
@@ -11,12 +11,11 @@ import './demo/styles.scss';
 
 # Checkbox
 
-`c-checkbox` may be applied to any `<input type="checkbox">` element. They are larger than native checkboxes and more visually consistent with our [input](/docs/components-input--text-elements) and [button](/docs/components-button--elements) components.
+`c-checkbox` may be applied to any `<input type="checkbox">` element. They are larger than native checkboxes and more visually consistent with our [radio](/docs/components-radio--Enabled), [input](/docs/components-input--text-elements) and [button](/docs/components-button--elements) components.
 
 <Canvas>
   <Story
     name="Enabled"
-    height="120px"
     args={{ disabled: false }}
     parameters={{
       docs: {
@@ -42,7 +41,6 @@ Checkboxes appear more subtle and less actionable when the `disabled` attribute 
 <Canvas>
   <Story
     name="Disabled"
-    height="120px"
     args={{ disabled: true }}
     parameters={{
       docs: {

--- a/src/components/checkbox/checkbox.twig
+++ b/src/components/checkbox/checkbox.twig
@@ -1,3 +1,11 @@
+{#
+This all might be a little overengineered? We're basically recreating all of
+the HTML attributes manually. See the radio component for another example.
+
+Leaving in for now since I'm not really interested in another breaking change
+so soon after our last one.
+#}
+
 {% set attributes %}
   type="checkbox"
   class="c-checkbox{% if class %} {{ class }}{% endif %}"

--- a/src/components/radio/demo/styles.scss
+++ b/src/components/radio/demo/styles.scss
@@ -1,0 +1,13 @@
+@use '../../../mixins/ms';
+
+.demo-radio-labels {
+  display: grid;
+  grid-gap: ms.step(1);
+}
+
+.demo-radio-label {
+  display: grid;
+  grid-gap: ms.step(-2);
+  grid-template-columns: auto 1fr;
+  user-select: none;
+}

--- a/src/components/radio/demo/with-label.twig
+++ b/src/components/radio/demo/with-label.twig
@@ -1,0 +1,11 @@
+<div class="demo-radio-labels">
+  {% for i in 1..3 %}
+    <label class="demo-radio-label">
+      {% include '@cloudfour/components/radio/radio.twig' with {
+        checked: loop.first,
+        name: disabled ? 'demo-radio-disabled' : 'demo-radio-enabled',
+      } %}
+      Option {{i}}
+    </label>
+  {% endfor %}
+</div>

--- a/src/components/radio/radio.scss
+++ b/src/components/radio/radio.scss
@@ -1,0 +1,5 @@
+@use '../../mixins/toggle-input';
+
+.c-radio {
+  @include toggle-input.radio;
+}

--- a/src/components/radio/radio.stories.mdx
+++ b/src/components/radio/radio.stories.mdx
@@ -1,4 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import withLabelDemo from './demo/with-label.twig';
+import './demo/styles.scss';
 
 <Meta
   title="Components/Radio"
@@ -12,5 +14,43 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs';
 `c-radio` may be applied to any `<input type="radio">` element. They are larger than native radio elements and more visually consistent with our [checkbox](/docs/components-checkbox--Enabled), [input](/docs/components-input--text-elements) and [button](/docs/components-button--elements) components.
 
 <Canvas>
-  <Story name="WIP">{`<div><input class="c-radio" name="what" type="radio" disabled checked></div><div><input class="c-radio" name="what" type="radio"></div><div><input class="c-radio" name="what" type="radio"></div><div><input class="c-radio" name="what" type="radio" disabled></div>`}</Story>
+  <Story
+    name="Enabled"
+    parameters={{
+      docs: {
+        source: {
+          code: `{% include '@cloudfour/components/radio/radio.twig' with {
+  name: 'demo-radio-enabled',
+  value: 'example',
+  checked: true,
+} only %}`,
+        },
+      },
+    }}
+  >
+    {(args) => withLabelDemo(args)}
+  </Story>
+</Canvas>
+
+Radios appear more subtle and less actionable when the `disabled` attribute is set.
+
+<Canvas>
+  <Story
+    name="Disabled"
+    args={{ disabled: true }}
+    parameters={{
+      docs: {
+        source: {
+          code: `{% include '@cloudfour/components/radio/radio.twig' with {
+  name: 'demo-radio-disabled',
+  value: 'example',
+  checked: true,
+  disabled: true,
+} only %}`,
+        },
+      },
+    }}
+  >
+    {(args) => withLabelDemo(args)}
+  </Story>
 </Canvas>

--- a/src/components/radio/radio.stories.mdx
+++ b/src/components/radio/radio.stories.mdx
@@ -1,0 +1,16 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+
+<Meta
+  title="Components/Radio"
+  argTypes={{
+    disabled: { type: { name: 'boolean' } },
+  }}
+/>
+
+# Radio
+
+`c-radio` may be applied to any `<input type="radio">` element. They are larger than native radio elements and more visually consistent with our [checkbox](/docs/components-checkbox--Enabled), [input](/docs/components-input--text-elements) and [button](/docs/components-button--elements) components.
+
+<Canvas>
+  <Story name="WIP">{`<div><input class="c-radio" name="what" type="radio" disabled checked></div><div><input class="c-radio" name="what" type="radio"></div><div><input class="c-radio" name="what" type="radio"></div><div><input class="c-radio" name="what" type="radio" disabled></div>`}</Story>
+</Canvas>

--- a/src/components/radio/radio.twig
+++ b/src/components/radio/radio.twig
@@ -1,0 +1,23 @@
+{% set attributes %}
+  type="radio"
+  class="c-radio{% if class %} {{ class }}{% endif %}"
+  {% for attribute_name in [
+    'value',
+    'id',
+    'name',
+    'autocomplete'
+  ] %}
+    {% set attribute_value = attribute(_context, attribute_name) %}
+    {% if attribute_value %}{{ attribute_name }}="{{ attribute_value }}"{% endif %}
+  {% endfor %}
+  {% for attribute_name in [
+    'checked',
+    'required',
+    'disabled'
+  ] %}
+    {% set attribute_value = attribute(_context, attribute_name) %}
+    {% if attribute_value %}{{ attribute_name }}{% endif %}
+  {% endfor %}
+{% endset %}
+
+<input {{ attributes }}>

--- a/src/components/radio/radio.twig
+++ b/src/components/radio/radio.twig
@@ -1,3 +1,8 @@
+{#
+This all might be a little overengineered? Leaving in for now for consistency
+with the checkbox component.
+#}
+
 {% set attributes %}
   type="radio"
   class="c-radio{% if class %} {{ class }}{% endif %}"

--- a/src/mixins/_toggle-input.scss
+++ b/src/mixins/_toggle-input.scss
@@ -6,144 +6,186 @@
 @use './theme';
 
 @include theme.props {
-  --theme-color-text-checkbox-checked-hover: var(
-    --theme-color-text-checkbox-hover
+  --theme-color-text-toggle-checked-hover: var(
+    --theme-color-text-toggle-hover
   );
-  --theme-color-text-checkbox-disabled: #{color.$base-gray-dark};
-  --theme-color-text-checkbox-hover: #{color.$brand-primary};
+  --theme-color-text-toggle-disabled: #{color.$base-gray-dark};
+  --theme-color-text-toggle-hover: #{color.$brand-primary};
 }
 
 @include theme.props(dark) {
-  --theme-color-text-checkbox-checked-hover: #{color.$brand-primary-darker};
-  --theme-color-text-checkbox-disabled: #{color.$text-light};
-  --theme-color-text-checkbox-hover: #{color.$text-dark};
+  --theme-color-text-toggle-checked-hover: #{color.$brand-primary-darker};
+  --theme-color-text-toggle-disabled: #{color.$text-light};
+  --theme-color-text-toggle-hover: #{color.$text-dark};
+}
+
+/// Styles that apply to both checkbox and radio inputs.
+///
+/// 1. Modern browsers let us apply wholly custom styles to certain elements,
+///    but only when `appearance` is set to `none`. Somewhat recent versions of
+///    Safari still requires a vendor prefix.
+/// 2. Some browsers will squish the input in flex containers, which we
+///    never, ever want.
+/// 3. Without this, inputs appear too small unless hard-pixel sizes are
+///    used (ew).
+@mixin base {
+  // stylelint-disable-next-line property-no-vendor-prefix
+  -webkit-appearance: none; // 1
+  appearance: none; // 1
+  background-color: color.$text-light;
+  block-size: size.$square-toggle-medium;
+  border: size.$edge-control solid currentColor;
+  color: color.$text-dark;
+  cursor: pointer;
+  flex: none; // 2
+  font: inherit; // 3
+  inline-size: size.$square-toggle-medium;
+  padding: 0;
+  position: relative;
+  transition-duration: transition.$quick;
+  transition-property: background-color, border-color, color;
+  transition-timing-function: ease.$out;
+  vertical-align: middle;
+}
+
+/// State: Focus
+@mixin base-focus {
+  box-shadow: 0 0 0 size.$edge-large color.$brand-primary-lighter;
+}
+
+/// State: Hover
+@mixin base-hover {
+  background-color: color.$text-light-emphasis;
+  color: var(--theme-color-text-toggle-hover);
+}
+
+/// State: Disabled
+///
+/// 1. We want the input to appear "read-only." A transparent background
+///    and dashed line help symbolize a lack of interactivity.
+/// 2. Same color used for disabled `c-input` borders.
+@mixin base-disabled {
+  background-color: transparent; // 1
+  border-style: dashed; // 1
+  color: var(--theme-color-text-toggle-disabled); // 2
+  cursor: not-allowed;
+}
+
+/// Shared styles for the inner toggle's "fill" that represents its `checked`
+/// state.
+@mixin base-inner-pseudo-default {
+  content: '';
+  inset: size.$edge-control;
+  opacity: 0;
+  position: absolute;
+  transform: scale(0);
+  transition-duration: transition.$quick;
+  transition-property: opacity, transform;
+  transition-timing-function: ease.$out;
+}
+
+@mixin base-inner-pseudo-checked {
+  opacity: 1;
+  transform: scale(1);
 }
 
 /// Checkbox styles
-///
-/// 1. This `@supports` query prevents IE11 (and older browsers) from applying
-///    these styles, falling back to the native checkbox appearance.
-/// 2. Modern browsers let us apply wholly custom styles to certain elements,
-///    but only when `appearance` is set to `none`. Because this property is not
-///    a finalized standard, vendor prefixes are still required.
-/// 3. Some browsers will squish the checkbox in flex containers, which we
-///    never, ever want.
-/// 4. Without this, checkboxes appear too small unless hard-pixel sizes are
-///    used (ew).
 @mixin checkbox {
-  @supports (-moz-appearance: none) or (-webkit-appearance: none) or
-    (appearance: none) {
-    // 1
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -moz-appearance: none;
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -webkit-appearance: none;
-    appearance: none; // 2
-    background-color: color.$text-light;
-    block-size: size.$square-toggle-medium;
-    border: size.$edge-control solid currentColor;
-    border-radius: size.$border-radius-medium;
-    color: color.$text-dark;
-    cursor: pointer;
-    flex: none; // 3
-    font: inherit; // 4
-    inline-size: size.$square-toggle-medium;
-    padding: 0;
-    position: relative;
-    transition-duration: transition.$quick;
-    transition-property: background-color, border-color, color;
-    transition-timing-function: ease.$out;
-    vertical-align: middle;
+  @include base;
+  border-radius: size.$border-radius-medium;
 
-    /// State: Focused
-    ///
-    /// We use `focus-visible` here because checkboxes do not inherently require
-    /// keyboard interactions.
-    @include focus.focus-visible {
-      box-shadow: 0 0 0 size.$edge-large color.$brand-primary-lighter;
-    }
+  @include focus.focus-visible {
+    @include base-focus;
+  }
 
-    /// We add the check mark via a pseudo element so we can easily apply
-    /// transitions to it without requiring separate elements.
-    ///
-    /// 1. The icon looks kind of claustrophobic if it runs right up to the
-    ///    element edge, so we re-use the border size as an inset value. This
-    ///    appears much more balanced!
-    /// 2. Starting state of animation.
+  &:hover {
+    @include base-hover;
+  }
+
+  /// We add the check mark via a pseudo element so we can easily apply
+  /// transitions to it without requiring separate elements.
+  &::after {
+    @include base-inner-pseudo-default;
+    background-image: svg-load(
+      'icons/check.svg',
+      stroke=color.$text-light-emphasis
+    );
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+  }
+
+  &:checked {
+    background-color: currentColor;
+
+    /// End state of animation
     &::after {
-      background-image: svg-load(
-        'icons/check.svg',
-        stroke=color.$text-light-emphasis
-      );
-      background-position: center;
-      background-repeat: no-repeat;
-      background-size: contain;
-      content: '';
-      inset: size.$edge-control; // 1
-      opacity: 0; // 2
-      position: absolute;
-      transform: scale(0); // 2
-      transition-duration: transition.$quick;
-      transition-property: opacity, transform;
-      transition-timing-function: ease.$out;
+      @include base-inner-pseudo-checked;
     }
 
-    /// State: Hover
     &:hover {
-      background-color: color.$text-light-emphasis;
-      color: var(--theme-color-text-checkbox-hover);
+      color: var(--theme-color-text-toggle-checked-hover);
+    }
+  }
+
+  &:disabled {
+    @include base-disabled;
+
+    &::after {
+      /// Inline SVGs aren't aware of custom properties, so we have to do a
+      /// bit of theming trickery here
+      @include theme.styles {
+        background-image: svg-load(
+          'icons/check.svg',
+          stroke=color.$base-gray-dark
+        );
+      }
+
+      @include theme.styles(dark) {
+        background-image: svg-load(
+          'icons/check.svg',
+          stroke=color.$text-light
+        );
+      }
     }
 
-    /// State: Checked
+    /// We can forego the border entirely for a disabled checkmark, as the hit
+    /// area is unimportant.
     &:checked {
-      background-color: currentColor;
-
-      /// End state of animation
-      &::after {
-        opacity: 1;
-        transform: scale(1);
-      }
-
-      &:hover {
-        color: var(--theme-color-text-checkbox-checked-hover);
-      }
+      border-color: transparent;
     }
+  }
+}
 
-    /// State: Disabled
-    ///
-    /// 1. We want the checkbox to appear "read-only." A transparent background
-    ///    and dashed line help symbolize a lack of interactivity.
-    /// 2. Same color used for disabled `c-input` borders.
+/// Radio styles
+@mixin radio {
+  @include base;
+  border-radius: size.$border-radius-full;
 
-    &:disabled {
-      background-color: transparent; // 1
-      border-style: dashed; // 1
-      color: var(--theme-color-text-checkbox-disabled); // 2
-      cursor: not-allowed;
+  @include focus.focus-visible {
+    @include base-focus;
+  }
 
-      &::after {
-        /// Inline SVGs aren't aware of custom properties, so we have to do a
-        /// bit of theming trickery here
-        @include theme.styles {
-          background-image: svg-load(
-            'icons/check.svg',
-            stroke=color.$base-gray-dark
-          );
-        }
+  &:hover {
+    @include base-hover;
+  }
 
-        @include theme.styles(dark) {
-          background-image: svg-load(
-            'icons/check.svg',
-            stroke=color.$text-light
-          );
-        }
-      }
+  &::after {
+    @include base-inner-pseudo-default;
+    background-color: currentColor;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    border-radius: inherit;
+  }
 
-      /// We can forego the border entirely for a disabled checkmark, as the hit
-      /// area is unimportant.
-      &:checked {
-        border-color: transparent;
-      }
+  &:checked {
+    &::after {
+      @include base-inner-pseudo-checked;
     }
+  }
+
+  &:disabled {
+    @include base-disabled;
   }
 }

--- a/src/mixins/_toggle-input.scss
+++ b/src/mixins/_toggle-input.scss
@@ -6,9 +6,7 @@
 @use './theme';
 
 @include theme.props {
-  --theme-color-text-toggle-checked-hover: var(
-    --theme-color-text-toggle-hover
-  );
+  --theme-color-text-toggle-checked-hover: var(--theme-color-text-toggle-hover);
   --theme-color-text-toggle-disabled: #{color.$base-gray-dark};
   --theme-color-text-toggle-hover: #{color.$brand-primary};
 }
@@ -142,10 +140,7 @@
       }
 
       @include theme.styles(dark) {
-        background-image: svg-load(
-          'icons/check.svg',
-          stroke=color.$text-light
-        );
+        background-image: svg-load('icons/check.svg', stroke=color.$text-light);
       }
     }
 
@@ -170,11 +165,14 @@
     @include base-hover;
   }
 
+  /// 1. Our linter is getting confused by the Sass expression and trying to
+  ///    split this into multiple lines.
   &::after {
     @include base-inner-pseudo-default;
     background-color: currentColor;
     border-radius: inherit;
-    inset: size.$edge-control * 2;
+    // stylelint-disable-next-line liberty/use-logical-spec
+    inset: size.$edge-control * 2; // 1
   }
 
   &:checked {

--- a/src/mixins/_toggle-input.scss
+++ b/src/mixins/_toggle-input.scss
@@ -75,18 +75,17 @@
 /// state.
 @mixin base-inner-pseudo-default {
   content: '';
-  inset: size.$edge-control;
   opacity: 0;
   position: absolute;
-  transform: scale(0);
+  scale: 0;
   transition-duration: transition.$quick;
-  transition-property: opacity, transform;
+  transition-property: opacity, scale;
   transition-timing-function: ease.$out;
 }
 
 @mixin base-inner-pseudo-checked {
   opacity: 1;
-  transform: scale(1);
+  scale: 1;
 }
 
 /// Checkbox styles
@@ -113,6 +112,7 @@
     background-position: center;
     background-repeat: no-repeat;
     background-size: contain;
+    inset: size.$edge-control;
   }
 
   &:checked {
@@ -173,10 +173,8 @@
   &::after {
     @include base-inner-pseudo-default;
     background-color: currentColor;
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: contain;
     border-radius: inherit;
+    inset: size.$edge-control * 2;
   }
 
   &:checked {

--- a/src/vendor/wordpress/styles/_jetpack-blocks.scss
+++ b/src/vendor/wordpress/styles/_jetpack-blocks.scss
@@ -39,6 +39,11 @@
   &[type='checkbox'] {
     @include toggle-input.checkbox;
   }
+
+  /// Radios
+  &[type='radio'] {
+    @include toggle-input.radio;
+  }
 }
 
 /// Apply the same spacing to fields and labels as in our Form Group object.


### PR DESCRIPTION
## Overview

Creates a new Radio component for styling `radio` type inputs and applies those same styles to the Jetpack contact form CSS for consistency with checkboxes.

## Screenshots

Before | After
--- | ---
<img width="417" alt="Screenshot 2023-09-01 at 9 35 44 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/10e51394-674f-4795-87a4-31de2a2221cd"> | <img width="426" alt="Screenshot 2023-09-01 at 9 35 20 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/9b70d382-e091-437b-942e-b39eeaed8da4">

<img width="1130" alt="Screenshot 2023-09-01 at 9 34 58 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/398a4a7f-6d3b-4a63-9792-f62d0b0cdd3e">

## Testing

Using the deploy preview, test in the following browsers:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari (Desktop)
- [ ] Safari (iOS)

---

- Fixes #2157 
