### PR TITLE
Render the Logo and Input stories inline again

### DIFF
--- a/src/components/input/input.stories.js
+++ b/src/components/input/input.stories.js
@@ -19,13 +19,9 @@ const elasticTextAreaConfig = {
   class: 'js-elastic-textarea',
 };
 
-// Inline stories disabled because when the same input element is rendered with
-// different settings within the same file, React syncs all their properties.
-
 /** @type {Meta} */
 const meta = {
   title: 'Components/Input',
-  parameters: { docs: { story: { inline: false } } },
 };
 
 export default meta;
@@ -82,7 +78,6 @@ export const ElasticTextarea = {
   },
   parameters: {
     docs: {
-      story: { iframeHeight: '250px' },
       source: {
         code: makeTwigInclude(
           '@cloudfour/components/input/input.twig',

--- a/src/components/logo/logo.stories.js
+++ b/src/components/logo/logo.stories.js
@@ -4,16 +4,9 @@ import logoTemplate from './logo.twig';
 import './demo/alignment.scss';
 const alignOptions = ['start', 'center', 'end'];
 
-// This component's options rely on CSS custom properties, which are currently
-// broken in the library we use for inlining Storybook stories. Until that issue
-// is resolved, we must fallback to iframes for these stories. 🙈️
-//
-// @see https://github.com/aknuds1/html-to-react/issues/144
-
 /** @type {Meta} */
 const meta = {
   title: 'Components/Logo',
-  parameters: { docs: { story: { inline: false } } },
 };
 
 export default meta;


### PR DESCRIPTION
## Overview

Two files disabled inline story rendering for reasons that no longer hold, both traceable to the same removed library. This is the documented half of #2428's Part 2 — the other eleven locations either have a reason that still applies or no recorded reason at all, and are left alone.

Logo's comment names the culprit: [html-to-react#144](https://github.com/aknuds1/html-to-react/issues/144). Storybook 6 used that library to convert story HTML into React elements, and it dropped CSS custom properties from inline styles — which is exactly how Logo works, setting `--logo-align`, `--logo-justify` and `--logo-scale` via a `style` attribute on the wrapper. Input's comment describes a different symptom, "React syncs all their properties" between identical `input` elements in the same file, but that can only happen if React is managing those DOM nodes, which required the same conversion step.

Both mechanisms are gone. `html-to-react` is absent from `node_modules` and from the lockfile as of #2405, and the Storybook 10 HTML renderer assigns `innerHTML` — there is no HTML-to-React step left anywhere in `@storybook/html` or `@storybook/addon-docs`. Verified against the installed packages rather than inferred from the upgrade.

One consequence worth flagging rather than burying: Elastic Textarea's `iframeHeight: '250px'` goes too. With the story rendering inline there is no iframe to size, so keeping it would leave exactly the kind of valid-looking-but-inert parameter #2420 removed from Illustrations for the same reason. If a reviewer would rather that story kept its own frame, the fix is to restore `inline: false` on that story alone rather than to keep the height.

## Screenshots

## Testing

Both pages should now render their examples directly in the docs page rather than in scrollable frames. The specific things the old workarounds were protecting:

- [x] Open the deploy preview, go to **Components → Logo** and the **Docs** tab. The **Basic Options** example should show the logo at its normal size.
- [x] In the Controls panel for that story, change **align** to `start` and then `end`. The logo should visibly move within its box. Then change **justify** the same way, and set **scale** to `0.5` — the logo should shrink. This is the behaviour the old library broke, so if any of these controls do nothing, this PR is wrong.
- [x] Check the **Before Alignment** and **After Alignment** examples on the same page still show their side-by-side comparison.
- [x] Go to **Components → Input** and the **Docs** tab. **Text Elements**, **Select Element** and **Elastic Textarea** should each render in full, with no clipping and no internal scrollbars.
- [x] Compare **Text Elements** against the [production library](https://patterns.cloudfour.com/): each input should keep its own type, placeholder and value. If two inputs that should differ now look identical, that is the property-syncing problem returning.
- [x] Type several lines into the **Elastic Textarea** example. It should grow to fit as you type, and the page should reflow around it rather than the box scrolling internally.

---

- Part of #2428
