### PR TITLE
Add cube icons

### DIFF
--- a/.changeset/warm-trains-rule.md
+++ b/.changeset/warm-trains-rule.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': minor
+---
+
+Add `cube` and `cube-alt` icons to represent three-dimensional elements.

--- a/src/assets/icons/cube-alt.svg
+++ b/src/assets/icons/cube-alt.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <polygon points="3 7.14 12 1.33 21 7.14 12 12.95 3 7.14" opacity=".66" stroke-width="0" />
+  <polygon points="12 22.67 3 16.86 3 7.14 12 12.95 12 22.67" opacity=".33" stroke-width="0" />
+  <path
+    d="m20.65,6.91L12.42,1.6c-.25-.16-.58-.16-.83,0L3.35,6.91c-.22.14-.35.38-.35.64v8.89c0,.26.13.5.35.64l8.24,5.32c.25.16.58.16.83,0l8.24-5.32c.22-.14.35-.38.35-.64V7.56c0-.26-.13-.5-.35-.64Z"
+    fill="none" stroke-linejoin="round" stroke-width="2" />
+</svg>

--- a/src/assets/icons/cube.svg
+++ b/src/assets/icons/cube.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <polygon points="12 22.67 3 16.86 3 7.14 12 12.95 12 22.67" opacity=".33" stroke-width="0" />
+  <polygon points="12 22.67 21 16.86 21 7.14 12 12.95 12 22.67" opacity=".66" stroke-width="0" />
+  <path
+    d="m20.65,6.91L12.42,1.6c-.25-.16-.58-.16-.83,0L3.35,6.91c-.22.14-.35.38-.35.64v8.89c0,.26.13.5.35.64l8.24,5.32c.25.16.58.16.83,0l8.24-5.32c.22-.14.35-.38.35-.64V7.56c0-.26-.13-.5-.35-.64Z"
+    fill="none" stroke-linejoin="round" stroke-width="2" />
+</svg>

--- a/src/components/button/button.stories.mdx
+++ b/src/components/button/button.stories.mdx
@@ -20,6 +20,7 @@ const iconControlConfig = {
   options: [
     '',
     'bell',
+    'cube-alt',
     'magnifying-glass',
     'heart',
     'brands/github',


### PR DESCRIPTION
## Overview

Adds `cube` and `cube-alt` icons to represent 3D models.

I added two separate icons because lighting is perceived pretty differently against dark or light backgrounds. In the future this could be dynamic using SVG and CSS, but I didn't want to delay the immediate use case.

## Screenshots

<img width="1027" alt="Screenshot 2023-11-16 at 3 36 24 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/1ffce97c-1ecc-49a3-a509-460480ab6c57">

<img width="198" alt="Screenshot 2023-11-16 at 3 32 59 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/d06a2705-acce-4986-869a-4be3198e8aa0">

---

/CC @spaceninja 
