### PR TITLE
Fix for page alert pointer-events issue

### DIFF
--- a/.changeset/shaggy-lemons-sleep.md
+++ b/.changeset/shaggy-lemons-sleep.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fixes issue where a page's alert container with no visible content could block pointer events toward the bottom of the viewport.

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -49,8 +49,8 @@
   inline-size: 100%;
   inset-block-end: 0;
   justify-content: center;
-  pointer-events: none;
-  position: fixed; // 3
+  pointer-events: none; // 3
+  position: fixed;
   z-index: z-index.$alert;
 }
 

--- a/src/objects/page/page.scss
+++ b/src/objects/page/page.scss
@@ -35,6 +35,9 @@
  * 1. Use a $factor of 0.5 to allow the alert to bleed more into the
  *    content margins instead of aligning with the content itself.
  * 2. Match the padding-inline for visual balance.
+ * 3. Prevent this container from blocking interactions with content beneath
+ *    its `z-index` layer in case the content within his hidden but not this
+ *    containing element.
  */
 
 .o-page__alert {
@@ -46,8 +49,17 @@
   inline-size: 100%;
   inset-block-end: 0;
   justify-content: center;
-  position: fixed;
+  pointer-events: none;
+  position: fixed; // 3
   z-index: z-index.$alert;
+}
+
+/**
+ * Restores pointer events for any page alert content.
+ */
+
+.o-page__alert > * {
+  pointer-events: initial;
 }
 
 .o-page__content {


### PR DESCRIPTION
## Overview

When our Page layout object has an alert, its container blocks clicks, text selections, etc. below.

This is an issue when an alert within is hidden but the element itself is not.

We could refactor our alert JavaScript to target a parent element or to extend page directly, but in doing so I found a few unexpected gotchas and complicated layout considerations.

So instead, I've modified the pattern to set `pointer-events` on the alert's container to `none`, then resetting that value for child elements.

## Screenshots

With this change, it's now possible to select/click/etc. elements beneath the alert row:

<img width="745" alt="Screenshot 2023-12-12 at 3 04 55 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/263ecb47-0178-401b-a71e-8d82423a0efb">

While still being able to interact with content therein:

<img width="754" alt="Screenshot 2023-12-12 at 3 05 03 PM" src="https://github.com/cloudfour/cloudfour.com-patterns/assets/69633/1f2fc10f-95fd-424e-8320-c3459379d875">

## Testing

On the deploy preview, navigate to [the Page Example with Alert story](https://deploy-preview-2217--cloudfour-patterns.netlify.app/?path=/story/objects-page--example-with-alert) and confirm that you can interact with content within _and_ beneath the `o-page__alert` element in the following browsers:

- [x] Chrome
- [x] Edge
- [x] Firefox
- [x] Safari

---

- See https://github.com/cloudfour/cloudfour.com-wp/issues/1037
