### PR TITLE
Clear the modernization sequence's tidy-ups

### DIFF
--- a/.changeset/tidy-jars-listen.md
+++ b/.changeset/tidy-jars-listen.md
@@ -1,0 +1,7 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Load `src/index-with-dependencies.scss` with `@use` rather than `@import`, which Dart Sass 3 removes. This was the last `@import` in the repo.
+
+Compiled output loses seven duplicate `@font-face` rules and nothing else. `@use` loads each stylesheet once, so the fonts configured at the top of the file are emitted a single time; under `@import` they came out twice, because `./index` loads `base/fonts` as well and an `@import` does not share the module graph with the file importing it. Every surviving rule is byte-for-byte one of the originals, in the same order, and all other CSS is byte-for-byte identical — 1,245 bytes smaller in the Storybook build.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,13 +28,7 @@ export default [
     languageOptions: {
       parserOptions: {
         tsconfigRootDir: import.meta.dirname,
-        projectService: {
-          // Our tsconfig covers `src`, because that is what ships. These files
-          // configure the tooling around it and belong to no project, so the type
-          // aware rules read them through an inferred one instead of failing to
-          // find them at all.
-          allowDefaultProject: ['vitest.config.mts', 'vitest.setup.*.ts'],
-        },
+        projectService: true,
       },
     },
   },

--- a/src/components/button-swap/button-swap.browser.test.ts
+++ b/src/components/button-swap/button-swap.browser.test.ts
@@ -7,12 +7,14 @@ import template from './button-swap.twig';
 
 const body = () => page.elementLocator(document.body);
 
