### PR TITLE
Restore the iframe heights docs stories lost in the CSF migration

### DIFF
--- a/src/components/cloud-cover/cloud-cover.stories.js
+++ b/src/components/cloud-cover/cloud-cover.stories.js
@@ -18,6 +18,7 @@ export default {
 export const Content = {
   parameters: {
     docs: {
+      story: { iframeHeight: '400px' },
       source: {
         code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
   {% block heading %}
@@ -43,6 +44,7 @@ export const Content = {
 export const Scene = {
   parameters: {
     docs: {
+      story: { iframeHeight: '400px' },
       source: {
         code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
   {% block heading %}
@@ -76,6 +78,7 @@ export const HorizonScene = {
   name: 'Horizon Scene',
   parameters: {
     docs: {
+      story: { iframeHeight: '400px' },
       source: {
         code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
   {% block heading %}
@@ -113,6 +116,7 @@ export const ExtraContent = {
   name: 'Extra Content',
   parameters: {
     docs: {
+      story: { iframeHeight: '400px' },
       source: {
         code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
   {% block heading %}
@@ -146,6 +150,7 @@ export const FullHeight = {
   name: 'Full Height',
   parameters: {
     docs: {
+      story: { iframeHeight: '600px' },
       source: {
         code: `{% embed '@cloudfour/components/cloud-cover/cloud-cover.twig' %}
   {% block heading %}

--- a/src/components/ground-nav/ground-nav.stories.js
+++ b/src/components/ground-nav/ground-nav.stories.js
@@ -19,6 +19,7 @@ export const CloudFour = {
   args: defaultArgs,
   argTypes: defaultArgTypes,
   parameters: {
+    docs: { story: { iframeHeight: '815px' } },
     layout: 'fullscreen',
   },
 };
@@ -31,6 +32,7 @@ export const OneFeature = {
   },
   argTypes: defaultArgTypes,
   parameters: {
+    docs: { story: { iframeHeight: '800px' } },
     layout: 'fullscreen',
   },
 };
@@ -43,6 +45,7 @@ export const NoFeatures = {
   },
   argTypes: defaultArgTypes,
   parameters: {
+    docs: { story: { iframeHeight: '475px' } },
     layout: 'fullscreen',
   },
 };
@@ -54,6 +57,7 @@ export const Alternate = {
   },
   argTypes: defaultArgTypes,
   parameters: {
+    docs: { story: { iframeHeight: '815px' } },
     layout: 'fullscreen',
   },
 };

--- a/src/components/input/input.stories.js
+++ b/src/components/input/input.stories.js
@@ -75,6 +75,7 @@ export const ElasticTextarea = {
   },
   parameters: {
     docs: {
+      story: { iframeHeight: '250px' },
       source: {
         code: makeTwigInclude(
           '@cloudfour/components/input/input.twig',

--- a/src/components/sky-nav/sky-nav.stories.js
+++ b/src/components/sky-nav/sky-nav.stories.js
@@ -34,6 +34,7 @@ export const Dark = {
     layout: 'fullscreen',
     themes: { disable: true },
     docs: {
+      story: { iframeHeight: '200px' },
       source: {
         code: makeTwigInclude('@cloudfour/components/sky-nav/sky-nav.twig', {
           class: 't-dark',
@@ -54,6 +55,7 @@ export const Light = {
     layout: 'fullscreen',
     themes: { disable: true },
     docs: {
+      story: { iframeHeight: '200px' },
       source: {
         code: makeTwigInclude(
           '@cloudfour/components/sky-nav/sky-nav.twig',

--- a/src/design/illustrations.stories.js
+++ b/src/design/illustrations.stories.js
@@ -36,7 +36,6 @@ export const FeatureImages = {
 
 export const ResponsiveFallbackImage = {
   name: 'Responsive fallback image',
-  parameters: { docs: { story: { height: '200px' } } },
   render: () =>
     responsiveImageDeck({
       ratios: ['1 / 1', '16 / 9', '9 / 16'],

--- a/src/objects/container/container.stories.js
+++ b/src/objects/container/container.stories.js
@@ -44,6 +44,7 @@ export const Basic = {
   args: { prose: false, pad: padOptions },
   parameters: {
     docs: {
+      story: { iframeHeight: '300px' },
       source: {
         code: `{% embed '@cloudfour/objects/container/container.twig' with {
   class: 'o-container--pad'
@@ -62,6 +63,7 @@ export const Prose = {
   args: { prose: true, pad: padOptions },
   parameters: {
     docs: {
+      story: { iframeHeight: '300px' },
       source: {
         code: `{% embed '@cloudfour/objects/container/container.twig' with {
   class: 'o-container--prose o-container--pad'
@@ -78,6 +80,11 @@ export const Prose = {
 
 export const Fill = {
   argTypes: {},
-  parameters: { docs: { source: { code: fillDemoSource } } },
+  parameters: {
+    docs: {
+      story: { iframeHeight: '500px' },
+      source: { code: fillDemoSource },
+    },
+  },
   render: fillDemo.bind({}),
 };

--- a/src/objects/deck/deck.stories.js
+++ b/src/objects/deck/deck.stories.js
@@ -88,10 +88,12 @@ export default {
 };
 
 export const Basic = {
+  parameters: { docs: { story: { iframeHeight: '400px' } } },
   render: articlesStory.bind({}),
 };
 
 export const Alignment = {
+  parameters: { docs: { story: { iframeHeight: '200px' } } },
   args: {
     columns: 3,
     columnsBreakpoint: '@m',
@@ -101,6 +103,7 @@ export const Alignment = {
 };
 
 export const Columns = {
+  parameters: { docs: { story: { iframeHeight: '400px' } } },
   args: {
     columns: 3,
     columnsBreakpoint: '@m',
@@ -109,6 +112,7 @@ export const Columns = {
 };
 
 export const HorizontalCard = {
+  parameters: { docs: { story: { iframeHeight: '500px' } } },
   name: 'Horizontal Card',
   args: {
     columns: 3,

--- a/src/objects/feature-group/feature-group.stories.js
+++ b/src/objects/feature-group/feature-group.stories.js
@@ -10,6 +10,7 @@ export default {
 export const Default = {
   parameters: {
     docs: {
+      story: { iframeHeight: '300px' },
       source: {
         code: defaultDemoSource,
       },

--- a/src/objects/hype-group/hype-group.stories.js
+++ b/src/objects/hype-group/hype-group.stories.js
@@ -70,7 +70,12 @@ export default {
 
 export const Single = {
   args: defaultArgs,
-  parameters: { docs: { source: { transform: singleTransformSource } } },
+  parameters: {
+    docs: {
+      story: { iframeHeight: '500px' },
+      source: { transform: singleTransformSource },
+    },
+  },
   render: (args) => demoStory(args),
 };
 
@@ -82,11 +87,17 @@ export const WithOptions = {
     object_outline: true,
     reverse: true,
   },
-  parameters: { docs: { source: { transform: singleTransformSource } } },
+  parameters: {
+    docs: {
+      story: { iframeHeight: '500px' },
+      source: { transform: singleTransformSource },
+    },
+  },
   render: (args) => demoStory(args),
 };
 
 export const Multiple = {
+  parameters: { docs: { story: { iframeHeight: '640px' } } },
   args: {
     ...defaultArgs,
     example_object_img_src: '/media/avatar-buster-a.jpg',

--- a/src/objects/list/list.stories.js
+++ b/src/objects/list/list.stories.js
@@ -28,7 +28,9 @@ export default {
   render: (args) => template(args),
 };
 
-export const Default = {};
+export const Default = {
+  parameters: { docs: { story: { iframeHeight: '200px' } } },
+};
 
 export const Inline = {
   args: { class: 'o-list--inline' },

--- a/src/objects/overview/overview.stories.js
+++ b/src/objects/overview/overview.stories.js
@@ -16,6 +16,7 @@ export default {
 export const Basic = {
   parameters: {
     docs: {
+      story: { iframeHeight: '300px' },
       source: {
         code: basicDemoSource,
       },
@@ -28,6 +29,7 @@ export const AdvancedUsage = {
   name: 'Advanced Usage',
   parameters: {
     docs: {
+      story: { iframeHeight: '300px' },
       source: {
         code: advancedDemoSource,
       },

--- a/src/objects/page/page.stories.js
+++ b/src/objects/page/page.stories.js
@@ -24,7 +24,10 @@ export default {
 export const Example = {
   parameters: {
     layout: 'fullscreen',
-    docs: { source: { code: exampleDemoSource } },
+    docs: {
+      story: { iframeHeight: '400px' },
+      source: { code: exampleDemoSource },
+    },
   },
   render: () => exampleDemo(),
 };
@@ -33,7 +36,10 @@ export const ExampleWithAlert = {
   name: 'Example with Alert',
   parameters: {
     layout: 'fullscreen',
-    docs: { source: { code: exampleDemoWithAlertSource } },
+    docs: {
+      story: { iframeHeight: '400px' },
+      source: { code: exampleDemoWithAlertSource },
+    },
   },
   render: () => exampleDemoWithAlert(),
 };

--- a/src/vendor/wordpress/utilities.stories.js
+++ b/src/vendor/wordpress/utilities.stories.js
@@ -76,7 +76,9 @@ export const Alignment = {
   },
   parameters: {
     layout: 'fullscreen',
-    docs: { story: { inline: false } },
+    docs: {
+      story: { inline: false, iframeHeight: '320px' },
+    },
   },
   render: (args) => alignmentDemo(args),
 };


### PR DESCRIPTION
## Overview

On docs pages, every story that renders in an iframe is clipped to 100px and scrolls
internally instead of sizing to its content — cards cut in half, text cut mid-sentence.
It affects thirty stories across thirteen files.

The `.stories.mdx` files set a per-story height on the docs block:

```jsx
<Story name="Basic" height="400px">
```

The CSF3 migration in #2405 did not carry that across, so those stories fall back to
Storybook's 100px default. One of them, Illustrations, *was* translated — but to
`docs.story.height`, which is not a parameter Storybook recognises, so it had no effect
either. Storybook 10 spells this `parameters.docs.story.iframeHeight`.

The values in this PR are the ones the `.stories.mdx` files used, recovered from the
commit before #2405. This restores the previous rendering rather than picking new numbers.

Two things deliberately left alone:

- **`inline: false` is untouched.** #2391 lists revisiting those as a follow-up, and it
  still wants doing — but it is a separate question. Some of these stories disable inline
  rendering for a reason that is now obsolete (the `html-to-react` bug #2405 removed),
  while others do it so media queries resolve against the example's own viewport, which is
  still valid. Telling those apart changes rendering behaviour; this PR only fixes height.
- **The Illustrations parameter is removed rather than corrected.** That story has never
  disabled inline rendering, so it has no iframe to size, and it already renders at full
  height. A valid-looking parameter that does nothing is worse than no parameter.

No changeset: only `*.stories.js` files change, and those are not in `package.json`'s
`files` array, so nothing published is affected.

## Screenshots

## Testing

Run `nvm use` first — this needs Node 24.19.0. Then `npm ci` and `npm start`.

The quickest way to see the problem is to compare against
[the current deploy of `main`](https://cloudfour-patterns.netlify.app), where each of
these examples is a short scrolling box.

- [ ] Open **Objects → Deck → Docs**. The three examples (Basic, Alignment, Specifying
      Columns) should each show their cards in full, with no internal scrollbar and
      nothing cut off.
- [ ] Scroll to the **Horizontal Card** example on the same page — it is the tallest, and
      should be fully visible too.
- [ ] Open **Objects → Container → Docs**. Basic, Prose and Fill should each show their
      full example.
- [ ] Open **Components → Ground Nav → Docs**. These are the tallest examples in the
      library; each should show the whole navigation without scrolling inside its box.
- [ ] Open **Components → Cloud Cover → Docs** and check all five examples.
- [ ] Open **Objects → Page → Docs**, **Objects → Overview → Docs**, **Objects → Hype
      Group → Docs**, **Objects → List → Docs** and **Objects → Feature Group → Docs**.
      Same expectation on each.
- [ ] Open **Components → Sky Nav → Docs** and **Components → Input → Docs** (the Elastic
      Textarea example).
- [ ] Open **Design → Illustrations → Docs**. The "Responsive fallback image" example
      should render at full height, as it does today — this one is not iframed, and the
      only change is removing a parameter that did nothing.
- [ ] Sanity check that the examples still respond to their controls: on **Objects → Deck
      → Columns**, change the **columns** slider and confirm the layout updates within the
      example.

---

- Follows #2416
- Related to #2391
