### PR TITLE
Bugfix: Ground Nav Feature Widths

### DIFF
--- a/.changeset/thirty-beers-rush.md
+++ b/.changeset/thirty-beers-rush.md
@@ -1,0 +1,5 @@
+---
+"@cloudfour/patterns": patch
+---
+
+Bugfix: Ground Nav Feature Widths: Better alignment for Ground Nav features with other page content.

--- a/src/components/ground-nav/demo/ground-nav-demo.twig
+++ b/src/components/ground-nav/demo/ground-nav-demo.twig
@@ -1,0 +1,77 @@
+<div class="o-container o-container--pad o-container--prose">
+<div class="o-container__content o-rhythm o-rhythm--default o-rhythm--generous-headings">
+
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Aliquam ultrices sagittis orci a scelerisque purus semper.</p>
+
+<article class="c-card c-card--contained o-container__fill-pad">
+  <div class="c-card__content">
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Neque vitae tempus quam pellentesque nec nam aliquam sem et. Proin gravida hendrerit lectus a.</p>
+  </div>
+</article>
+
+</div>
+</div>
+
+{% embed '@cloudfour/components/ground-nav/ground-nav.twig' %}
+  {% block feature_one %}
+    <div class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed">
+      <div class="o-rhythm o-rhythm--compact">
+        {% embed '@cloudfour/components/heading/heading.twig' with {
+          "tag_name": "h2",
+          "level": 1,
+          "weight": "light"
+        } only %}
+          {% block content %}
+            Nice to meet you
+          {% endblock %}
+        {% endembed %}
+        <p>
+          Cloud Four helps every day.
+        </p>
+      </div>
+      {% embed '@cloudfour/objects/button-group/button-group.twig' with { "feature_count": feature_count } only %}
+        {% block content %}
+          {% set button_class = feature_count > 1 ? 'c-button--secondary' : null %}
+          {% include '@cloudfour/components/button/button.twig' with {
+            label: 'See our work',
+            class: button_class,
+          } only %}
+          {% include '@cloudfour/components/button/button.twig' with {
+            label: 'Get in touch',
+            class: button_class,
+          } only %}
+        {% endblock %}
+      {% endembed %}
+    </div>
+  {% endblock %}
+  {% block feature_two %}
+    <form class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed" action="#">
+      <div class="o-rhythm o-rhythm--compact">
+        {% embed '@cloudfour/components/heading/heading.twig' with {
+          "tag_name": "h2",
+          "level": 1,
+          "weight": "light"
+        } only %}
+          {% block content %}
+            Cloud Four, in your inbox
+          {% endblock %}
+        {% endembed %}
+        <p>
+          Our latest articles, updates, quick tips and insights in one
+          convenient, occasional newsletter.
+        </p>
+      </div>
+      {% embed '@cloudfour/objects/input-group/input-group.twig' only %}
+        {% block content %}
+          {% include '@cloudfour/components/input/input.twig' with {
+            placeholder: 'Your Email',
+            type: 'email',
+          } only %}
+          {% include '@cloudfour/components/button/button.twig' with {
+            label: 'Sign up'
+          } only %}
+        {% endblock %}
+      {% endembed %}
+    </form>
+  {% endblock %}
+{% endembed %}

--- a/src/components/ground-nav/demo/ground-nav-demo.twig
+++ b/src/components/ground-nav/demo/ground-nav-demo.twig
@@ -19,14 +19,15 @@
         {% embed '@cloudfour/components/heading/heading.twig' with {
           "tag_name": "h2",
           "level": 1,
-          "weight": "light"
+          "weight": "light",
+          "feature_one_title": feature_one_title,
         } only %}
           {% block content %}
-            Nice to meet you
+            {{ feature_one_title }}
           {% endblock %}
         {% endembed %}
         <p>
-          Cloud Four helps every day.
+          {{ feature_one_content }}
         </p>
       </div>
       {% embed '@cloudfour/objects/button-group/button-group.twig' with { "feature_count": feature_count } only %}
@@ -50,15 +51,15 @@
         {% embed '@cloudfour/components/heading/heading.twig' with {
           "tag_name": "h2",
           "level": 1,
-          "weight": "light"
+          "weight": "light",
+          "feature_two_title": feature_two_title,
         } only %}
           {% block content %}
