### PR TITLE
Add `text-wrap` to typographic elements

### DIFF
--- a/.changeset/loud-paws-tease.md
+++ b/.changeset/loud-paws-tease.md
@@ -2,6 +2,4 @@
 '@cloudfour/patterns': major
 ---
 
-Improved text wrapping for headings and subheadings.
-
-This is a breaking change because it may disrupt existing techniques for avoiding orphans and widows in text (such as inserting `&nbsp;` or `<span class="u-inline-block">`). It's recommended to remove these workarounds.
+Improved text wrapping for headings and subheadings with `text-wrap`. Removes the `u-rescue-orphan` utility, which is now redundant.

--- a/.changeset/loud-paws-tease.md
+++ b/.changeset/loud-paws-tease.md
@@ -2,6 +2,6 @@
 '@cloudfour/patterns': major
 ---
 
-Improved text wrapping for headings, paragraphs, list items, figure captions and more.
+Improved text wrapping for headings and subheadings.
 
 This is a breaking change because it may disrupt existing techniques for avoiding orphans and widows in text (such as inserting `&nbsp;` or `<span class="u-inline-block">`). It's recommended to remove these workarounds.

--- a/.changeset/loud-paws-tease.md
+++ b/.changeset/loud-paws-tease.md
@@ -1,0 +1,7 @@
+---
+'@cloudfour/patterns': major
+---
+
+Improved text wrapping for headings, paragraphs, list items, figure captions and more.
+
+This is a breaking change because it may disrupt existing techniques for avoiding orphans and widows in text (such as inserting `&nbsp;` or `<span class="u-inline-block">`). It's recommended to remove these workarounds.

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -52,6 +52,16 @@ body {
 }
 
 /**
+ * Default text wrapping
+ */
+
+p,
+li,
+figcaption {
+  text-wrap: pretty;
+}
+
+/**
  * Headings
  */
 
@@ -59,6 +69,7 @@ body {
   h#{$i} {
     @include headings.level($i);
     color: var(--theme-color-text-emphasis);
+    text-wrap: balance;
   }
 }
 

--- a/src/base/_typography.scss
+++ b/src/base/_typography.scss
@@ -52,16 +52,6 @@ body {
 }
 
 /**
- * Default text wrapping
- */
-
-p,
-li,
-figcaption {
-  text-wrap: pretty;
-}
-
-/**
  * Headings
  */
 

--- a/src/components/heading/heading.scss
+++ b/src/components/heading/heading.scss
@@ -140,6 +140,7 @@ $max-width-permalink-shift: math.div($min-width-permalink-shift * 16 - 1, 16);
   font-weight: font-weight.$medium;
   line-height: line-height.$tight;
   max-inline-size: 100%;
+  text-wrap: balance;
 
   .c-heading--light & {
     font-weight: font-weight.$normal;

--- a/src/design/defaults.stories.mdx
+++ b/src/design/defaults.stories.mdx
@@ -7,6 +7,12 @@ import figureImage from './demo/tiny-web-stacks.png';
 
 To keep our styles manageable and avoid conflicts of specificity, our default HTML elements are pretty modest. That said, it's important to have a solid foundation so our markup doesn't become a murky soup of utility classes and bespoke styles.
 
+## Paragraph
+
+<Canvas>
+  <Story name="Paragraph">{`<p>Every journey begins by knowing both where we’re going and where we’re starting from. Identifying your application’s current architecture is the first step on your modernization journey. In the next article, we’ll talk about tactics for delivering incremental improvements—taking baby steps if you will—towards your end goal.</p>`}</Story>
+</Canvas>
+
 ## Headings
 
 More options are available via [the Heading component](/docs/components-heading--example).

--- a/src/design/defaults.stories.mdx
+++ b/src/design/defaults.stories.mdx
@@ -7,12 +7,6 @@ import figureImage from './demo/tiny-web-stacks.png';
 
 To keep our styles manageable and avoid conflicts of specificity, our default HTML elements are pretty modest. That said, it's important to have a solid foundation so our markup doesn't become a murky soup of utility classes and bespoke styles.
 
-## Paragraph
-
-<Canvas>
-  <Story name="Paragraph">{`<p>Every journey begins by knowing both where we’re going and where we’re starting from. Identifying your application’s current architecture is the first step on your modernization journey. In the next article, we’ll talk about tactics for delivering incremental improvements—taking baby steps if you will—towards your end goal.</p>`}</Story>
-</Canvas>
-
 ## Headings
 
 More options are available via [the Heading component](/docs/components-heading--example).

--- a/src/utilities/display/demo/rescue-orphan.twig
+++ b/src/utilities/display/demo/rescue-orphan.twig
@@ -1,5 +1,0 @@
-<div class="u-border-md u-pad-1" style="max-width: 11em;">
-  <a href="#">
-    Look how the last two words <span class="u-rescue-orphan">stay together</span>
-  </a>
-</div>

--- a/src/utilities/display/display.scss
+++ b/src/utilities/display/display.scss
@@ -12,9 +12,3 @@
   content: '';
   display: block;
 }
-
-/// Attempt to keep chunks of text together as space allows
-.u-rescue-orphan {
-  display: inline-block;
-  text-decoration: inherit;
-}

--- a/src/utilities/display/display.stories.mdx
+++ b/src/utilities/display/display.stories.mdx
@@ -1,7 +1,6 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import hiddenVisuallyDemo from './demo/hidden-visually.twig';
 import clearfixDemo from './demo/clearfix.twig';
-import rescueOrphanDemo from './demo/rescue-orphan.twig';
 
 <Meta title="Utilities/Display" />
 
@@ -30,12 +29,4 @@ The `u-clearfix` class forces a container to expand to fit floated children.
 
 <Canvas>
   <Story name="Clearfix">{clearfixDemo}</Story>
-</Canvas>
-
-## Rescue Orphan
-
-The `u-rescue-orphan` class can wrap the last few words of a chunk of text, attempting to keep them together unless space limitations force a break. This can help reduce the chance of [a typographic orphan](https://en.wikipedia.org/wiki/Widows_and_orphans) in some situations.
-
-<Canvas>
-  <Story name="Rescue Orphan">{rescueOrphanDemo}</Story>
 </Canvas>


### PR DESCRIPTION
## Overview

Sets some default `text-wrap` styles for ~~paragraphs, list items, figure captions,~~ headings and subheadings.

I marked this as a breaking change because it will conflict with the existing techniques in our theme for reducing orphans and widows. Those workarounds will need to be removed when applying this update.

## Screenshots

Before | After
--- | ---
<img width="265" alt="Screenshot 2025-02-05 at 2 55 08 PM" src="https://github.com/user-attachments/assets/a993f53a-8cb0-485e-842f-ac4fc02d686a" /> | <img width="262" alt="Screenshot 2025-02-05 at 2 55 18 PM" src="https://github.com/user-attachments/assets/1709cf12-a8a1-4311-8aad-1b581604a8e0" />
