### PR TITLE
Restrict Button scaling in Input Groups

### DIFF
--- a/.changeset/dry-tables-leave.md
+++ b/.changeset/dry-tables-leave.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Prevent Buttons from feeling disconnected from Input Groups when `:hover` or `:active` states are applied

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -90,16 +90,20 @@
   /**
    * Transform, opacity and filter changes are performant and will work across
    * many more stylistic modifiers than specific color shifts.
+   *
+   * We optionally support custom properties to allow the amount of scaling to
+   * be adjusted by other patterns. For example, an Input Group might disable
+   * the scaling so the button always appeared joined to adjacent elements.
    */
 
   &:hover {
     filter: brightness(brightness.$control-brighten);
-    transform: scale(scale.$effect-grow);
+    transform: scale(var(--scale-effect-grow, #{scale.$effect-grow}));
   }
 
   &:active {
     filter: brightness(brightness.$control-dim);
-    transform: scale(scale.$effect-shrink);
+    transform: scale(var(--scale-effect-shrink, #{scale.$effect-shrink}));
   }
 
   &:disabled,

--- a/src/objects/input-group/input-group.scss
+++ b/src/objects/input-group/input-group.scss
@@ -1,6 +1,9 @@
 @use '../../compiled/tokens/scss/size';
 
 .o-input-group {
+  // Prevent button effects from appearing disconnected from the input group
+  --scale-effect-grow: 1;
+  --scale-effect-shrink: 1;
   display: flex;
 
   // Keeps focus styles from being cut off by adjacent, un-focused elements


### PR DESCRIPTION
## Overview

Our newfound emphasis on newsletter signups has increased the prominence of our Input Group layout object, which has made a lingering issue more visible: On hover/active, our button scaling effects make the button appear disconnected from its adjacent input.

At one time I considered removing the scaling effects entirely, but @gerardo-rodriguez convinced me to reconsider. (See #2141)

I explored some alternative effects, but found they didn't work as well across the different interactive elements (pagination links, alert closure, etc.) that rely on the same tokens.

So I decided to expose those scale values as custom properties, so I could reset them _just_ for the Input Group object.

**TL;DR:** Buttons (and similar interactive elements) will continue to scale in most cases, except in Input Groups, when only the filter effect will apply.

## Screenshots

State | Before | After
--- | --- | ---
`:hover` | <img width="315" alt="Screenshot 2023-09-13 at 2 26 54 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/482bc08a-b719-4bb5-93b7-a8524b9113fa"> | <img width="314" alt="Screenshot 2023-09-13 at 2 26 22 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/ff1ab0e2-61cd-45e3-b899-b89fdbfac43d">
`:active` | <img width="318" alt="Screenshot 2023-09-13 at 2 27 00 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/142cea47-6793-4211-b975-c82b9faaa04a"> | <img width="318" alt="Screenshot 2023-09-13 at 2 26 30 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/eced9430-7714-4292-a2f0-a70420d09ce3">

## Testing

Try out deploy preview stories for Button and Input Group in:

- [ ] Chrome
- [ ] Edge
- [ ] Firefox
- [ ] Safari

---

- Closes #2141 