### PR TITLE
Stop publishing the Storybook-only Sass entry point

### DIFF
--- a/.changeset/lucky-pandas-gather.md
+++ b/.changeset/lucky-pandas-gather.md
@@ -1,0 +1,9 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Stop publishing `src/index-with-dependencies.scss`. It is a Storybook-only entry point, and `files` already excludes its sibling `src/index.scss` for the same reason — this was the exclusion being one file short rather than a deliberate choice.
+
+No consumer can have been using it. It loads `@wordpress/block-library` through `../node_modules/`, which resolves inside our own package directory, and that is a devDependency we never install for anyone else; it then loads `./index`, which `files` deliberately excludes; and it configures the font directory as `/src/assets/fonts`, a root-absolute path that only means anything while Vite is serving Storybook. Compiling it from an installed tarball fails on the first of those three.
+
+The tarball goes from 361 files to 360, and nothing else changes. Storybook reads the file from the working tree, so it is unaffected.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "!/src/**/demo/**/*.twig",
     "/src/assets",
     "!.gitignore",
-    "!src/index.scss"
+    "!src/index.scss",
+    "!src/index-with-dependencies.scss"
   ],
   "devDependencies": {
     "@babel/core": "7.29.7",


### PR DESCRIPTION
## Overview

`files` already excludes `src/index.scss` because it is a Storybook-only entry point. `src/index-with-dependencies.scss` is the other one, and it was shipping — the exclusion was one file short of its own intent rather than making a distinction between the two.

Nobody can have been depending on it, which is what makes this a patch rather than a break. Compiling it from an installed tarball fails immediately: it loads `@wordpress/block-library` through `../node_modules/`, which resolves inside our own package directory, and that is a devDependency we never install for a consumer. Behind that failure are two more — `@use './index'` points at the file we already exclude, and the font directory is configured as `/src/assets/fonts`, a root-absolute path that only resolves while Vite is serving Storybook.

## Screenshots

## Testing

- [ ] Run `npm pack --dry-run`. The listed file count should be **360**, and no `src/index-with-dependencies.scss` or `src/index.scss` should appear.
- [ ] Run `npm start` and confirm Storybook boots and looks normal — fonts, WordPress block styles, and component pages all as before. `files` only affects the published tarball, so Storybook reads this file from the working tree either way.

---

- Fixes #2445
