### PR TITLE
Publish to npm via OIDC trusted publishing

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,9 @@
+---
+'@cloudfour/patterns': patch
+---
+
+Publish releases via npm trusted publishing (OIDC) instead of a stored token.
+
+There are no functional changes to the package. From this release onward,
+published versions carry a provenance attestation linking the tarball to the
+workflow run and commit that produced it.

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -18,6 +18,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # Lets the job mint the OIDC token npm exchanges for short-lived publish
+      # credentials. Without it, npm silently falls back to looking for a token.
+      id-token: write
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7.0.1
@@ -29,9 +32,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          # Writes an .npmrc that reads NODE_AUTH_TOKEN. changesets/action v2
-          # no longer writes one from NPM_TOKEN itself, so without this the
-          # publish step has no credentials.
+          # Required for trusted publishing, not just for tokens: npm only
+          # attempts the OIDC exchange when an .npmrc points at the registry.
+          # Omitting this makes publishes fail as though unauthenticated.
           registry-url: 'https://registry.npmjs.org'
       - name: Install Dependencies
         run: npm ci
@@ -39,6 +42,15 @@ jobs:
         run: npm run preprocess
       - name: Run Build
         run: npm run build
+      # No npm credentials are passed here. `changeset publish` shells out to
+      # `npm publish`, which detects the OIDC environment and authenticates
+      # itself against the trusted publisher configured on npmjs.com. That
+      # config names this file, so renaming or splitting this workflow means
+      # updating the package settings on npm to match.
+      #
+      # v2 removed support for passing a token via GITHUB_TOKEN. The
+      # `github-token` input defaults to the GitHub-provided token, which is
+      # what this workflow used before, so it is left unset.
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v2.1.1
         with:
@@ -46,8 +58,3 @@ jobs:
           version-script: npm run version
           pr-title: 'Publish Next Version'
           commit-message: 'Publish Next Version'
-        env:
-          # v2 removed support for passing a token via GITHUB_TOKEN. The
-          # `github-token` input defaults to the GitHub-provided token, which
-          # is what this workflow used before, so it is left unset.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Overview

The `NPM_TOKEN` secret is a 90-day npm granular token created 2026-08-25 that expires around 2026-11-23 — [#2452](https://github.com/cloudfour/cloudfour.com-patterns/issues/2452) exists to renew it. npm [capped granular write tokens at 90 days](https://github.blog/changelog/2025-11-05-npm-security-update-classic-token-creation-disabled-and-granular-token-changes/) after revoking classic tokens entirely, so that renewal is now a permanent recurring chore. This switches to OIDC trusted publishing, which removes the stored credential and ends the cycle.

The change is small because `changeset publish` shells out to `npm publish`, which detects OIDC on its own: we add `id-token: write` and drop `NODE_AUTH_TOKEN`. `registry-url` was already set (required — OIDC silently fails without it), `access: public` is already in the changeset config, and `repository` matches the GitHub repo as provenance requires. The same migration was just completed on `cloudfour/lighthouse-parade`, which published successfully with provenance.

This includes a **patch changeset**, deliberately. Trusted publishing can only be verified by an actual publish, and this package releases roughly quarterly — waiting for a natural release risks reaching the token's November expiry still unverified. Releasing now exercises the new path while the existing token remains valid as a fallback. There is a live npm CLI bug ([npm/cli#8976](https://github.com/npm/cli/issues/8976)) where scoped packages 404 under OIDC, but the reported cases are workspace monorepos publishing many packages; this repo publishes a single package with no workspaces. Verifying now rather than in November is the point.

Note this references #2452 without a closing keyword, so merging won't auto-close it. The renewal reminder should stay open until a publish has actually succeeded without a token — if OIDC turns out not to work here, that reminder is the safety net.

## Screenshots

## Testing

Publishing can only be exercised from `main`, so most of this is post-merge verification.

- [ ] Confirm npmjs.com → `@cloudfour/patterns` → Settings lists a trusted publisher for repository `cloudfour/cloudfour.com-patterns` and workflow **`changesets.yml`** (note: not `release.yml` — this repo's workflow has a different filename)
- [ ] After merging, a **Publish Next Version** PR should open automatically, bumping to 17.2.1. Merging that PR is what triggers the actual publish
- [ ] Watch the **Release** workflow run on `main` after that second merge — it should finish green
- [ ] Run `npm view @cloudfour/patterns version` — it should report `17.2.1`
- [ ] On the [npm package page](https://www.npmjs.com/package/@cloudfour/patterns), 17.2.1 should show a green **Provenance** badge linking back to the Actions run
- [ ] Confirm nothing in the published package changed apart from the version — this release is infrastructure only

If the publish fails with `E404`, the token fallback is still available: revert this PR and the existing `NPM_TOKEN` will publish as before.

---

- Related to #2452 (intentionally not "Fixes" — see above)