### PR TITLE
Add Block Size Utilities

### DIFF
--- a/.changeset/thin-schools-brush.md
+++ b/.changeset/thin-schools-brush.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": minor
+---
+
+Add Block Size Utilities: Adds "full" and "auto" size utility classes for the `block` direction.

--- a/src/utilities/size/demo/block-size.twig
+++ b/src/utilities/size/demo/block-size.twig
@@ -1,0 +1,12 @@
+<div class="demo-u-size-block">
+  <div style="height:150px;">
+    <div class="u-size-block-full u-pad-n1 u-rounded t-dark t-alternate u-text-center">
+      full (in a 150px tall container)
+    </div>
+  </div>
+  <div style="height:150px;">
+    <div class="u-size-block-auto u-pad-n1 u-rounded t-dark t-alternate u-text-center">
+      auto (in a 150px tall container)
+    </div>
+  </div>
+</div>

--- a/src/utilities/size/demo/styles.scss
+++ b/src/utilities/size/demo/styles.scss
@@ -8,6 +8,12 @@
   }
 }
 
+.demo-u-size-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+}
+
 .demo-u-size-responsive {
   display: flex;
   gap: 1em;

--- a/src/utilities/size/size.scss
+++ b/src/utilities/size/size.scss
@@ -21,8 +21,21 @@
   }
 }
 
+// Set the block size styles in a mixin. The suffix will let us easily append
+// breakpoint suffixes.
+@mixin _block-size-utilities($suffix: '') {
+  .u-size-block-full#{$suffix} {
+    block-size: 100% !important;
+  }
+
+  .u-size-block-auto#{$suffix} {
+    block-size: auto !important;
+  }
+}
+
 // Include the default versions (no media queries)
 @include _inline-size-utilities;
+@include _block-size-utilities;
 
 // Include responsive versions. This would be simpler if we could use the
 // `breakpoint-classes` mixin instead, but in this case we want all of the
@@ -31,4 +44,5 @@
 @include media-query.breakpoint-loop using ($key) {
   $suffix: \@#{$key};
   @include _inline-size-utilities($suffix);
+  @include _block-size-utilities($suffix);
 }

--- a/src/utilities/size/size.stories.mdx
+++ b/src/utilities/size/size.stories.mdx
@@ -39,8 +39,8 @@ Utilities beginning with `u-size-inline-` specify the `inline-size` of an elemen
 
 Utilities beginning with `u-size-block-` specify the `block-size` of an element:
 
-- `u-size-inline-full` sets the `inline-size` to `100%` of the container.
-- `u-size-inline-auto` sets the `inline-size` to the natural value for the element.
+- `u-size-block-full` sets the `block-size` to `100%` of the container.
+- `u-size-block-auto` sets the `block-size` to the natural value for the element.
 
 <Canvas>
   <Story name="Block size (Height)">{() => blockSizeDemo()}</Story>

--- a/src/utilities/size/size.stories.mdx
+++ b/src/utilities/size/size.stories.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import inlineSizeDemo from './demo/inline-size.twig';
+import blockSizeDemo from './demo/block-size.twig';
 import responsiveDemo from './demo/responsive.twig';
 import './demo/styles.scss';
 
@@ -32,6 +33,17 @@ Utilities beginning with `u-size-inline-` specify the `inline-size` of an elemen
 
 <Canvas>
   <Story name="Inline size (Width)">{() => inlineSizeDemo()}</Story>
+</Canvas>
+
+## Block size
+
+Utilities beginning with `u-size-block-` specify the `block-size` of an element:
+
+- `u-size-inline-full` sets the `inline-size` to `100%` of the container.
+- `u-size-inline-auto` sets the `inline-size` to the natural value for the element.
+
+<Canvas>
+  <Story name="Block size (Height)">{() => blockSizeDemo()}</Story>
 </Canvas>
 
 ## Responsive


### PR DESCRIPTION
## Overview

In a recent WordPress change I had use for a `u-block-size-full` util but it didn't exist. This adds both "full" and "auto" size utils for the block direction.

## Screenshots

<img width="750" alt="Screenshot 2023-09-07 at 8 39 45 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/257309/4c8110fc-a798-4c69-9169-8028a1cd8c38">

## Testing

1. Review the new "Block Size" story in Utilities > Size on the preview deploy.