### PR TITLE
Disable calc minification

### DIFF
--- a/.changeset/slimy-eagles-approve.md
+++ b/.changeset/slimy-eagles-approve.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Disable calc optimization in minified stylesheet. This addresses a warning when `calc` included a `clamp` function, and very slightly reduces the size of the stylesheet when compressed.

--- a/gulpfile.js/tasks/build-sass.js
+++ b/gulpfile.js/tasks/build-sass.js
@@ -20,7 +20,7 @@ const buildSass = () =>
     .pipe(
       postcss([
         cssnano({
-          preset: ['cssnano-preset-default', { colormin: false }],
+          preset: ['cssnano-preset-default', { colormin: false, calc: false }],
         }),
       ])
     )


### PR DESCRIPTION
## Overview

We recently added our first styles that combine `calc` with `clamp`. cssnano's `calc` optimization does not like this combination ([see an upstream dependency's related issue](https://github.com/postcss/postcss-calc/issues/130)).

Disabling this optimization has two benefits:

- It silences the warning we were receiving on build.
- It actually decreases the file size after compression by a few bytes, presumably because the unoptimized expressions are more likely to recur throughout our stylesheet.

---

- Closes #2210
