### PR TITLE
Restore the frame on Button Swap's Default story

### DIFF
--- a/src/components/button-swap/button-swap.stories.js
+++ b/src/components/button-swap/button-swap.stories.js
@@ -32,6 +32,11 @@ export const Default = {
   },
   parameters: {
     docs: {
+      // This story rendered in its own frame before the CSF migration, which dropped
+      // the setting. No `iframeHeight` to go with it, matching the original: the
+      // component measures about 45px against Storybook's 100px default, so unlike
+      // the stories in #2420 there is nothing here to clip.
+      story: { inline: false },
       source: {
         code: makeTwigInclude(
           '@cloudfour/components/button-swap/button-swap.twig',


### PR DESCRIPTION
## Overview

The #2428 sweep compared every `<Story>` attribute in the pre-migration MDX against the CSF files, and this was the one genuine drop it found: Button Swap's Default story set `inline={false}`, and the CSF migration in #2405 did not carry it across. It was the only `inline` attribute in the whole of the old MDX, which is presumably why it slipped — there was no pattern to notice.

Restoring it returns the story to the rendering it had before the migration, the same conservative approach #2420 took with the thirty iframe heights. Deliberately no `iframeHeight` to accompany it, matching the original, which had no `height` attribute either — the component measures about 45px against Storybook's 100px default, so this cannot reproduce the clipping #2420 fixed. Verified by rendering the component against the published stylesheet rather than assumed.

This does not settle whether the story *should* be framed — that is the per-story judgment in #2428's Part 2, which covers thirteen other locations and is unaffected by this. All this PR does is stop the setting being absent by accident rather than by decision, so Part 2 has a clean slate to work from.

## Screenshots

## Testing

- [x] Open the deploy preview and go to **Components → Button Swap**, then the **Docs** tab.
- [x] The Default example should render in its own frame, showing the "Give me all the notifications!" button in full, with no scrollbar and nothing cut off.
- [x] Switch to the **Canvas** tab and confirm the story still renders normally there.

---

- Part of #2428