-            Cloud Four, in your inbox
+            {{ feature_two_title }}
           {% endblock %}
         {% endembed %}
         <p>
-          Our latest articles, updates, quick tips and insights in one
-          convenient, occasional newsletter.
+          {{ feature_two_content }}
         </p>
       </div>
       {% embed '@cloudfour/objects/input-group/input-group.twig' only %}

--- a/src/components/ground-nav/ground-nav-args.js
+++ b/src/components/ground-nav/ground-nav-args.js
@@ -16,6 +16,12 @@ const menu = { items: [...skyNavMenu.items, ...groundNavMenu.items] };
 export const defaultArgs = {
   alternate: false,
   feature_count: 2,
+  feature_one_title: 'Nice to meet you',
+  feature_one_content:
+    'Cloud Four helps organizations solve complex responsive web design and development challenges every day. Let’s connect so we can tailor a solution to fit your needs.',
+  feature_two_title: 'Cloud Four, in your inbox',
+  feature_two_content:
+    'Our latest articles, updates, quick tips and insights in one convenient, occassional newsletter.',
   organizationName: organization.name,
   organizationStreetAddress: organization.address.street_address,
   organizationAddressLocality: organization.address.address_locality,
@@ -34,6 +40,10 @@ export const defaultArgs = {
 export const defaultArgTypes = {
   alternate: { control: { type: 'boolean' } },
   feature_count: { control: { type: 'number', min: 0, max: 2 } },
+  feature_one_title: { type: { name: 'string' } },
+  feature_one_content: { type: { name: 'string' } },
+  feature_two_title: { type: { name: 'string' } },
+  feature_two_content: { type: { name: 'string' } },
   organizationName: { type: { name: 'string' } },
   organizationStreetAddress: { type: { name: 'string' } },
   organizationAddressLocality: { type: { name: 'string' } },
@@ -59,6 +69,10 @@ export const generateGroundNavProps = (args) => ({
   topics,
   alternate: args.alternate,
   feature_count: args.feature_count,
+  feature_one_title: args.feature_one_title,
+  feature_one_content: args.feature_one_content,
+  feature_two_title: args.feature_two_title,
+  feature_two_content: args.feature_two_content,
   organization: {
     name: args.organizationName,
     address: {

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -62,33 +62,27 @@
 }
 
 /**
- * 1. Used to center `features-inner` when there's only one feature.
- *    We can't put `margin:auto` on `features-inner` because it has negative
- *    margins from `o-container__fill`.
- */
-.c-ground-nav__features-layout {
-  display: flex; // 1
-  justify-content: center; // 1
-}
-
-/**
  * 1. Keep contents from overflowing border-radius
- * 2. If we don't set min-width here, then the features container won't
- *    use up the full width and won't match the content below. It needs
- *    to be scoped to the `c-ground-nav--multiple-features` modifier
- *    because we _don't_ want this width when there's only one feature.
- * 3. Used to position the features side-by-side on large screens
+ * 2. Constrain the width when there's only one feature
+ * 3. Positions multiple features side-by-side. `auto-fit` means this
+ *    works even when there's only one feature.
  */
 .c-ground-nav__features-inner {
   @include border-radius.conditional;
   contain: paint; // 1
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  inline-size: 100%;
+  margin-inline: auto;
 
-  .c-ground-nav--multiple-features & {
-    min-inline-size: 100%; // 2
+  .c-ground-nav--single-feature & {
+    max-inline-size: calc(
+      #{size.$max-width-prose} + #{spacing.$fluid-spacing-inline} * 2
+    ); // 2
   }
 
   @media (width >= breakpoint.$l) {
-    display: flex; // 3
+    grid-template-columns: repeat(auto-fit, minmax(0, 1fr)); // 3
   }
 }
 
@@ -100,12 +94,17 @@
  */
 .c-ground-nav__feature {
   @include spacing.fluid-padding-block;
+  @include spacing.fluid-padding-inline;
+  inline-size: 100%;
 
   &:only-child {
     margin-inline: auto; // 1
-    min-inline-size: calc(
-      #{size.$max-width-prose} + #{spacing.$fluid-spacing-inline} * 2
-    ); // 1
+
+    @media (width >= breakpoint.$l) {
+      min-inline-size: calc(
+        #{size.$max-width-prose} + #{spacing.$fluid-spacing-inline} * 2
+      ); // 1
+    }
   }
 
   @media (width >= breakpoint.$l) {

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -73,22 +73,28 @@
 
 /**
  * 1. Keep contents from overflowing border-radius
- * 2. Min width to keep promos with short content from shrinking
+ * 2. If we don't set min-width here, then the features container won't
+ *    use up the full width and won't match the content below. It needs
+ *    to be scoped to the `c-ground-nav--multiple-features` modifier
+ *    because we _don't_ want this width when there's only one feature.
  * 3. Used to position the features side-by-side on large screens
  */
 .c-ground-nav__features-inner {
   @include border-radius.conditional;
   contain: paint; // 1
-  min-inline-size: 100%; // 2
+
+  .c-ground-nav--multiple-features & {
+    min-inline-size: 100%; // 2
+  }
 
   @media (width >= breakpoint.$l) {
     display: flex; // 3
-    min-inline-size: size.$max-width-prose; // 2
   }
 }
 
 /**
- * 1. If there's only one feature, center it and use prose width
+ * 1. If there's only one feature, center it and match the width of
+ *    `fill-pad` containers in the prose width content above.
  * 2. Flex layout to keep both features' form elements vertically aligned
  * 3. Features should take up an equal amount of the layout
  */
@@ -97,7 +103,9 @@
 
   &:only-child {
     margin-inline: auto; // 1
-    max-inline-size: size.$max-width-prose; // 1
+    min-inline-size: calc(
+      #{size.$max-width-prose} + #{spacing.$fluid-spacing-inline} * 2
+    ); // 1
   }
 
   @media (width >= breakpoint.$l) {

--- a/src/components/ground-nav/ground-nav.scss
+++ b/src/components/ground-nav/ground-nav.scss
@@ -119,6 +119,7 @@
 .c-ground-nav__feature-inner {
   display: grid; // 1
   grid-template-rows: minmax(0, 1fr) minmax(0, auto); // 1
+  inline-size: 100%;
 }
 
 /**

--- a/src/components/ground-nav/ground-nav.stories.mdx
+++ b/src/components/ground-nav/ground-nav.stories.mdx
@@ -4,7 +4,7 @@ import {
   defaultArgs,
   generateGroundNavProps,
 } from './ground-nav-args.js';
-import template from './ground-nav.twig';
+import template from './demo/ground-nav-demo.twig';
 
 <!--
 Inline stories disabled so media queries will behave as expected within

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -1,66 +1,10 @@
 {% set feature_one %}
   {% block feature_one %}
-    <div class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed">
-      <div class="o-rhythm o-rhythm--compact">
-        {% embed '@cloudfour/components/heading/heading.twig' with {
-          "tag_name": "h2",
-          "level": 1,
-          "weight": "light"
-        } only %}
-          {% block content %}
-            Nice to meet you
-          {% endblock %}
-        {% endembed %}
-        <p>
-          Cloud Four helps every day.
-        </p>
-      </div>
-      {% embed '@cloudfour/objects/button-group/button-group.twig' only %}
-        {% block content %}
-          {% include '@cloudfour/components/button/button.twig' with {
-            label: 'See our work',
-            class: 'c-button--secondary'
-          } only %}
-          {% include '@cloudfour/components/button/button.twig' with {
-            label: 'Get in touch',
-            class: 'c-button--secondary'
-          } only %}
-        {% endblock %}
-      {% endembed %}
-    </div>
   {% endblock %}
 {% endset %}
 
 {% set feature_two %}
   {% block feature_two %}
-    <form class="c-ground-nav__feature-inner o-rhythm o-rhythm--condensed" action="#">
-      <div class="o-rhythm o-rhythm--compact">
-        {% embed '@cloudfour/components/heading/heading.twig' with {
-          "tag_name": "h2",
-          "level": 1,
-          "weight": "light"
-        } only %}
-          {% block content %}
-            Cloud Four, in your inbox
-          {% endblock %}
-        {% endembed %}
-        <p>
-          Our latest articles, updates, quick tips and insights in one
-          convenient, occasional newsletter.
-        </p>
-      </div>
-      {% embed '@cloudfour/objects/input-group/input-group.twig' only %}
-        {% block content %}
-          {% include '@cloudfour/components/input/input.twig' with {
-            placeholder: 'Your Email',
-            type: 'email',
-          } only %}
-          {% include '@cloudfour/components/button/button.twig' with {
-            label: 'Sign up'
-          } only %}
-        {% endblock %}
-      {% endembed %}
-    </form>
   {% endblock %}
 {% endset %}
 
@@ -75,7 +19,8 @@
 
 <footer class="c-ground-nav {% if alternate %}c-ground-nav--alternate{% endif %}">
   {% if feature_count > 0 %}
-    <div class="c-ground-nav__features o-container o-container--pad-inline">
+    <div class="c-ground-nav__features o-container o-container--pad-inline
+                {% if feature_count > 1 %}c-ground-nav--multiple-features{% endif %}">
       <div class="c-ground-nav__features-layout o-container__content">
         <div class="c-ground-nav__features-inner t-dark o-container__fill">
           <div class="c-ground-nav__feature o-container__pad

--- a/src/components/ground-nav/ground-nav.twig
+++ b/src/components/ground-nav/ground-nav.twig
@@ -17,21 +17,36 @@
   {% endblock %}
 {% endset %}
 
-<footer class="c-ground-nav {% if alternate %}c-ground-nav--alternate{% endif %}">
+<footer
+  class="c-ground-nav
+         {% if alternate %}c-ground-nav--alternate{% endif %}
+         {% if feature_count == 1 %}c-ground-nav--single-feature{% endif %}"
+>
+
+  {#
+    A note to future devs:
+    Looking at this code, you may be tempted to simplify. You may think,
+    surely `c-ground-nav__features-inner` could move up a level to save a div,
+    or similar changes. Trust me, I've tried. The three outer containers are
+    needed to keep the layout in alignment with other containers on the page.
+    The features and their wrapper need to be nested inside so they can be
+    centered and behave appropriately when there's only one feature.
+    Modify at your own risk, and test thoroughly.
+  #}
   {% if feature_count > 0 %}
-    <div class="c-ground-nav__features o-container o-container--pad-inline
-                {% if feature_count > 1 %}c-ground-nav--multiple-features{% endif %}">
-      <div class="c-ground-nav__features-layout o-container__content">
-        <div class="c-ground-nav__features-inner t-dark o-container__fill">
-          <div class="c-ground-nav__feature o-container__pad
-                      {% if feature_count > 1 %}t-alternate{% endif %}">
-            {{ feature_one }}
-          </div>
-          {% if feature_count > 1 %}
-            <div class="c-ground-nav__feature o-container__pad">
-              {{ feature_two }}
+    <div class="c-ground-nav__features o-container o-container--pad-inline">
+      <div class="o-container__content">
+        <div class="o-container__fill">
+          <div class="c-ground-nav__features-inner t-dark">
+            <div class="c-ground-nav__feature {% if feature_count > 1 %}t-alternate{% endif %}">
+              {{ feature_one }}
             </div>
-          {% endif %}
+            {% if feature_count > 1 %}
+              <div class="c-ground-nav__feature">
+                {{ feature_two }}
+              </div>
+            {% endif %}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Overview

This PR fixes a bug where the width of the features for the Ground Nav wasn't quite right. Now, when there are two features, they'll match the width of the Ground Nav content, and when there's one feature, it'll match the width of a `fill-pad` container in the prose-width content above the Ground Nav.

## Screenshots

**Two Features**

<img width="1382" alt="Screenshot 2023-09-12 at 11 24 03 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/257309/17693192-b797-4812-97d7-6821ba625151">

**One Feature**

<img width="1387" alt="Screenshot 2023-09-12 at 11 23 38 AM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/257309/afc344d1-ec57-42cc-bd7e-08244918cc93">

**Note:** See comment below for updated screenshots.

## Testing

1. On the preview deploy, review the Ground Nav stories (particularly the "Cloud Four" and "One Feature" stories) at multiple viewport sizes in the following browsers:
    - [x] Chrome
    - [x] Edge
    - [x] Firefox
    - [x] Safari
    - [ ] Mobile Safari
2. Then test again by changing the content of the features to very short strings to ensure the features don't collapse when the content isn't full-width.