### PR TITLE
Export the files we publish

### DIFF
--- a/.changeset/fuzzy-moons-arrive.md
+++ b/.changeset/fuzzy-moons-arrive.md
@@ -1,0 +1,13 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Make every published file reachable through Node resolution. `exports` was a bare string pointing at the browser bundle, and defining `exports` at all encapsulates every other subpath — so of the 360 files in the tarball, exactly one could be resolved. Requiring the compiled design tokens failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`, and so did reading our own `package.json`, which is something tooling routinely does to a dependency.
+
+`files` and `exports` disagreed about what the public API is, and `files` is the field expressing the intent: we deliberately publish `/dist`, the compiled tokens, the Sass partials, the Twig templates and the assets. `exports` now mirrors that shape, so what we ship and what a consumer can reach are the same set.
+
+The subpath patterns are written per extension rather than as a blanket `./src/*`, which keeps stories and tests encapsulated even for a consumer resolving against a working tree rather than an installed tarball. `files` remains the authority on the exact file list.
+
+Widening `exports` cannot break an import that already worked, and the published file list is byte-for-byte unchanged — only reachability changes. Sass is unaffected in both directions: it compiles identically before and after via both `loadPaths` and the `pkg:` importer, because neither route enforces the export map for stylesheets.
+
+Also adds a `types` condition to the main entry. Under `node16`/`nodenext`/`bundler` module resolution, TypeScript reads types through `exports` and ignores the top-level `types` field, so consumers on those settings were getting `any` — TypeScript reported "There are types at dist/cloudfour-patterns.d.ts, but this result could not be resolved when respecting package.json exports". This was already true before this change; it is fixed here because it is the same field and the same root cause. What the main entry resolves to at runtime is unchanged.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,18 @@
   "main": "./dist/cloudfour-patterns.js",
   "unpkg": "./dist/cloudfour-patterns.min.js",
   "module": "./dist/cloudfour-patterns.mjs",
-  "exports": "./dist/cloudfour-patterns.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/cloudfour-patterns.d.ts",
+      "default": "./dist/cloudfour-patterns.mjs"
+    },
+    "./package.json": "./package.json",
+    "./dist/*": "./dist/*",
+    "./src/assets/*": "./src/assets/*",
+    "./src/compiled/tokens/*": "./src/compiled/tokens/*",
+    "./src/*.scss": "./src/*.scss",
+    "./src/*.twig": "./src/*.twig"
+  },
   "types": "./dist/cloudfour-patterns.d.ts",
   "files": [
     "/dist",


### PR DESCRIPTION
## Overview

We publish 360 files — the compiled design tokens, the Sass partials, the Twig templates, the assets — and exactly one of them could be reached through Node resolution. Defining an `exports` field at all encapsulates every subpath that isn't listed, and ours was a bare string pointing at the browser bundle, so requiring the design tokens failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`. So did reading our own `package.json`, which tooling routinely does to a dependency.

`files` and `exports` disagreed about what our public API is, and `files` is the field expressing the intent — those files are deliberately published. `exports` now mirrors its shape, so what we ship and what a consumer can reach are the same set. Widening `exports` cannot break an import that already worked, and the published file list is byte-for-byte unchanged; only reachability changes.

This also adds a `types` condition to the main entry. Under `node16`/`nodenext`/`bundler` module resolution, TypeScript reads types through `exports` and ignores the top-level `types` field, so consumers on those settings were silently getting `any`. That was already true before this change — it is fixed here because it is the same field and the same root cause, and it seemed wrong to touch `exports` and knowingly leave it broken. Runtime resolution of the main entry is unchanged. Happy to split it out if you'd rather keep this to the letter of the issue.

Two things worth a reviewer's attention. First, this commits us to those paths as API, which is the real decision in the issue; the answer taken here is that `files` already made that commitment and `exports` was contradicting it. Second, `main` still points at the CommonJS build but `exports` sends `require()` to the ESM one, exactly as it did before — that predates this change and is left alone rather than quietly folded in.

## Screenshots

## Testing

Sass is unaffected in both directions, so there is nothing to check there — it compiles identically before and after, because neither the load-path route nor the `pkg:` importer enforces the export map for stylesheets.

- [ ] From the repo root, run `npm run build`, then `npm pack`. A file named `cloudfour-patterns-17.1.0.tgz` should appear in the repo root.
- [ ] Make a new empty folder somewhere outside the repo, and in it run `npm init -y` followed by `npm install /full/path/to/cloudfour-patterns-17.1.0.tgz`.
- [ ] In that folder, create a file called `check.js` containing:
      ```js
      const tokens = require('@cloudfour/patterns/src/compiled/tokens/json/tokens.json');
      console.log(Object.keys(tokens));
      ```
- [ ] Run `node check.js`. It should print a list of token group names. On `main` this same step fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- [ ] In the same folder, create `check-manifest.js` containing `console.log(require('@cloudfour/patterns/package.json').version);` and run it. It should print `17.1.0` rather than an error — reading a dependency's manifest is something build tools do routinely.
- [ ] Confirm the main entry point still works: create `check-main.mjs` containing `import * as p from '@cloudfour/patterns'; console.log(Object.keys(p));` and run it. It should list four component functions.
- [ ] Optional, for the types change: in that same folder run `npm i -D typescript`, add a `tsconfig.json` with `{"compilerOptions":{"moduleResolution":"bundler","module":"preserve","noEmit":true}}`, create `check.ts` containing `import { createElasticTextArea } from '@cloudfour/patterns';` and pass it a string: `createElasticTextArea('nope');`. Run `npx tsc`. You should get a complaint that a string isn't an `HTMLTextAreaElement` — meaning the type declarations were found. On `main` you instead get "Could not find a declaration file for module".

---

- Fixes #2078
