### PR TITLE
Fixed ugly default borders on WordPress table blocks

### DIFF
--- a/.changeset/green-windows-march.md
+++ b/.changeset/green-windows-march.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Fixed ugly default borders on WordPress table blocks

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -328,6 +328,8 @@ figure.wp-block-image {
 .c-comment {
   table td,
   table th {
+    // At some point, WordPress started setting a default border on table cells
+    border-width: 0;
     @include table.t-container;
   }
 

--- a/src/vendor/wordpress/styles/_core-blocks.scss
+++ b/src/vendor/wordpress/styles/_core-blocks.scss
@@ -328,9 +328,10 @@ figure.wp-block-image {
 .c-comment {
   table td,
   table th {
+    @include table.t-container;
+
     // At some point, WordPress started setting a default border on table cells
     border-width: 0;
-    @include table.t-container;
   }
 
   table th {


### PR DESCRIPTION
## Overview

At some point, WordPress shipped an update that applied a default `border-width` on table block `td` and `th` elements unless a block style was applied.

This adds `border-width: 0` to those elements by default so they'll be consistent with our table component again.

## Screenshots

Before | After
--- | ---
<img width="848" alt="Screenshot 2025-02-05 at 10 23 30 AM" src="https://github.com/user-attachments/assets/e9e1ca38-8456-4ddb-a25c-bc2627e5fa57" /> | <img width="858" alt="Screenshot 2025-02-05 at 10 24 06 AM" src="https://github.com/user-attachments/assets/0ab43dda-55aa-4f74-84ec-d32aee8e7744" />

## Testing

For whatever reason, this issue isn't symptomatic with our imported Gutenberg styles. But it wouldn't hurt to check our stories for the WordPress table block on the deploy preview to make sure this didn't introduce regressions.
