### PR TITLE
Upgrade CI and local development to Node 24

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -15,12 +15,10 @@ jobs:
         with:
           # Fetch all git history for correct changelog commits
           fetch-depth: 0
-      - name: Use Node.js 16
+      - name: Use Node.js 24
         uses: actions/setup-node@v6.5.0
         with:
-          node-version: 16.20.2
-      - name: Update npm
-        run: npm i -g npm@7
+          node-version: 24.19.0
       - name: Install Dependencies
         run: CYPRESS_INSTALL_BINARY=0 npm ci
       - name: Run Preprocess

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,18 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.1.0
-      - name: Use Node.js 16
+      - name: Use Node.js 24
         uses: actions/setup-node@v6.5.0
         with:
-          node-version: 16.20.2
+          node-version: 24.19.0
       - name: Cache node modules
         uses: actions/cache@v5.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
-      - name: Update npm
-        run: npm i -g npm@7
       - name: Install Dependencies
         run: npm ci
       - name: Run Preprocess
@@ -40,18 +38,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.1.0
-      - name: Use Node.js 16
+      - name: Use Node.js 24
         uses: actions/setup-node@v6.5.0
         with:
-          node-version: 16.20.2
+          node-version: 24.19.0
       - name: Cache node modules
         uses: actions/cache@v5.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
-      - name: Update npm
-        run: npm i -g npm@7
       - name: Install Dependencies
         run: npm ci
       - name: Run Build
@@ -61,18 +57,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.1.0
-      - name: Use Node.js 16
+      - name: Use Node.js 24
         uses: actions/setup-node@v6.5.0
         with:
-          node-version: 16.20.2
+          node-version: 24.19.0
       - name: Cache node modules
         uses: actions/cache@v5.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
-      - name: Update npm
-        run: npm i -g npm@7
       - name: Install Dependencies
         run: npm ci
       - name: Run Build
@@ -88,18 +82,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6.1.0
-      - name: Use Node.js 16
+      - name: Use Node.js 24
         uses: actions/setup-node@v6.5.0
         with:
-          node-version: 16.20.2
+          node-version: 24.19.0
       - name: Cache node modules
         uses: actions/cache@v5.1.0
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
-      - name: Update npm
-        run: npm i -g npm@7
       - name: Install Dependencies
         run: npm ci
       - name: Run Preprocess

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+24.19.0

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,7 @@
+// Must come first: twing-loader compiles templates in Node during the build, and
+// Twing 3 needs util predicates that Node 22+ removed. See the shim for details.
+require('../twing/node-util-shim.cjs');
+
 const { join } = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const {

--- a/package.json
+++ b/package.json
@@ -157,6 +157,9 @@
         "$1.js",
         "$1.ts"
       ]
-    }
+    },
+    "setupFiles": [
+      "./twing/node-util-shim.cjs"
+    ]
   }
 }

--- a/twing/node-util-shim.cjs
+++ b/twing/node-util-shim.cjs
@@ -1,0 +1,41 @@
+/**
+ * Restores the `util` type-check predicates that Node removed in v22.
+ *
+ * Twing 3 calls `util.isNullOrUndefined()` in the code it generates for templates, so
+ * on Node 22+ every template throws `util_1.isNullOrUndefined is not a function` at
+ * render time. Twing fixed this in v7, but that upgrade is tied to the Storybook/Vite
+ * migration -- this shim decouples the Node upgrade from that work.
+ *
+ * Delete this file, and its two require sites, once Twing is on v7.
+ * @see https://nodejs.org/api/deprecations.html#DEP0044
+ */
+
+const util = require('node:util');
+
+/** Only the predicates Twing actually reaches for, plus their near neighbours. */
+const predicates = {
+  isNullOrUndefined: (value) => value === null || value === undefined,
+  isNull: (value) => value === null,
+  isUndefined: (value) => value === undefined,
+  isString: (value) => typeof value === 'string',
+  isNumber: (value) => typeof value === 'number',
+  isBoolean: (value) => typeof value === 'boolean',
+  isSymbol: (value) => typeof value === 'symbol',
+  isFunction: (value) => typeof value === 'function',
+  isArray: Array.isArray,
+  isObject: (value) => typeof value === 'object' && value !== null,
+  isPrimitive: (value) =>
+    value === null ||
+    (typeof value !== 'object' && typeof value !== 'function'),
+  isRegExp: (value) => value instanceof RegExp,
+  isDate: (value) => value instanceof Date,
+  isError: (value) => value instanceof Error,
+  isBuffer: (value) => Buffer.isBuffer(value),
+};
+
+for (const [name, predicate] of Object.entries(predicates)) {
+  // Never shadow a predicate the running Node still provides.
+  if (typeof util[name] !== 'function') {
+    util[name] = predicate;
+  }
+}


### PR DESCRIPTION
## Overview

Node 16 has been end-of-life since September 2023, and nearly every pending dependency upgrade in our backlog requires Node 18 or newer — so the entire queue is stuck behind this one bump. This PR moves CI and local development to Node 24 on its own, so the mechanical upgrades behind it can proceed without waiting on the much larger Storybook/Vite migration.

The reason this hasn't been a one-line change: Node 22 removed the deprecated `util` type-check predicates, and Twing 3 calls `util.isNullOrUndefined()` in the code it generates for every template. On Node 22+ that means every Twig render throws, which is why the automated Node bump (#2350) failed its `test` and `build-storybook` checks. Twing 7 fixes this, but that upgrade is bound up with replacing webpack — so this PR adds a small shim that restores the removed predicates, letting the Node upgrade land independently. The shim is documented as temporary and gets deleted with the Twing 7 upgrade.

This also drops the `Update npm` step that pinned npm 7. Node 24 ships npm 11, so re-pinning would install an unsupported release.

## Screenshots

## Testing

Most of this is CI configuration, so the main thing to confirm is that all four CI jobs pass on this branch. Beyond that, it's worth verifying the pattern library still works locally on the new Node version:

- [ ] Check out this branch and run `nvm use` (or otherwise switch to Node 24) — it should select **24.19.0**
- [ ] Run `npm ci` — it should complete without engine errors
- [ ] Run `npm start` and open the pattern library in a browser
- [ ] Browse to a few components with Twig templates — **Badge**, **Button**, and **Sky Nav** are good ones — and confirm each renders normally rather than showing an error
- [ ] On any component's docs page, expand **Show code** and confirm the Twig source snippet still appears and is syntax-highlighted
- [ ] Run `npm test` — all 9 suites should pass, including the 20 snapshots

---

- Refs #2391
