### PR TITLE
Better Ground Nav Options

### DIFF
--- a/.changeset/gentle-cycles-call.md
+++ b/.changeset/gentle-cycles-call.md
@@ -1,0 +1,7 @@
+---
+"@cloudfour/patterns": patch
+---
+
+Better Options for Ground Nav:
+- renamed `features` to `feature_count`
+- added blocks for each feature

--- a/src/components/ground-nav/ground-nav-args.js
+++ b/src/components/ground-nav/ground-nav-args.js
@@ -15,7 +15,7 @@ const menu = { items: [...skyNavMenu.items, ...groundNavMenu.items] };
  */
 export const defaultArgs = {
   alternate: false,
-  features: 2,
+  feature_count: 2,
   organizationName: organization.name,
   organizationStreetAddress: organization.address.street_address,
   organizationAddressLocality: organization.address.address_locality,
@@ -33,7 +33,7 @@ export const defaultArgs = {
  */
 export const defaultArgTypes = {
   alternate: { control: { type: 'boolean' } },
-  features: { control: { type: 'number', min: 0, max: 2 } },
+  feature_count: { control: { type: 'number', min: 0, max: 2 } },
   organizationName: { type: { name: 'string' } },
   organizationStreetAddress: { type: { name: 'string' } },
   organizationAddressLocality: { type: { name: 'string' } },
@@ -58,7 +58,7 @@ export const generateGroundNavProps = (args) => ({
   social,
   topics,
   alternate: args.alternate,
-  features: args.features,
+  feature_count: args.feature_count,
   organization: {
     name: args.organizationName,
     address: {

--- a/src/components/ground-nav/ground-nav.stories.mdx
+++ b/src/components/ground-nav/ground-nav.stories.mdx
@@ -42,7 +42,7 @@ If you only define a single feature block, it will be centered.
     height="800px"
     args={{
       ...defaultArgs,
-      features: 1,
+      feature_count: 1,
     }}
     argTypes={defaultArgTypes}
     parameters={{
@@ -61,7 +61,7 @@ If you don't define any feature blocks, the layout will collapse appropriately.
     height="475px"
     args={{
       ...defaultArgs,
-      features: 0,
+      feature_count: 0,
     }}
     argTypes={defaultArgTypes}
     parameters={{
@@ -96,7 +96,7 @@ the background colors of the Ground Nav to match.
 
 ## Template Properties
 
-- `features`: The number of feature blocks to display. Defaults to 2.
+- `feature_count`: The number of feature blocks to display. Defaults to 2.
 - `organization`: Object containing Cloud Four details for contact information and copyright. Structure and property names are based on the [the Organization schema](https://schema.org/Organization).
   - `name`
   - `address`
@@ -112,4 +112,9 @@ the background colors of the Ground Nav to match.
 - `menu`: An object containing navigation menu `items` to iterate over in the same structure as that expected by [Timber menus](https://timber.github.io/docs/guides/menus/).
 - `topics`: The same structure as `menu` but for content topics.
 - `social`: The same structure as `menu` but for social links. Each item must also contain an `icon` property corresponding to a key from [our icon library](/docs/design-icons--page).
+
+## Template Blocks
+
 - `legal`: Optional HTML content to display in the legal section. If not provided, a copyright statement will be displayed by default.
+- `feature_one`: Optional HTML content to display in the first feature slot.
+- `feature_two`: Optional HTML content to display in the second feature slot.

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -1,65 +1,69 @@
 {% set feature_one %}
-  <div class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed">
-    <div class="o-rhythm o-rhythm--compact">
-      {% embed '@cloudfour/components/heading/heading.twig' with {
-        "tag_name": "h2",
-        "level": 1,
-        "weight": "light"
-      } only %}
+  {% block feature_one %}
+    <div class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed">
+      <div class="o-rhythm o-rhythm--compact">
+        {% embed '@cloudfour/components/heading/heading.twig' with {
+          "tag_name": "h2",
+          "level": 1,
+          "weight": "light"
+        } only %}
+          {% block content %}
+            Nice to meet you
+          {% endblock %}
+        {% endembed %}
+        <p>
+          Cloud Four helps organizations solve complex responsive web
+          design and development challenges every day.
+          Let's connect so we can tailor a solution to fit your needs.
+        </p>
+      </div>
+      {% embed '@cloudfour/objects/button-group/button-group.twig' only %}
         {% block content %}
-          Nice to meet you
+          {% include '@cloudfour/components/button/button.twig' with {
+            label: 'See our work',
+            class: 'c-button--secondary'
+          } only %}
+          {% include '@cloudfour/components/button/button.twig' with {
+            label: 'Get in touch',
+            class: 'c-button--secondary'
+          } only %}
         {% endblock %}
       {% endembed %}
-      <p>
-        Cloud Four helps organizations solve complex responsive web
-        design and development challenges every day.
-        Let's connect so we can tailor a solution to fit your needs.
-      </p>
     </div>
-    {% embed '@cloudfour/objects/button-group/button-group.twig' only %}
-      {% block content %}
-        {% include '@cloudfour/components/button/button.twig' with {
-          label: 'See our work',
-          class: 'c-button--secondary'
-        } only %}
-        {% include '@cloudfour/components/button/button.twig' with {
-          label: 'Get in touch',
-          class: 'c-button--secondary'
-        } only %}
-      {% endblock %}
-    {% endembed %}
-  </div>
+  {% endblock %}
 {% endset %}
 
 {% set feature_two %}
-  <form class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed" action="#">
-    <div class="o-rhythm o-rhythm--compact">
-      {% embed '@cloudfour/components/heading/heading.twig' with {
-        "tag_name": "h2",
-        "level": 1,
-        "weight": "light"
-      } only %}
+  {% block feature_two %}
+    <form class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed" action="#">
+      <div class="o-rhythm o-rhythm--compact">
+        {% embed '@cloudfour/components/heading/heading.twig' with {
+          "tag_name": "h2",
+          "level": 1,
+          "weight": "light"
+        } only %}
+          {% block content %}
+            Cloud Four, in your inbox
+          {% endblock %}
+        {% endembed %}
+        <p>
+          Our latest articles, updates, quick tips and insights in one
+          convenient, occasional newsletter.
+        </p>
+      </div>
+      {% embed '@cloudfour/objects/input-group/input-group.twig' only %}
         {% block content %}
-          Cloud Four, in your inbox
+          {% include '@cloudfour/components/input/input.twig' with {
+            placeholder: 'Your Email',
+            type: 'email',
+          } only %}
+          {% include '@cloudfour/components/button/button.twig' with {
+            label: 'Sign up'
+          } only %}
         {% endblock %}
       {% endembed %}
-      <p>
-        Our latest articles, updates, quick tips and insights in one
-        convenient, occasional newsletter.
-      </p>
-    </div>
-    {% embed '@cloudfour/objects/input-group/input-group.twig' only %}
-      {% block content %}
-        {% include '@cloudfour/components/input/input.twig' with {
-          placeholder: 'Your Email',
-          type: 'email',
-        } only %}
-        {% include '@cloudfour/components/button/button.twig' with {
-          label: 'Sign up'
-        } only %}
-      {% endblock %}
-    {% endembed %}
-  </form>
+    </form>
+  {% endblock %}
 {% endset %}
 
 {% set legal %}
@@ -72,15 +76,15 @@
 {% endset %}
 
 <footer class="c-ground-nav {% if alternate %}c-ground-nav--alternate{% endif %}">
-  {% if features > 0 %}
+  {% if feature_count > 0 %}
     <div class="c-ground-nav__features o-container o-container--pad-inline">
       <div class="c-ground-nav__features-layout o-container__content">
         <div class="c-ground-nav__features-inner t-dark o-container__fill">
           <div class="c-ground-nav__feature o-container__pad
-                      {% if features > 1 %}t-alternate{% endif %}">
+                      {% if feature_count > 1 %}t-alternate{% endif %}">
             {{ feature_one }}
           </div>
-          {% if features > 1 %}
+          {% if feature_count > 1 %}
             <div class="c-ground-nav__feature o-container__pad">
               {{ feature_two }}
             </div>


### PR DESCRIPTION
## Overview

This PR makes a couple changes to make it easier to use the Ground Nav template in WordPress:

- Renames `features` to `feature_count`
- Adds a `block` for both features so the content can be set

## Testing

Review the Ground Nav page on the preview deploy. It should still show the appropriate number of features in each story.