### PR TITLE
Extend shared Renovate preset

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,16 +1,18 @@
 {
-  "extends": ["config:recommended", ":automergeMinor", ":pinVersions"],
-  "minimumReleaseAge": "3 days",
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>cloudfour/renovate-config:library"],
   "packageRules": [
     {
+      "description": "A Storybook bump usually changes how the pattern library renders, which no automated check here catches. Block auto-merge and mark the PR so it is obvious in the list that someone has to open the preview and look.",
+      "matchPackageNames": ["/storybook/"],
       "automerge": false,
+      "commitMessagePrefix": "[Review carefully]",
       "prBodyNotes": [
         ":warning: **Warning:** There are likely to be breaking changes, please closely review the pattern library preview."
-      ],
-      "commitMessagePrefix": "[Review carefully]",
-      "matchPackageNames": ["/storybook/"]
+      ]
     },
     {
+      "description": "@wordpress/block-library releases far more often than the site needs, so updates are batched to once a month instead of arriving continuously. minimumReleaseAge drops to 0 because the monthly schedule already provides more soak time than the shared three-day cooldown would.",
       "matchPackageNames": ["@wordpress/block-library"],
       "extends": ["schedule:monthly"],
       "minimumReleaseAge": "0"


### PR DESCRIPTION
## Overview

[`cloudfour/renovate-config`](https://github.com/cloudfour/renovate-config) is now the shared Renovate preset source for Cloud Four repos, so a config change we want everywhere is a one-file edit instead of a hand-edit across two dozen repos. This replaces the shared portion of the local config with a one-line `extends` and keeps only the two rules specific to this repo.

Both surviving rules now carry a `description` explaining why they exist. That's deliberate: centralizing the config means this repo's git history no longer tells the story of why a rule was added, so the reason has to live in the rule itself.

**One deviation from the plan worth flagging.** Issue #1 assigns this repo the `default` preset, but it publishes to npm as `@cloudfour/patterns`, so this PR uses `library` instead. `library` adds one rule keeping `peerDependencies` and `engines` as ranges rather than pinning them. This package declares neither field today, so the rule changes nothing right now — but the shared config pins exact versions globally, and the day someone adds `"engines": { "node": ">=22" }` here it would be silently pinned and break installs for consumers. Happy to switch it back to `default` if you'd rather stick to the plan as written.

## Screenshots

## Testing

- [ ] Open `.renovaterc.json` on this branch and confirm two rules remain: one for Storybook, one for `@wordpress/block-library`
- [ ] After merging, open the **Dependency Dashboard** issue and wait for Renovate to run (or tick the checkbox at the bottom of the dashboard to request an immediate run)
- [ ] The dashboard should render its usual list of pending updates with no error banner at the top. A red "Config Validation" or "Preset Not Found" warning would mean the preset failed to resolve
- [ ] On the next Storybook update PR, confirm it is **not** set to auto-merge, that its title is prefixed `[Review carefully]`, and that the PR body still carries the warning about reviewing the pattern library preview
- [ ] Confirm `@wordpress/block-library` updates still arrive on a monthly schedule rather than immediately

---

Part of cloudfour/renovate-config#1
