### PR TITLE
Let design token tables size their own columns

### DIFF
--- a/src/tokens/aspect-ratio.mdx
+++ b/src/tokens/aspect-ratio.mdx
@@ -37,7 +37,7 @@ console.log(tokens.number.aspect_ratio.wide.value); // => 1.7777777777777777
 <table>
   <thead>
     <tr>
-      <th style={{ width: '10%' }}>Name</th>
+      <th>Name</th>
       <th>Value</th>
       <th>Comment</th>
     </tr>

--- a/src/tokens/font.mdx
+++ b/src/tokens/font.mdx
@@ -9,7 +9,7 @@ export const generateTokenTable = (props) => {
     <table>
       <thead>
         <tr>
-          <th style={{ width: '10%' }}>Name</th>
+          <th>Name</th>
           <th>Value</th>
           {hasComments && <th>Comment</th>}
         </tr>

--- a/src/tokens/layout.mdx
+++ b/src/tokens/layout.mdx
@@ -35,7 +35,7 @@ console.log(tokens.size.max_width.prose.value); // => 40em
 <table>
   <thead>
     <tr>
-      <th style={{ width: '10%' }}>Name</th>
+      <th>Name</th>
       <th>Value</th>
     </tr>
   </thead>

--- a/src/tokens/line-height.mdx
+++ b/src/tokens/line-height.mdx
@@ -32,7 +32,7 @@ console.log(tokens.number.line_height.loose.value); // => 1.5625
 <table>
   <thead>
     <tr>
-      <th style={{ width: '10%' }}>Name</th>
+      <th>Name</th>
       <th>Value</th>
       <th>Comment</th>
     </tr>

--- a/src/tokens/modular-scale.mdx
+++ b/src/tokens/modular-scale.mdx
@@ -38,7 +38,7 @@ console.log(tokens.number.scale.modular.ratio.value); // => 1.25
 <table>
   <thead>
     <tr>
-      <th style={{ width: '10%' }}>Name</th>
+      <th>Name</th>
       <th>Value</th>
     </tr>
   </thead>

--- a/src/tokens/motion.mdx
+++ b/src/tokens/motion.mdx
@@ -9,7 +9,7 @@ export const generateTokenTable = (props, filterLevel) => {
     <table>
       <thead>
         <tr>
-          <th style={{ width: '10%' }}>Name</th>
+          <th>Name</th>
           <th>Value</th>
           {hasComments && <th>Comment</th>}
         </tr>

--- a/src/tokens/opacity.mdx
+++ b/src/tokens/opacity.mdx
@@ -34,7 +34,7 @@ console.log(tokens.number.opacity.muted.value); // => 0.65
 <table>
   <thead>
     <tr>
-      <th style={{ width: '10%' }}>Name</th>
+      <th>Name</th>
       <th>Value</th>
     </tr>
   </thead>

--- a/src/tokens/sizes.mdx
+++ b/src/tokens/sizes.mdx
@@ -8,7 +8,7 @@ export const generateTokenTable = (props) => {
     <table>
       <thead>
         <tr>
-          <th style={{ width: '10%' }}>Name</th>
+          <th>Name</th>
           <th>Value</th>
           {hasComments && <th>Comment</th>}
         </tr>

--- a/src/tokens/z-index.mdx
+++ b/src/tokens/z-index.mdx
@@ -32,7 +32,7 @@ console.log(tokens.number.line_height.z_index.value); // => 999
 <table>
   <thead>
     <tr>
-      <th style={{ width: '10%' }}>Name</th>
+      <th>Name</th>
       <th>Value</th>
       <th>Comment</th>
     </tr>


### PR DESCRIPTION
## Overview

All nine design token pages pin their first column with `<th style={{ width: '10%' }}>`, and on the wider tables that produces genuinely broken output rather than merely tight columns. On the Size page the Name column is held at 100px, so `size.$font-heading-n2-max` renders as four fragments broken mid-word, while the Comment column takes 696px that most rows leave empty. The table ends up more than twice as tall as it needs to be.

Worth knowing why a percentage does that at all, because it is not the usual behaviour: a table cell cannot normally shrink below its min-content width, so a long unbroken token name should just widen the column and override the 10%. What defeats that is `base/typography` setting `overflow-wrap: anywhere` on `body` — that drops min-content to a single character, which makes 10% achievable, so the browser honours it literally. Both rules are reasonable on their own.

This removes the widths and lets the table size columns to their content. There is nothing to replace them with; the browser's automatic layout is the behaviour we want.

## Screenshots

## Testing

The Size page is the clearest case, since it has the longest token names.

- [ ] On the deploy preview, open **Design → Tokens → Size**. In the first table, each token name should sit on one line — a few of the longest may wrap, but only at a hyphen, never mid-word. Before this change names broke into four or five fragments like `size.$fo` / `nt-` / `heading-` / `n2-max`.
- [ ] Check the three columns look sensibly proportioned: Name wide enough for its content, and Comment no longer holding a large empty area on rows that have no comment.
- [ ] Open **Design → Tokens → Motion**, which has four tables, and **Design → Tokens → Font**, which has two. Every table should read cleanly, with no column squeezed to a sliver.
- [ ] Spot-check **Design → Tokens → Aspect Ratio**, **Layout**, **Line Height**, **Modular Scale**, **Opacity** and **Z-index**. Same expectation: names on one line, no mid-word breaks.
- [ ] Narrow the browser window to roughly phone width on any of those pages. The tables should shrink to fit and the page should not scroll sideways.

---

- Follows #2422, part of #2391
