### PR TITLE
Chore/ground nav promos width

### DIFF
--- a/.changeset/thick-roses-juggle.md
+++ b/.changeset/thick-roses-juggle.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": patch
+---
+
+Bugfix: This addresses an issue where when a single Ground Nav feature was set with very short content, the feature could appear too narrow.

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -73,14 +73,17 @@
 
 /**
  * 1. Keep contents from overflowing border-radius
- * 2. Used to position the features side-by-side on large screens
+ * 2. Min width to keep promos with short content from shrinking
+ * 3. Used to position the features side-by-side on large screens
  */
 .c-ground-nav__features-inner {
   @include border-radius.conditional;
   contain: paint; // 1
+  min-inline-size: 100%; // 2
 
   @media (width >= breakpoint.$l) {
-    display: flex; // 2
+    display: flex; // 3
+    min-inline-size: size.$max-width-prose; // 2
   }
 }
 

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -12,9 +12,7 @@
           {% endblock %}
         {% endembed %}
         <p>
-          Cloud Four helps organizations solve complex responsive web
-          design and development challenges every day.
-          Let's connect so we can tailor a solution to fit your needs.
+          Cloud Four helps every day.
         </p>
       </div>
       {% embed '@cloudfour/objects/button-group/button-group.twig' only %}

--- a/src/utilities/size/demo/block-size.twig
+++ b/src/utilities/size/demo/block-size.twig
@@ -4,7 +4,7 @@
       full (in a 150px tall container)
     </div>
   </div>
-  <div style="height:150px;">
+  <div style="height:150px;" class="t-alternate">
     <div class="u-size-block-auto u-pad-n1 u-rounded t-dark t-alternate u-text-center">
       auto (in a 150px tall container)
     </div>


### PR DESCRIPTION
## Overview

While testing the updated Ground Nav in WordPress, I noticed that if the promo content was too short, and there was only one promo showing, it should shrink and look odd. This PR remedies that by applying a min-width to the promo container.

## Screenshots

<img width="1016" alt="Screenshot 2023-09-07 at 11 34 07 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/257309/58c15ae6-18e5-461c-abf0-c3b5c9e0df20">

## Testing

Review the "One Feature" story on the Ground Nav component on the preview environment. It should look appropriate even though it now has short content.