### PR TITLE
Pin changesets/action and migrate to v2

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,21 +5,34 @@ on:
     branches:
       - main
 
+env:
+  NODE_VERSION: 24.19.0
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Required by changesets/action v2 to commit version changes and open the
+    # release PR. Declaring them explicitly also drops every other permission
+    # the default token would otherwise carry.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7.0.1
         with:
           # Fetch all git history for correct changelog commits
           fetch-depth: 0
-      - name: Use Node.js 24
+      - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v7.0.0
         with:
-          node-version: 24.19.0
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
+          # Writes an .npmrc that reads NODE_AUTH_TOKEN. changesets/action v2
+          # no longer writes one from NPM_TOKEN itself, so without this the
+          # publish step has no credentials.
+          registry-url: 'https://registry.npmjs.org'
       - name: Install Dependencies
         run: npm ci
       - name: Run Preprocess
@@ -27,12 +40,14 @@ jobs:
       - name: Run Build
         run: npm run build
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@master
+        uses: changesets/action@v2.1.1
         with:
-          publish: npm run release
-          version: npm run version
-          title: 'Publish Next Version'
-          commit: 'Publish Next Version'
+          publish-script: npm run release
+          version-script: npm run version
+          pr-title: 'Publish Next Version'
+          commit-message: 'Publish Next Version'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # v2 removed support for passing a token via GITHUB_TOKEN. The
+          # `github-token` input defaults to the GitHub-provided token, which
+          # is what this workflow used before, so it is left unset.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Overview

`changesets.yml` was still tracking `changesets/action@master`, the last floating action ref in this repo. It turned out to be a worse problem than "unpinned": that repository's default branch is `main`, and **`master` was last committed to in November 2021** — while the action has shipped v2.0.0, v2.1.0 and v2.1.1 in the past two weeks. The ref wasn't drifting with upstream, it was frozen on a four-year-old build with nothing to signal that development had moved elsewhere. Renovate can see the entry but can't propose an upgrade from a branch ref, which is why it never surfaced.

That means the pin can't be done on its own. v2 renames **every input this workflow used**, and changes how both tokens are supplied. Since this is the workflow that publishes to npm, the details are below — the failure modes here are quiet ones.

Found while auditing floating action refs across the org: of 137 non-archived repos, three had one. This and `lighthouse-parade` were two of them; the third belongs to another maintainer and was left alone.

## Screenshots

## Testing

There's no way to exercise this without an actual release, so the useful review is reading rather than running. These are the things to check when it does run.

- [ ] Read the diff against [the v2 API table](https://github.com/changesets/action/tree/v2.1.1#api) and confirm all four renamed inputs match: `publish-script`, `version-script`, `pr-title`, `commit-message`.
- [ ] After merging, watch the first `Release` run on `main`. It should update the existing "Publish Next Version" pull request rather than opening a second one — `pr-title` is unchanged, so it should match.
- [ ] On the next actual publish, confirm the npm step authenticates. This is the change most likely to fail: v2 stopped writing an `.npmrc` from `NPM_TOKEN`, so auth now comes from `setup-node`'s `registry-url` plus `NODE_AUTH_TOKEN`. A failure looks like `ENEEDAUTH` or a 401 from the registry, not a workflow syntax error.
- [ ] Confirm the release commit and tag land on `main` as usual. v2 pushes them via the GitHub API rather than the Git CLI by default, so they'll be signed by GitHub and attributed to the token owner — expect the commit author to look different from previous releases.

## Notes for the reviewer

**Three breaking changes needed handling beyond the renames:**

1. **`GITHUB_TOKEN` env var is ignored in v2.** The `github-token` input now has to be explicit — but it defaults to the GitHub-provided token, which is exactly what this was passing. So it's dropped rather than converted.
2. **`NPM_TOKEN` env var no longer configures npm.** v2 removed its `.npmrc` handling and directs you to `setup-node`'s `registry-url` with `NODE_AUTH_TOKEN`. The repository secret is unchanged; only the variable name it binds to differs.
3. **`permissions` is now required.** v2's docs call for `contents: write` and `pull-requests: write`. Declaring them explicitly also drops every other permission the default token would carry.

**v2 requires Changesets v3.** This repo is on `@changesets/cli` 3.0.1, so that's satisfied — worth confirming, since the v1 line is what pairs with Changesets v2.

Also lifted the pinned Node version into an `env` block to match what `ci.yml` in this repo already does. No behavior change.

The equivalent change for `lighthouse-parade` is in cloudfour/lighthouse-parade#389.