-test('Swap UI state when clicked', async () => {
+test('Render both states, exposing only the initial one', async () => {
   document.body.innerHTML = template();
 
   // This package ships the markup for Button Swap but not the script that swaps it:
-  // that lives in the consuming site. So what this asserts is the initial state --
-  // only the unsubscribed button is exposed, and it is not the slashed variant.
+  // that lives in the consuming site. So there is no swap to exercise here -- what
+  // the template has to get right is that both states are present and only the
+  // unsubscribed one reaches the accessibility tree. The snapshot covers the second
+  // half: `hidden` keeps the swapped state out of it.
   await expect.element(body()).toMatchAriaInlineSnapshot(`
     - status: Currently unsubscribed from notifications
     - button "Get notifications"
@@ -21,6 +23,12 @@ test('Swap UI state when clicked', async () => {
   const firstBtn = page.getByRole('button');
   await expect.element(firstBtn).toBeVisible();
   await expect.element(firstBtn).not.toHaveClass('is-slashed');
+
+  const swapped = document.querySelector(
+    '.js-button-swap__swapped-button-wrapper',
+  );
+  expect(swapped).not.toBeNull();
+  expect(swapped).toHaveAttribute('hidden');
 });
 
 test('Set custom messages and labels', async () => {

--- a/src/index-with-dependencies.scss
+++ b/src/index-with-dependencies.scss
@@ -12,6 +12,9 @@
   $dir: '/src/assets/fonts'
 );
 
-// stylelint-disable at-rule-disallowed-list
-@import '../node_modules/@wordpress/block-library/build-style/style';
-@import './index';
+/// `@use` rather than `@import`, which Dart Sass 3 removes. Because `@use` loads each
+/// stylesheet once, the `@font-face` rules from `base/fonts` above are emitted a single
+/// time here; under `@import` they came out twice, since `./index` loads `base/fonts`
+/// too and an `@import` does not share the module graph with the file importing it.
+@use '../node_modules/@wordpress/block-library/build-style/style';
+@use './index';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,14 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src"],
+  // `src` is what ships. The root-level globs pick up the tooling that configures the
+  // build and tests around it: those files belong to no project otherwise, so the
+  // type-aware lint rules either fail to find them or fall back to an inferred
+  // project that ignores the strictness settings above. Globs rather than a list, so
+  // the next root-level TypeScript file is covered without anyone remembering to add
+  // it. Nothing outside `ts-dist/src` reaches `dist`, so this does not widen what we
+  // publish.
+  "include": ["src", "*.ts", "*.mts", "*.cts"],
   "exclude": [
     "src/prototypes",
     "src/vendor/highlight/demo/samples",

--- a/twing/vite-plugin-twig.mjs
+++ b/twing/vite-plugin-twig.mjs
@@ -64,15 +64,22 @@ export const twigInputs =
 export const twigPlugin = () => ({
   name: 'cloudfour-twig',
 
+  /** @param {string} id */
   resolveId(id) {
     if (id === VIRTUAL_ID) return RESOLVED_VIRTUAL_ID;
   },
 
+  /** @param {string} id */
   load(id) {
     if (id === RESOLVED_VIRTUAL_ID) return environmentModule;
   },
 
-  transform(code, id) {
+  /**
+   * @param {string} _code The module source, which we never read: the transform
+   *   rewrites `.twig` imports into a render wrapper generated from the id alone.
+   * @param {string} id
+   */
+  transform(_code, id) {
     // Let `?raw` imports through untouched -- the environment module needs the source.
     if (!id.endsWith('.twig')) return;
 


### PR DESCRIPTION
## Overview

Three unrelated leftovers from the #2391 modernization sequence, which would otherwise have vanished when that issue closed.

**Button Swap's test name.** It was called `Swap UI state when clicked` and never clicked — this package ships the component's markup but not the script that swaps it, so there is nothing to click. Rather than just renaming it, the test now also asserts the half the old name implied but never checked: that the swapped state is in the markup and is `hidden`. The aria snapshot already covered the other half, since `hidden` keeps that subtree out of the accessibility tree.

**Root-level TypeScript and the type-aware lint rules.** `tsconfig.json` covered only `src`, so root-level tooling files belonged to no project. #2421 worked around that with a hand-maintained `allowDefaultProject` list, which is the mechanism that let `test-utils.ts` sit unlinted from #2416 until #2421 deleted it. Of the two options in the issue, extending the config came out cleaner — there is nowhere sensible to relocate `vitest.config.mts` to that a project already covers, since the only covered directory is the one that ships. Root-level globs in `include` mean the next file is picked up without anyone remembering, and those files now get our actual `strict` settings instead of an inferred project's defaults. That last part is why `twing/vite-plugin-twig.mjs` gains four JSDoc annotations: adding `vitest.config.mts` pulls the plugin it imports into the program, where `checkJs` finally looks at it.

**`@use` instead of `@import`.** `src/index-with-dependencies.scss` held the last two `@import`s in the repo, and Dart Sass 3 removes the rule. See the note below on what this did to the compiled output — the change is not output-neutral, and it is worth a look before approving.

## Screenshots

## Testing

- [x] Open the deploy preview. Fonts should look the same as on the [production library](https://patterns.cloudfour.com/) — body text in Source Sans Pro, code samples in Source Code Pro. Italics and bold weights should render as real font files rather than browser-synthesized slants, which is what would break if a `@font-face` rule went missing.
- [x] Visit a page with WordPress block markup, such as any **Gutenberg** story, and confirm the block library styles still apply.
- [x] Spot-check a handful of component pages for unstyled or differently-styled content. All the non-font CSS is byte-identical, so anything visual here would be a surprise.

---

### One thing to look at before approving

The `@use` swap is not output-neutral, so per the bail-out condition in #2431 here is exactly what changed.

Compiling the file directly, and in the real Storybook build, **all non-`@font-face` CSS is byte-for-byte identical**. The only difference is that seven `@font-face` rules used to be emitted twice and are now emitted once. The surviving seven are byte-for-byte the originals, in the original order — the built Storybook stylesheet goes from 14 blocks to 7 and shrinks by 1,245 bytes.

The cause is the load-once semantics the issue flagged, landing the favourable way round: `./index` loads `base/fonts` as well, and an `@import` does not share the module graph with the file importing it, so the fonts were emitted a second time. `@use` loads each stylesheet once.

I read this as a pass rather than the bail-out, because nothing is dropped, reordered, or newly duplicated, and a browser handed the same `@font-face` set twice behaves identically to being handed it once. But it is a judgment call against the issue's wording, so if you would rather have byte-identical output, dropping this one file's changes leaves the other two items intact.

To reproduce:

```js
import * as sass from 'sass';
const { css } = await sass.compileAsync('src/index-with-dependencies.scss', {
  loadPaths: ['node_modules'],
});
```

### Why this has a changeset

#2440 lists this issue as needing none, on the strength of the issue body saying the Sass file is excluded from the published `files`. It is not — `files` excludes `src/index.scss` but not `src/index-with-dependencies.scss`, and `npm pack --dry-run` confirms the file ships. So this changes published output and takes a patch.

Worth a separate issue: that file is documented as Storybook-only and hard-codes `/src/assets/fonts`, a root-absolute path that cannot mean anything to a consumer. It probably should not be in the tarball at all, which is the same "what is actually our public surface" question as #2078.

---

- Fixes #2431
