### PR TITLE
Remove the engines.node field

### DIFF
--- a/.changeset/plain-otters-gather.md
+++ b/.changeset/plain-otters-gather.md
@@ -1,0 +1,7 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Drop the `engines.node` field, so installing the package no longer declares a Node requirement. Nothing in the published `files` runs on Node — the package ships CSS, Sass, Twig templates, assets and a browser bundle — so the field was only ever gating installation, and it was gating it on `>=12.16.3`, a floor nobody chose deliberately. Removing a restriction cannot break an install that worked before.
+
+`.nvmrc` and the pinned Node version in CI are what actually control the development environment, and neither changes.

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,10 +3,6 @@
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
-      "matchDepTypes": ["peerDependencies", "engines"],
-      "rangeStrategy": "replace"
-    },
-    {
       "automerge": false,
       "prBodyNotes": [
         ":warning: **Warning:** There are likely to be breaking changes, please closely review the pattern library preview."

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,9 +42,10 @@ export default [
   {
     settings: {
       n: {
-        // Without this the `n/no-unsupported-features/*` rules fall back to
-        // `engines.node`, which describes what *consumers* of the published package
-        // need -- not what our build scripts, Storybook config and tests run on.
+        // Without this the `n/no-unsupported-features/*` rules guess, since we
+        // declare no `engines.node` -- and they should not read one if we ever do,
+        // because that field describes what *consumers* of the published package
+        // need, not what our build scripts, Storybook config and tests run on.
         // Those files are never published, so they should be checked against the
         // Node version we actually develop and run CI on (see .nvmrc).
         version: '>=24.19.0',

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "bem",
     "typography"
   ],
-  "engines": {
-    "node": ">=12.16.3"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/cloudfour/cloudfour.com-patterns.git"


### PR DESCRIPTION
## Overview

`package.json` declared `engines.node: ">=12.16.3"`, which npm uses to warn on or refuse an install. Nothing we publish runs on Node — the package ships CSS, Sass, Twig templates, assets and a browser bundle — so the field never described a real requirement, and the floor it set was inherited rather than chosen. Dropping it can only loosen who is able to install us, so it lands as a patch.

The matching `.renovaterc.json` rule goes with it. That rule was added in the same PR (#689) that created the field, purely to stop Renovate from pinning `engines.node`; since we declare no `peerDependencies` either, with `engines` gone it matches nothing at all. `.nvmrc` and the pinned `node-version` in the CI workflows are what actually control our development and CI environment, and neither is affected. The `eslint-plugin-n` `version` setting also stays — that is the right home for "what Node do we develop on" — but its comment no longer describes `engines.node` as a field we declare.

## Screenshots

## Testing

Nothing here changes how the library renders, so the check is on the published metadata:

- [ ] Run `npm pack` and unpack the resulting tarball (or run `npm pack --dry-run`).
- [ ] Open the `package.json` inside it — there should be no `engines` block, and everything else about the packed file list should look the same as before.
- [ ] Run `npm start` and confirm Storybook still boots and serves the library normally. Nothing should have changed about local development.

---

- Fixes #2423
