### PR TITLE
Remove the dead welcome.mdx entry from Storybook's stories globs

### DIFF
--- a/.storybook/main.mjs
+++ b/.storybook/main.mjs
@@ -8,8 +8,7 @@ import { twigPlugin } from '../twing/vite-plugin-twig.mjs';
 const here = dirname(fileURLToPath(import.meta.url));
 
 export default {
-  // We load the welcome story separately so it will be the first sidebar item.
-  stories: ['../src/welcome.mdx', '../src/**/*.stories.js', '../src/**/*.mdx'],
+  stories: ['../src/**/*.stories.js', '../src/**/*.mdx'],
   staticDirs: ['../static', '../src/assets'],
   addons: [
     '@storybook/addon-docs',


### PR DESCRIPTION
## Overview

Storybook has been printing `No story files found for the specified pattern: ./src/welcome.mdx` on every build. That file was removed a while ago, but the glob loading it stayed, along with a comment explaining that it was listed separately so it would sort to the top of the sidebar. `src/docs/intro.mdx` has been doing that job ever since, so the comment was the stale half rather than the glob — there is no welcome page to bring back.

Storybook does not fail on an unmatched glob, it just warns and moves on, which is why this survived as long as it did.

## Screenshots

## Testing

- [x] Open the deploy preview. The first item in the left sidebar should be **Introduction**, followed by **Contributing** and **Changelog**.
- [x] Click each of those three — every page should render its documentation the same as it does on the [production library](https://patterns.cloudfour.com/).
- [x] Spot-check a few component pages further down the sidebar to confirm nothing went missing. The sidebar should hold the same 337 entries as before.
- [ ] Optionally, run `npm run build-storybook` locally. The output should no longer contain a "No story files found for the specified pattern" line.

---

- Fixes #2415
