### PR TITLE
Fix for overflow scrolling issue

### DIFF
--- a/.changeset/smart-memes-argue.md
+++ b/.changeset/smart-memes-argue.md
@@ -1,0 +1,5 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Prevent visually-hidden language labels from breaking width of overflowing code blocks

--- a/src/base/_defaults.scss
+++ b/src/base/_defaults.scss
@@ -135,7 +135,9 @@ audio {
  * Code blocks
  *
  * 1. Don't allow code blocks to overflow willy-nilly.
- * 2. Set a shallower tab size to encourage accessible code samples without
+ * 2. Prevent absolute-positioned children (such as visually-hidden language
+ *    labels) from breaking horizontal scroll in Chrome.
+ * 3. Set a shallower tab size to encourage accessible code samples without
  *    compromising horizontal real estate.
  */
 
@@ -145,7 +147,8 @@ pre {
   color: color.$text-light;
   overflow: auto; /* 1 */
   padding: ms.step(1);
-  tab-size: 2; /* 2 */
+  position: relative; /* 2 */
+  tab-size: 2; /* 3 */
 }
 
 /**


### PR DESCRIPTION
## Overview

Addresses an issue where code blocks in comments could break the page's horizontal scroll.

## Screenshots

Before, you can scroll the document horizontally as far as the overflow content, even though it's clipped by the `<pre>` element. After, horizontal scrolling is only applied to the `<pre>`.

Before | After
--- | ---
![cloudfour com_thinks_css-circles_(iPhone SE)](https://github.com/user-attachments/assets/4e073538-b159-4ee3-b12a-f017cb35463e) | ![cloudfour com_thinks_css-circles_(iPhone SE) (1)](https://github.com/user-attachments/assets/b09d4b8a-c518-4ce9-907e-0db8c5b98235)

## Testing

I tried, I really tried, to add a test story to this repository. But because the issue's only symptomatic in a comment thread when the `syntax-highlighting-code-block` is applied within a full page, it was going to take me a _lot_ more time to recreate in a story.

You can recreate the fix by visiting https://cloudfour.com/thinks/css-circles/#comment-6111 in a Chromium browser, resizing to a narrow width, inspecting the `<pre>` element, and applying `position: relative` to the existing `pre` block of styles.

Other than that, a review of existing `<pre>` patterns on the deploy preview seems like a good idea. That includes:

- https://deploy-preview-2275--cloudfour-patterns.netlify.app/?path=/story/design-defaults--code-block
- https://deploy-preview-2275--cloudfour-patterns.netlify.app/?path=/docs/vendor-highlight--theme
- https://deploy-preview-2275--cloudfour-patterns.netlify.app/?path=/docs/vendor-syntax-highlighting-code-block--basic
- https://deploy-preview-2275--cloudfour-patterns.netlify.app/?path=/docs/vendor-wordpress-core-blocks--code
- https://deploy-preview-2275--cloudfour-patterns.netlify.app/?path=/docs/vendor-wordpress-core-blocks--preformatted
- https://deploy-preview-2275--cloudfour-patterns.netlify.app/?path=/docs/vendor-wordpress-core-element-comparison--markdown
- https://deploy-preview-2275--cloudfour-patterns.netlify.app/?path=/docs/vendor-wordpress-core-element-comparison--html
- https://deploy-preview-2275--cloudfour-patterns.netlify.app/?path=/docs/vendor-wordpress-core-element-comparison--gutenberg

---

- Fixes #2274 