### PR TITLE
Stop publishing Storybook arg fixtures in the library bundle

### DIFF
--- a/.changeset/brave-otters-wander.md
+++ b/.changeset/brave-otters-wander.md
@@ -1,0 +1,7 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Stop publishing three Storybook demo fixtures — `defaultArgs`, `defaultArgTypes` and `generateGroundNavProps`. They come from `ground-nav-args.js`, which only the Ground Nav stories import, and they reached the bundle because the build's entry glob excluded `.stories.` and `.test.` files but not `-args.` ones. They were never documented or intended as API, and nothing a consumer would want can be done with them.
+
+The four real exports — `createElasticTextArea`, `createSubscribe`, `initCommentReplyForm` and `initSkyNav` — are byte-for-byte unchanged, and `dist/standalone.css` and `dist/standalone.min.css` are untouched. Dropping the fixtures takes `dist/cloudfour-patterns.min.js` from 7.8KB to 4.1KB (2.7KB to 1.5KB gzipped), the ESM bundle from 9.4KB to 5.9KB, the UMD bundle from 21KB to 15KB, and the type declarations from 8.0KB to 1.6KB.

--- a/scripts/rollup-root-entry.mjs
+++ b/scripts/rollup-root-entry.mjs
@@ -28,10 +28,11 @@ export const createVirtualRootEntry = async () => {
 
   return (
     matches
-      // Don't include test files or stories in the build. Stories became `.js` when
-      // they moved off `.stories.mdx`, so without this they land in the published
-      // bundle -- and they import `.twig` and `.scss`, which Rollup cannot parse.
-      .filter((f) => !/\.(test|stories)\.[jt]sx?$/.test(f))
+      // Don't include test files, stories, or the arg fixtures stories import in the
+      // build. Stories became `.js` when they moved off `.stories.mdx`, so without
+      // this they land in the published bundle -- and they import `.twig` and
+      // `.scss`, which Rollup cannot parse.
+      .filter((f) => !/(\.(test|stories)|-args)\.[jt]sx?$/.test(f))
       // The order of these exports reaches the published bundle and type
       // declarations, so sort rather than depending on the order the file system
       // happens to hand back.


### PR DESCRIPTION
## Overview

The published bundle has been exposing three symbols we never meant to ship: `defaultArgs`, `defaultArgTypes` and `generateGroundNavProps`. They come from `ground-nav-args.js`, a fixture only the Ground Nav stories import. They reached `dist` because the build has no explicit entry list — it globs everything in `src/{objects,components}/*/` and re-exports it, filtering out only `.stories.` and `.test.` files. Adding `-args.` to that filter closes the gap.

Because these were never documented, never intended as API, and useless outside Storybook, we are treating this as a bug fix rather than a breaking change. The changeset names all three explicitly so it is discoverable if someone turns out to have imported them. The four real exports come out byte-for-byte identical, and `dist/standalone.css` and `dist/standalone.min.css` are untouched — the minified JS bundle drops from 7.8KB to 4.1KB.

## Screenshots

## Testing

The fixture we stopped publishing is still imported by stories, so the thing worth confirming is that Storybook is unaffected:

- [x] Open the deploy preview and go to the **Ground Nav** component page. Every variation should render with its full set of navigation links, exactly as on the [production library](https://patterns.cloudfour.com/).
- [x] Use the Controls panel on a Ground Nav story to change a value — the preview should update as usual.
- [x] Check the **Icon**, **Embed**, **Hype Group** and **Spacing** pages, which use the same shared arg definitions, and confirm their controls still appear and work.
- [ ] Optionally, run `npm run build` and open `dist/cloudfour-patterns.d.ts`. It should declare exactly four things — `createElasticTextArea`, `createSubscribe`, `initCommentReplyForm` and `initSkyNav` — with no Ground Nav argument objects.

---

- Fixes #2427
